### PR TITLE
Fix spelling of cookie and lengthen expiration.

### DIFF
--- a/app.js
+++ b/app.js
@@ -59,8 +59,9 @@ app.use(session({
   secret: 'vertical donkey gatorade helicopter',
   resave: false,
   saveUninitialized: true,
-  cooke: {
-    secure: true
+  cookie: {
+    secure: true,
+    maxAge: 365 * 24 * 60 * 60 * 1000
   }
 }));
 


### PR DESCRIPTION
app.js misspelled cookie, and so the secure attribute was not actually being set. Additionally, the maximum age was not being set, and so logouts occur frequently. On the current site, this often leads to putting in a bunch of changes and then having them disappear because the "save" button just leads to a re-login. maxAge is now set to 1 year.