### PR TITLE
Fix the card object generated by the .csv bulk upload process

### DIFF
--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -980,6 +980,7 @@ function bulkuploadCSV(req, res, cards, cube) {
     let split = util.CSVtoArray(card_raw);
     let name = split[0];
     let card = {
+      name: name,
       cmc: split[1],
       type_line: split[2].replace('-', '—'),
       colors: split[3].split(''),
@@ -994,9 +995,9 @@ function bulkuploadCSV(req, res, cards, cube) {
       let matchingSet = potentialIds.find(id => carddb.carddict[id].set.toUpperCase() == card.set);
       let nonPromo = potentialIds.find(notPromoOrDigitalId);
       let first = potentialIds[0];
-      card.id = matchingSet || nonPromo || first;
+      card.cardID = matchingSet || nonPromo || first;
       cube.cards.push(card);
-      changelog += addCardHtml(carddb.carddict[card.id]);
+      changelog += addCardHtml(carddb.carddict[card.cardID]);
     } else {
       missing += card.name + '\n';
     }


### PR DESCRIPTION
# Overview

This update fixes two issues with the .csv bulk upload:

1. The generated card object was missing the `name` field.
2. The generated card object stored the identifier in `card.id`, but the rest of the codebase expects to find it in `card.cardID`.

Fixes #288.

# Testing

1. Navigate to the cube of your choice and export a .csv file.
2. Create a new cube and import the .csv exported above.