### PR TITLE
changed wording and function of edit selected

### DIFF
--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -336,21 +336,25 @@ if (canEdit) {
       $('#cubeSaveModal').modal('show');
     });
   });
-  $('#editSelected').click(function(e) {
+  $('#massEdit').click(function(e) {
     e.preventDefault();
-    groupSelect = [];
-    cube.forEach(function(card, index) {
-      if (card.checked) {
-        groupSelect.push(card);
+    if (view == 'list') {
+      groupSelect = [];
+      cube.forEach(function(card, index) {
+        if (card.checked) {
+          groupSelect.push(card);
+        }
+      });
+      if (groupSelect.length == 0) {
+        $('#selectEmptyModal').modal('show');
+      } else if (groupSelect.length == 1) {
+        card = groupSelect[0];
+        show_contextModal(card);
+      } else {
+        show_groupContextModal();
       }
-    });
-    if (groupSelect.length == 0) {
-      $('#selectEmptyModal').modal('show');
-    } else if (groupSelect.length == 1) {
-      card = groupSelect[0];
-      show_contextModal(card);
     } else {
-      show_groupContextModal();
+      $('#viewSelect').val('list').change();
     }
   });
 }
@@ -977,6 +981,11 @@ function filteredCube() {
 }
 
 function updateCubeList() {
+  if (view == 'list') {
+    $('#massEdit').text('Edit Selected');
+  } else {
+    $('#massEdit').text('Mass Edit');
+  }
   switch (view) {
     case 'table':
       renderTableView();

--- a/views/cube/cube_list.pug
+++ b/views/cube/cube_list.pug
@@ -59,7 +59,7 @@ block content
 						if user
 							if user.id == cube.owner
 								li.nav-item
-									a(href="#")#editSelected.nav-link Edit Selected
+									a(href="#")#massEdit.nav-link Mass Edit
 								li.nav-item.dropdown
 									a#bulkdropdown.nav-link.dropdown-toggle(href='#', role='button', data-toggle='dropdown', aria-haspopup='true', aria-expanded='false') Bulk Upload
 									.dropdown-menu(aria-labelledby='bulkdropdown')


### PR DESCRIPTION
This is an attempted resolution to #160. This update changes the "Edit Selected" button to say "Mass Edit" while the user is not in list view, and changes it to say "Edit Selected" while they are in list view. In addition, pressing the button while not in list view will switch the user to list view instead of showing a
dialog.

I am not sure about my implementation for changing the text of the button. An alternative might be to put some javascript into the pug file, to be evaluated on the page as the user switches views. This might
be preferable as it keeps all display related code in the pug file (cube_list.pug) rather than in the javascript.

I have also changed the name for the DOM element "editSelected" to "massEdit" to reflect it's new default value.

Sorry about the "messy" diff for editcube.js, basically all that changed is a wrapping if statement, which calls `$('#viewSelect').val('list').change();` when the button is pressed, if the view isn't list view.

I resubmitted this PR as originally I mistakenly attempted to merge with master, instead of development. I could not figure out how to edit the original.