### PR TITLE
allow card update objects not to contain all card fields

### DIFF
--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -2228,7 +2228,13 @@ router.post('/api/updatecard/:id', function(req, res) {
           }
           if (!found && cardsAreEquivalent(card, req.body.src, carddb)) {
             found = true;
-            cube.cards[index] = req.body.updated;
+            var updated = req.body.updated;
+            Object.keys(Cube.schema.paths.cards.schema.paths).forEach(function(key) {
+              if (!updated.hasOwnProperty(key)) {
+                updated[key] = card[key];
+              }
+            });
+            cube.cards[index] = updated;
           }
         });
         if (!found) {


### PR DESCRIPTION
This pull request fixes https://github.com/dekkerglen/CubeCobra/issues/131 by setting missing fields on the card update object to their database values. This ensures that update objects that don't include all card fields don't cause those missing fields to be unset in the resulting database update. At the moment, `addedTmsp` is the only field to which this applies.