### PR TITLE
mass edit remove colors

### DIFF
--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -166,7 +166,7 @@ if(canEdit) {
     });
     if(val.length > 0)
     {
-      if(val.indexOf('C') !== -1)
+      if(val.indexOf('C') === 0 && val.length === 1)
       {
         updated.colors = [];
       }

--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -157,7 +157,7 @@ if(canEdit) {
       updated.type_line = val;
     }
     val = [];
-    ['W','U','B','R','G'].forEach(function(color, index)
+    ['W','U','B','R','G','C'].forEach(function(color, index)
     {
       if($('#groupContextModalCheckbox'+color).prop('checked'))
       {
@@ -166,7 +166,14 @@ if(canEdit) {
     });
     if(val.length > 0)
     {
-      updated.colors = val;
+      if(val.indexOf('C') !== -1)
+      {
+        updated.colors = [];
+      }
+      else
+      {
+        updated.colors = val;
+      }
     }
 
     var filterobj = null;

--- a/views/cube/cube_list.pug
+++ b/views/cube/cube_list.pug
@@ -215,7 +215,7 @@ block content
 										label.form-check-label(for='groupContextModalCheckboxC')
 											img(src='/content/symbols/c.png' alt='Colorless' title='Colorless')
 									br
-									em No symbols selected will have no change.
+									em Selecting no mana symbols will cause the selected cards' color identity to remain unchanged. Selecting only colorless will cause the selected cards' color identity to be set to colorless.
 									br
 									br
 									h5 Edit Tags

--- a/views/cube/cube_list.pug
+++ b/views/cube/cube_list.pug
@@ -210,6 +210,10 @@ block content
 										input#groupContextModalCheckboxG.form-check-input(type='checkbox', value='option5')
 										label.form-check-label(for='groupContextModalCheckboxG')
 											img(src='/content/symbols/g.png' alt='Green' title='Green')
+									.form-check.form-check-inline
+										input#groupContextModalCheckboxC.form-check-input(type='checkbox', value='option6')
+										label.form-check-label(for='groupContextModalCheckboxC')
+											img(src='/content/symbols/c.png' alt='Colorless' title='Colorless')
 									br
 									em No symbols selected will have no change.
 									br


### PR DESCRIPTION
This pull request fixes https://github.com/dekkerglen/CubeCobra/issues/161 by adding the ability to remove color identity from multiple cards simultaneously (that is, make the color identity colorless).

The semantics of the colorless checkbox are as follows:
If unset, it has no effect
If set when other colors are also set, it has no effect (example: R + U + C = RU)
If set when no other colors are set, it unsets the color identity of the selected cards (that is, it sets their color identity to colorless)