### PR TITLE
Draft bugs

### DIFF
--- a/public/js/draft.js
+++ b/public/js/draft.js
@@ -1,5 +1,7 @@
 
 var draft = JSON.parse(document.getElementById("draftraw").value);
+if(draft.ratings === undefined) draft.ratings = {};
+
 var dragElement = document.getElementById('dragelement');
 var dragCard = null;
 
@@ -307,17 +309,18 @@ function saveDraft(callback)
 function renderDraft()
 {
 
-  //move cards over if they don't fit into columns
-  for(var i = numCols; i < draft.picks[0].length; i++)
-  {
-    draft.picks[0][numCols-1] = draft.picks[0][numCols-1].concat(draft.picks[0][i].splice(0,draft.picks[0][i].length));
-  }
-
   if(draft.packs[0].length > 0)
   {
     $('#packTitle').text('Pack ' + draft.packNumber + ', Pick ' + draft.pickNumber);
     $('#packSubtitle').text( draft.packs[0].length - 1 + ' unopened packs left');
     setupPickColumns();
+
+    //move cards over if they don't fit into columns
+    for(var i = numCols; i < draft.picks[0].length; i++)
+    {
+      draft.picks[0][numCols-1] = draft.picks[0][numCols-1].concat(draft.picks[0][i].splice(0,draft.picks[0][i].length));
+    }
+
     //fill upp pack
     var packhtml = "";
     draft.packs[0][0].forEach(function(card, index)


### PR DESCRIPTION
These two small changes fix a couple crashes that were happening on localhost but not the live site for me. 

- I think that the first line is only necessary if you have an empty card ratings db which is why this doesn't crash on the live site.

- I'm not sure why the second bit of code works on the live site, so I might be missing something here. I think that moving the loop until after setupPickColumns is called is the correct thing to do since otherwise numCols is not initialized (it then crashes when you try to pick a card and it tries to set the -1 index when it does draft.picks[0][numCols-1]), but please correct me if I'm missing something.