### PR TITLE
deduplicate card addition

### DIFF
--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -977,16 +977,7 @@ router.post('/importcubetutor/:id',ensureAuth, function(req,res) {
                     found = true;
                     added.push(carddb.carddict[possible]);
                     var details = carddb.carddict[possible];
-                    cube.cards.push(
-                      {
-                        tags:['New'],
-                        status:"Not Owned",
-                        colors:details.color_identity,
-                        cmc:details.cmc,
-                        cardID:possible,
-                        type_line:details.type
-                      }
-                    );
+                    util.addCardToCube(cube, details);
                     changelog += '<span style=""Lucida Console", Monaco, monospace;" class="badge badge-success">+</span> ';
                     if(carddb.carddict[possible].image_flip)
                     {
@@ -1002,16 +993,7 @@ router.post('/importcubetutor/:id',ensureAuth, function(req,res) {
                 {
                   added.push(carddb.carddict[currentId[0]]);
                   var details = carddb.carddict[currentId[0]];
-                  cube.cards.push(
-                    {
-                      tags:['New'],
-                      status:"Not Owned",
-                      colors:details.color_identity,
-                      cmc:details.cmc,
-                      cardID:currentId[0],
-                      type_line:details.type
-                    }
-                  );
+                  util.addCardToCube(cube, details);
                   changelog += '<span style=""Lucida Console", Monaco, monospace;" class="badge badge-success">+</span> ';
                   if(carddb.carddict[currentId[0]].image_flip)
                   {
@@ -1340,17 +1322,8 @@ function bulkUpload(req, res, list, cube) {
               {
                 //if we've found a match, and it doesn't need to be parsed with cubecobra syntax
                 var details = carddb.carddict[currentId[0]];
-                cube.cards.push(
-                  {
-                    tags:['New'],
-                    status:"Not Owned",
-                    colors:details.color_identity,
-                    cmc:details.cmc,
-                    cardID:currentId[0],
-                    type:carddb.carddict[currentId[0]].type
-                  }
-                );
-                added.push(carddb.carddict[currentId[0]]);
+                util.addCardToCube(cube, details);
+                added.push(details);
                 changelog += '<span style=""Lucida Console", Monaco, monospace;" class="badge badge-success">+</span> ';
                 if(carddb.carddict[currentId[0]].image_flip)
                 {
@@ -1976,16 +1949,7 @@ router.post('/edit/:id',ensureAuth, function(req,res)
           }
           else
           {
-            cube.cards.push(
-              {
-                tags:['New'],
-                status:"Not Owned",
-                colors:details.color_identity,
-                cmc:details.cmc,
-                cardID:details._id,
-                type:details.type
-              }
-            );
+            util.addCardToCube(cube, details);
             changelog += '<span style=""Lucida Console", Monaco, monospace;" class="badge badge-success">+</span> ';
             if(carddb.carddict[edit.substring(1)].image_flip)
             {
@@ -2034,16 +1998,7 @@ router.post('/edit/:id',ensureAuth, function(req,res)
         {
           var tmp_split = edit.substring(1).split('>');
           var details = carddb.carddict[tmp_split[1]];
-          cube.cards.push(
-            {
-              tags:['New'],
-              status:"Not Owned",
-              colors:details.color_identity,
-              cmc:details.cmc,
-              cardID:details._id,
-              type:details.type
-            }
-          );
+          util.addCardToCube(cube, details);
 
           var rm_index = -1;
           cube.cards.forEach(function(card_to_remove, remove_index)

--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -1289,17 +1289,8 @@ function bulkUpload(req, res, list, cube) {
                   if(!found && carddb.carddict[possible].set.toLowerCase() == set)
                   {
                     var details = carddb.carddict[possible];
-                    cube.cards.push(
-                      {
-                        tags:['New'],
-                        status:"Not Owned",
-                        colors:details.color_identity,
-                        cmc:details.cmc,
-                        cardID:carddb.carddict[possible],
-                        type:carddb.carddict[possible].type
-                      }
-                    );
-                    added.push(carddb.carddict[possible]);
+                    util.addCardToCube(cube, details, details);
+                    added.push(details);
                     found = true;
                   }
                 });

--- a/serverjs/util.js
+++ b/serverjs/util.js
@@ -64,6 +64,19 @@ function binaryInsert(value, array, startVal, endVal) {
   }
 }
 
+function addCardToCube(cube, card_details, idOverride) {
+  cube.cards.push(
+    {
+      tags:['New'],
+      status:"Not Owned",
+      colors:card_details.color_identity,
+      cmc:card_details.cmc,
+      cardID:idOverride === undefined ? card_details._id : idOverride,
+      type:card_details.type
+    }
+  );
+}
+
 var methods = {
   shuffle: function (array, seed) {
     if (!seed) {
@@ -82,6 +95,7 @@ var methods = {
     return res;
   },
   binaryInsert: binaryInsert,
+  addCardToCube: addCardToCube,
   arraysEqual: function (a, b) {
     if (a === b) return true;
     if (a == null || b == null) return false;


### PR DESCRIPTION
This pull request deduplicates the addition of new cards to a cube by implementing `util.addCardToCube`. This function simply pushes a card object onto a `cube`'s `cards` array. This pull request also adjusts duplicated instances of this logic to use the new function.

Note that [this instance](https://github.com/dekkerglen/CubeCobra/blob/497d6709eaf5dd0b32707554c4ccce46681f4d7a/routes/cube_routes.js#L1316) of the duplicated logic is subtly different than the others in the manner described in https://github.com/dekkerglen/CubeCobra/issues/165#issuecomment-525996895. This pull request maintains this difference through the use of an extra argument to `util.addCardToCube`. If it's later discovered that this difference is a bug, the third argument to `util.addCardToCube` could be removed.

Fixes https://github.com/dekkerglen/CubeCobra/issues/165