### PR TITLE
add note and link to product ideas document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,10 @@ We have a fairly active discord and would love for you to join the discussion.  
 
 Private Message 'DEKKARU', the admin on Discord, to gain the contributor role and unlock the contributor-only channels.
 
+# Community feedback / product ideas
+
+Feedback from the community is collected and synthesized into roadmap ideas in a shared document [here](https://www.notion.so/CubeCobra-community-feedback-142b06cd81994a61bd850fb5bc817cc8). To gain read/write access, PM 'DEKKARU' or 'emmett9001' on Discord.
+
 ### Commit Message Style
 
 Please keep commit messages brief and informative.


### PR DESCRIPTION
This pull request links to the product ideation document from the contributor documentation.