### PR TITLE
card added timestamp

### DIFF
--- a/models/cube.js
+++ b/models/cube.js
@@ -21,6 +21,7 @@ let cubeSchema = mongoose.Schema({
     cmc: Number,
     cardID: String,
     type_line: String,
+    addedTmsp: Date,
     details: {}
   }],
   decks: [String],

--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -577,7 +577,10 @@ function getLabels(sort) {
     var days = [], formattedDay;
     cube.forEach(function(card, index) {
       formattedDay = ISODateToYYYYMMDD(card.addedTmsp);
-      if (formattedDay !== undefined && !days.includes(formattedDay)) {
+      if (formattedDay === undefined) {
+          formattedDay = "unknown";
+      }
+      if (!days.includes(formattedDay)) {
         days.push(formattedDay);
       }
     });

--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -573,6 +573,18 @@ function getLabels(sort) {
       });
     });
     return tags.sort();
+  } else if (sort == 'Date Added') {
+    var days = [], formattedDay, addedTmsp;
+    cube.forEach(function(card, index) {
+      if (card.addedTmsp !== undefined) {
+        addedTmsp = new Date(card.addedTmsp);
+        formattedDay = addedTmsp.getFullYear() + "-" + addedTmsp.getMonth() + "-" + addedTmsp.getDate();
+        if (!days.includes(formattedDay)) {
+            days.push(formattedDay);
+        }
+      }
+    });
+    return days.sort();
   } else if (sort == 'Status') {
     return ['Not Owned', 'Ordered', 'Owned', 'Premium Owned'];
   } else if (sort == 'Guilds') {

--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -574,14 +574,11 @@ function getLabels(sort) {
     });
     return tags.sort();
   } else if (sort == 'Date Added') {
-    var days = [], formattedDay, addedTmsp;
+    var days = [], formattedDay;
     cube.forEach(function(card, index) {
-      if (card.addedTmsp !== undefined) {
-        addedTmsp = new Date(card.addedTmsp);
-        formattedDay = addedTmsp.getFullYear() + "-" + addedTmsp.getMonth() + "-" + addedTmsp.getDate();
-        if (!days.includes(formattedDay)) {
-            days.push(formattedDay);
-        }
+      formattedDay = ISODateToYYYYMMDD(card.addedTmsp);
+      if (formattedDay !== undefined && !days.includes(formattedDay)) {
+        days.push(formattedDay);
       }
     });
     return days.sort();

--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -543,7 +543,7 @@ function GetColorIdentity(colors) {
 }
 
 function getSorts() {
-  return ['Artist', 'CMC', 'Color Category', 'Color Count', 'Color Identity', 'Color', 'Guilds', 'Legality', 'Loyalty', 'Manacost Type', 'Power', 'Price', 'Price Foil', 'Rarity', 'Set', 'Shards / Wedges', 'Status', 'Subtype', 'Supertype', 'Tags', 'Toughness', 'Type', 'Types-Multicolor'];
+  return ['Artist', 'CMC', 'Color Category', 'Color Count', 'Color Identity', 'Color', 'Date Added', 'Guilds', 'Legality', 'Loyalty', 'Manacost Type', 'Power', 'Price', 'Price Foil', 'Rarity', 'Set', 'Shards / Wedges', 'Status', 'Subtype', 'Supertype', 'Tags', 'Toughness', 'Type', 'Types-Multicolor'];
 
 
 }

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -48,6 +48,14 @@ $(document).ready(function() {
   })
 });
 
+function ISODateToYYYYMMDD(dateString) {
+    if (dateString === undefined) {
+      return undefined;
+    }
+    var date = new Date(dateString);
+    return date.getFullYear() + "-" + date.getMonth() + "-" + date.getDate();
+}
+
 function toggleRecent() {
   var x = document.getElementById("recentMore");
   if (x.innerHTML === "View More...") {

--- a/public/js/sortfilter.js
+++ b/public/js/sortfilter.js
@@ -143,7 +143,11 @@ function cardIsLabel(card, label, sort) {
   } else if (sort == 'Status') {
     return card.status == label;
   } else if (sort == 'Date Added') {
-    return label === ISODateToYYYYMMDD(card.addedTmsp);
+    var day = ISODateToYYYYMMDD(card.addedTmsp);
+    if (day === undefined) {
+      day = "unknown";
+    }
+    return label === day;
   } else if (sort == 'Guilds') {
     if (card.colors.length != 2) {
       return false;

--- a/public/js/sortfilter.js
+++ b/public/js/sortfilter.js
@@ -143,12 +143,7 @@ function cardIsLabel(card, label, sort) {
   } else if (sort == 'Status') {
     return card.status == label;
   } else if (sort == 'Date Added') {
-    var addedTmsp = card.addedTmsp, formattedDay;
-    if (addedTmsp !== undefined) {
-      addedTmsp = new Date(addedTmsp);
-      formattedDay = addedTmsp.getFullYear() + "-" + addedTmsp.getMonth() + "-" + addedTmsp.getDate();
-    }
-    return label === formattedDay;
+    return label === ISODateToYYYYMMDD(card.addedTmsp);
   } else if (sort == 'Guilds') {
     if (card.colors.length != 2) {
       return false;

--- a/public/js/sortfilter.js
+++ b/public/js/sortfilter.js
@@ -142,6 +142,13 @@ function cardIsLabel(card, label, sort) {
     return card.tags.includes(label);
   } else if (sort == 'Status') {
     return card.status == label;
+  } else if (sort == 'Date Added') {
+    var addedTmsp = card.addedTmsp, formattedDay;
+    if (addedTmsp !== undefined) {
+      addedTmsp = new Date(addedTmsp);
+      formattedDay = addedTmsp.getFullYear() + "-" + addedTmsp.getMonth() + "-" + addedTmsp.getDate();
+    }
+    return label === formattedDay;
   } else if (sort == 'Guilds') {
     if (card.colors.length != 2) {
       return false;

--- a/serverjs/util.js
+++ b/serverjs/util.js
@@ -68,7 +68,8 @@ function addCardToCube(cube, card_details, idOverride) {
     colors: card_details.color_identity,
     cmc: card_details.cmc,
     cardID: idOverride === undefined ? card_details._id : idOverride,
-    type: card_details.type
+    type: card_details.type,
+    addedTmsp: new Date()
   });
 }
 


### PR DESCRIPTION
This pull request fixes https://github.com/dekkerglen/CubeCobra/issues/131 by tracking the date of cards' addition to the cube and allowing sorting and filtering by that date.

Overview of changes:
* Adds `addedTmsp` to the cube card schema as a `Date` field
* Adds `Date Added` to the list of available sorts and filters
* Adds sorting and filtering logic supporting the new `Date Added` option
* Adds `ISODateToYYYYMMDD` utility function to `main.js` to avoid code duplication