### PR TITLE
Remove Edit Token

### DIFF
--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -181,7 +181,6 @@ if (canEdit) {
       selected: groupSelect,
       filters: filterobj,
       updated: updated,
-      token: $('#edittoken').val()
     };
 
     fetch("/cube/api/updatecards/" + $('#cubeID').val(), {
@@ -290,7 +289,6 @@ if (canEdit) {
     let data = {
       src: modalSelect,
       updated: updated,
-      token: document.getElementById("edittoken").value
     };
     fetch("/cube/api/updatecard/" + $('#cubeID').val(), {
       method: "POST",
@@ -324,7 +322,6 @@ if (canEdit) {
     temp_sorts[1] = document.getElementById('secondarySortSelect').value;
     let data = {
       sorts: temp_sorts,
-      token: document.getElementById("edittoken").value
     };
     fetch("/cube/api/savesorts/" + $('#cubeID').val(), {
       method: "POST",
@@ -1208,7 +1205,6 @@ function renderListView() {
         let data = {
           src: cube[index],
           updated: updated,
-          token: document.getElementById("edittoken").value
         };
         fetch("/cube/api/updatecard/" + $('#cubeID').val(), {
           method: "POST",
@@ -1239,7 +1235,6 @@ function renderListView() {
         let data = {
           src: cube[index],
           updated: updated,
-          token: document.getElementById("edittoken").value
         };
         fetch("/cube/api/updatecard/" + $('#cubeID').val(), {
           method: "POST",
@@ -1270,7 +1265,6 @@ function renderListView() {
         let data = {
           src: cube[index],
           updated: updated,
-          token: document.getElementById("edittoken").value
         };
         fetch("/cube/api/updatecard/" + $('#cubeID').val(), {
           method: "POST",
@@ -1301,7 +1295,6 @@ function renderListView() {
         let data = {
           src: cube[index],
           updated: updated,
-          token: document.getElementById("edittoken").value
         };
         fetch("/cube/api/updatecard/" + $('#cubeID').val(), {
           method: "POST",
@@ -1335,7 +1328,6 @@ function renderListView() {
         let data = {
           src: cube[index],
           updated: updated,
-          token: document.getElementById("edittoken").value
         };
         fetch("/cube/api/updatecard/" + $('#cubeID').val(), {
           method: "POST",
@@ -1369,7 +1361,6 @@ function renderListView() {
         let data = {
           src: cube[index],
           updated: updated,
-          token: document.getElementById("edittoken").value
         };
         fetch("/cube/api/updatecard/" + $('#cubeID').val(), {
           method: "POST",

--- a/views/cube/cube_list.pug
+++ b/views/cube/cube_list.pug
@@ -174,7 +174,7 @@ block content
 		input#only_b(type='hidden', name='only_b', value=only_b)
 	input#cuberaw(type='hidden', name='cuberaw', value=cube_raw)        
 	if user && user.id == cube.owner
-		input#edittoken(type='hidden', name='edittoken', value=edittoken)
+		input#edittoken(type='hidden', name='edittoken', value='edit')
 	if cube.default_sorts        
 		input#sort1(type='hidden', name='edittoken', value=cube.default_sorts[0])        
 		input#sort2(type='hidden', name='edittoken', value=cube.default_sorts[1])        


### PR DESCRIPTION
Fix for #220 

Edit Token was unnecessary for the app to work as intended, and just
added complexity to any possible new routes. Now validity is checked on
the server side based on whether the de-serialized user object generated by
passport matches the cube owner, and is checked on the client side by a
hidden input field with a generic value. That input field is only
created if a user exists as a part of the request. This has no changed
front-end functionality, as currently the front-end only checked whether
the edit token existed, then simply passed it back to the server.

No additional token needs to be passed back and forth, now the session
cookie handles authentication, like it should. Changes to editcube.js no 
longer require the author to remember to submit the token either. Auth
is handled automatically as part of the session!