### PR TITLE
Add collector number to .csv export

### DIFF
--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -1169,7 +1169,7 @@ router.get('/download/csv/:id', function(req, res) {
       res.setHeader('Content-disposition', 'attachment; filename=' + cube.name.replace(/\W/g, '') + '.csv');
       res.setHeader('Content-type', 'text/plain');
       res.charset = 'UTF-8';
-      res.write('Name,CMC,Type,Color,Set,Status,Tags\r\n');
+      res.write('Name,CMC,Type,Color,Set,Collector Number,Status,Tags\r\n');
       cube.cards.forEach(function(card, index) {
         if (!card.type_line) {
           card.type_line = carddb.carddict[card.cardID].type;
@@ -1195,6 +1195,7 @@ router.get('/download/csv/:id', function(req, res) {
           res.write(',');
         }
         res.write('"' + carddb.carddict[card.cardID].set + '"' + ',');
+        res.write('"' + carddb.carddict[card.cardID].collector_number + '"' + ',');
         res.write(card.status + ',"');
         card.tags.forEach(function(tag, t_index) {
           if (t_index != 0) {

--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -988,8 +988,9 @@ function bulkuploadCSV(req, res, cards, cube) {
       type_line: split[2].replace('-', '—'),
       colors: split[3].split(''),
       set: split[4].toUpperCase(),
-      status: split[5],
-      tags: split[6].split(',')
+      collector_number: split[5],
+      status: split[6],
+      tags: split[7].split(',')
     };
 
     let potentialIds = carddb.allIds(card);
@@ -1048,7 +1049,7 @@ function bulkuploadCSV(req, res, cards, cube) {
 function bulkUpload(req, res, list, cube) {
   cards = list.match(/[^\r\n]+/g);
   if (cards) {
-    if (cards[0].trim() == 'Name,CMC,Type,Color,Set,Status,Tags') {
+    if (cards[0].trim() == 'Name,CMC,Type,Color,Set,Collector Number,Status,Tags') {
       cards.splice(0, 1);
       bulkuploadCSV(req, res, cards, cube);
     } else {

--- a/serverjs/updatecards.js
+++ b/serverjs/updatecards.js
@@ -129,6 +129,7 @@ function convertExtraCard(card) {
   let newcard = {};
   newcard._id = card.id + '2';
   newcard.set = card.set;
+  newcard.collector_number = card.collector_number;
   newcard.promo = card.promo;
   newcard.digital = card.digital;
   newcard.border_color = card.border_color;
@@ -192,6 +193,7 @@ function convertCard(card) {
 
   newcard._id = card.id;
   newcard.set = card.set;
+  newcard.collector_number = card.collector_number;
   newcard.promo = card.promo;
   newcard.digital = card.digital;
   newcard.border_color = card.border_color;


### PR DESCRIPTION
# Overview

This update adds collector number to the .csv export and updates the bulk upload process to accept the new file format.  The old file format is no longer supported.

All cards show up as unrecognized if a user attempts to import an old .csv without adding the "Collector Number" column.  The collector number is not used by the import process, so it's safe to leave the column blank.

Card data must be re-imported once this change is applied as the `collector_number` field that it relies on was not loaded into the card db previously.

Fixes #278.

# Examples

```csv
Name,CMC,Type,Color,Set,Collector Number,Status,Tags
"Dauntless Bodyguard",1,"Creature - Human Knight",W,"dom","14",Not Owned,"New"
"Doomed Traveler",1,"Creature - Human Soldier",W,"bbd","91",Not Owned,"New"
"Haazda Marshal",1,"Creature - Human Soldier",W,"grn","13",Not Owned,"New"
"Healer's Hawk",1,"Creature - Bird",W,"grn","14",Not Owned,"New"
"Novice Knight",1,"Creature - Human Knight",W,"m19","30",Not Owned,"New"
"Skymarcher Aspirant",1,"Creature - Vampire Soldier",W,"rix","21",Not Owned,"New"
```

# Testing

Remember to re-import the card data before testing this feature.

## Export

1. Navigate to the cube of your choice.
2. Click on the "List" tab, then click on the "Export" menu and select "Comma Separated (.csv)".
3. Save the file to a known location.
4. Open the file and confirm that the "Collector Number" column appears after "Set".

## Import

1. Sign in and create a new cube.
2. Click on the "List" tab, then click on the "Bulk Upload" menu and select "Upload File"
3. Select the file exported above and click "Upload".
4. The cube list view should display once the upload process completes.