### PR TITLE
toggle custom images

### DIFF
--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -325,3 +325,7 @@ border-bottom: none;
     width: 150px;
     vertical-align: top;
 }
+
+#customImageDisplayToggle {
+    margin-right: 6px;
+}

--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -329,3 +329,11 @@ border-bottom: none;
 #customImageDisplayToggle {
     margin-right: 6px;
 }
+
+#customImageDisplayMenuItem {
+    float: right;
+}
+
+#packTitle, .card-header h4 {
+    display: inline-block;
+}

--- a/public/js/deck.js
+++ b/public/js/deck.js
@@ -33,12 +33,7 @@ $('#customImageDisplayToggle').click(function(e) {
   var enabled = $(this).prop('checked'), display_image;
   deck.forEach(function(inner, index) {
     inner.forEach(function(card, index) {
-      if (enabled) {
-        display_image = card.imgUrl !== undefined ? card.imgUrl : card.details.image_normal;
-      } else {
-        display_image = card.details.image_normal;
-      }
-      card.details.display_image = display_image;
+      adjustDisplayImage(card, enabled);
     });
   });
   renderDraft();

--- a/public/js/deck.js
+++ b/public/js/deck.js
@@ -17,6 +17,33 @@ window.onresize = function() {
   renderDraft();
 }
 
+var hasCustomImages = false;
+$("#customImageDisplayMenuItem").hide();
+deck.forEach(function(inner, index) {
+  inner.forEach(function(card, index) {
+    if (!hasCustomImages && card.imgUrl !== undefined) {
+      hasCustomImages = true;
+      $("#customImageDisplayToggle").prop("checked", true);
+      $("#customImageDisplayMenuItem").show();
+    }
+  });
+});
+
+$('#customImageDisplayToggle').click(function(e) {
+  var enabled = $(this).prop('checked'), display_image;
+  deck.forEach(function(inner, index) {
+    inner.forEach(function(card, index) {
+      if (enabled) {
+        display_image = card.imgUrl !== undefined ? card.imgUrl : card.details.image_normal;
+      } else {
+        display_image = card.details.image_normal;
+      }
+      card.details.display_image = display_image;
+    });
+  });
+  renderDraft();
+});
+
 
 function renderDraft() {
   setupColumns();

--- a/public/js/deckbuilder.js
+++ b/public/js/deckbuilder.js
@@ -53,12 +53,7 @@ $('#customImageDisplayToggle').click(function(e) {
   var enabled = $(this).prop('checked'), display_image;
   deck.playerdeck.forEach(function(inner, index) {
     inner.forEach(function(card, index) {
-      if (enabled) {
-        display_image = card.imgUrl !== undefined ? card.imgUrl : card.details.image_normal;
-      } else {
-        display_image = card.details.image_normal;
-      }
-      card.details.display_image = display_image;
+      adjustDisplayImage(card, enabled);
     });
   });
   renderDraft();

--- a/public/js/deckbuilder.js
+++ b/public/js/deckbuilder.js
@@ -21,6 +21,18 @@ window.onresize = function() {
   renderDraft();
 }
 
+var hasCustomImages = false;
+$("#customImageDisplayMenuItem").hide();
+deck.playerdeck.forEach(function(inner, index) {
+  inner.forEach(function(card, index) {
+    if (!hasCustomImages && card.imgUrl !== undefined) {
+      hasCustomImages = true;
+      $("#customImageDisplayToggle").prop("checked", true);
+      $("#customImageDisplayMenuItem").show();
+    }
+  });
+});
+
 $('#addBasicsButton').click(function(e) {
   addCards(basics.Plains, $('#basicsWhite').val());
   addCards(basics.Island, $('#basicsBlue').val());
@@ -35,6 +47,21 @@ $('#addBasicsButton').click(function(e) {
 $('#saveDeckButton').click(function(e) {
   $('#deckraw').val(JSON.stringify(deck));
   $('#submitDeckForm').submit();
+});
+
+$('#customImageDisplayToggle').click(function(e) {
+  var enabled = $(this).prop('checked'), display_image;
+  deck.playerdeck.forEach(function(inner, index) {
+    inner.forEach(function(card, index) {
+      if (enabled) {
+        display_image = card.imgUrl !== undefined ? card.imgUrl : card.details.image_normal;
+      } else {
+        display_image = card.details.image_normal;
+      }
+      card.details.display_image = display_image;
+    });
+  });
+  renderDraft();
 });
 
 function addCards(card, amount) {

--- a/public/js/draft.js
+++ b/public/js/draft.js
@@ -22,6 +22,20 @@ window.onresize = function() {
   renderDraft();
 }
 
+var hasCustomImages = false;
+$("#customImageDisplayMenuItem").hide();
+draft.packs.forEach(function(pack, index) {
+  pack.forEach(function(inner, index) {
+    inner.forEach(function(card, index) {
+      if (!hasCustomImages && card.imgUrl !== undefined) {
+        hasCustomImages = true;
+        $("#customImageDisplayToggle").prop("checked", true);
+        $("#customImageDisplayMenuItem").show();
+      }
+    });
+  });
+});
+
 $('#passpack').click(function(e) {
   passPack();
 });

--- a/public/js/draft.js
+++ b/public/js/draft.js
@@ -45,23 +45,13 @@ $('#customImageDisplayToggle').click(function(e) {
   draft.packs.forEach(function(pack, index) {
     pack.forEach(function(inner, index) {
       inner.forEach(function(card, index) {
-        if (enabled) {
-          display_image = card.imgUrl !== undefined ? card.imgUrl : card.details.image_normal;
-        } else {
-          display_image = card.details.image_normal;
-        }
-        card.details.display_image = display_image;
+        adjustDisplayImage(card, enabled);
       });
     });
   });
   draft.picks[0].forEach(function(slot, index) {
     slot.forEach(function(card, index) {
-      if (enabled) {
-          display_image = card.imgUrl !== undefined ? card.imgUrl : card.details.image_normal;
-      } else {
-          display_image = card.details.image_normal;
-      }
-      card.details.display_image = display_image;
+      adjustDisplayImage(card, enabled);
     });
   });
   renderDraft();

--- a/public/js/draft.js
+++ b/public/js/draft.js
@@ -26,6 +26,33 @@ $('#passpack').click(function(e) {
   passPack();
 });
 
+$('#customImageDisplayToggle').click(function(e) {
+  var enabled = $(this).prop('checked'), display_image;
+  draft.packs.forEach(function(pack, index) {
+    pack.forEach(function(inner, index) {
+      inner.forEach(function(card, index) {
+        if (enabled) {
+          display_image = card.imgUrl !== undefined ? card.imgUrl : card.details.image_normal;
+        } else {
+          display_image = card.details.image_normal;
+        }
+        card.details.display_image = display_image;
+      });
+    });
+  });
+  draft.picks[0].forEach(function(slot, index) {
+    slot.forEach(function(card, index) {
+      if (enabled) {
+          display_image = card.imgUrl !== undefined ? card.imgUrl : card.details.image_normal;
+      } else {
+          display_image = card.details.image_normal;
+      }
+      card.details.display_image = display_image;
+    });
+  });
+  renderDraft();
+});
+
 function arrayRotate(arr, reverse) {
   if (reverse) arr.unshift(arr.pop());
   else arr.push(arr.shift());

--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -63,12 +63,7 @@ $('#customImageDisplayToggle').click(function(e) {
   console.log("clicked");
   var enabled = $(this).prop('checked'), display_image;
   cube.forEach(function(card, index) {
-    if (enabled) {
-      display_image = card.imgUrl !== undefined ? card.imgUrl : card.details.image_normal;
-    } else {
-      display_image = card.details.image_normal;
-    }
-    card.details.display_image = display_image;
+    adjustDisplayImage(card, enabled);
   });
   updateCubeList();
 });

--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -53,6 +53,20 @@ $('.updateButton').click(function(e) {
   updateCubeList();
 });
 
+$('#customImageDisplayToggle').click(function(e) {
+  console.log("clicked");
+  var enabled = $(this).prop('checked'), display_image;
+  cube.forEach(function(card, index) {
+    if (enabled) {
+      display_image = card.imgUrl !== undefined ? card.imgUrl : card.details.image_normal;
+    } else {
+      display_image = card.details.image_normal;
+    }
+    card.details.display_image = display_image;
+  });
+  updateCubeList();
+});
+
 $('#viewSelect').change(function(e) {
   view = $('#viewSelect').val();
   updateCubeList();

--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -22,11 +22,17 @@ if ($('#in_both').length) {
   view = 'table';
 }
 
-var cubeDict = {};
+var cubeDict = {}, hasCustomImages = false;
+$("#customImageDisplayMenuItem").hide();
 var cube = JSON.parse($('#cuberaw').val());
 cube.forEach(function(card, index) {
   card.index = index;
   cubeDict[index] = card;
+  if (!hasCustomImages && card.imgUrl !== undefined) {
+    hasCustomImages = true;
+    $("#customImageDisplayToggle").prop("checked", true);
+    $("#customImageDisplayMenuItem").show();
+  }
 });
 
 $('#compareButton').click(function(e) {

--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -1,0 +1,8 @@
+function adjustDisplayImage(card, customImagesEnabled) {
+  if (customImagesEnabled) {
+    display_image = card.imgUrl !== undefined ? card.imgUrl : card.details.image_normal;
+  } else {
+    display_image = card.details.image_normal;
+  }
+  card.details.display_image = display_image;
+}

--- a/views/cube/cube_deck.pug
+++ b/views/cube/cube_deck.pug
@@ -3,6 +3,9 @@ extends cube_layout
 block cube_content
   link(rel='stylesheet' href='/css/draft.css')
   br
+  span#customImageDisplayMenuItem
+    input#customImageDisplayToggle(type='checkbox')
+    label(for='customImageDisplayToggle') Show custom images
   if oldformat
     .container
       h4 Drafted by #{drafter}

--- a/views/cube/cube_deck.pug
+++ b/views/cube/cube_deck.pug
@@ -3,9 +3,6 @@ extends cube_layout
 block cube_content
   link(rel='stylesheet' href='/css/draft.css')
   br
-  span#customImageDisplayMenuItem
-    input#customImageDisplayToggle(type='checkbox')
-    label(for='customImageDisplayToggle') Show custom images
   if oldformat
     .container
       h4 Drafted by #{drafter}
@@ -18,6 +15,9 @@ block cube_content
     .card.card-hover#deckhover
       .card-header
         h4 Drafted by #{drafter}
+        span#customImageDisplayMenuItem
+          input#customImageDisplayToggle(type='checkbox')
+          label(for='customImageDisplayToggle') Show Custom Images
       .card-body
         input#deckraw(type='hidden', name='deckraw', value=deck)
         #deckarea(style='margin: 3px;')

--- a/views/cube/cube_deck.pug
+++ b/views/cube/cube_deck.pug
@@ -47,4 +47,5 @@ block cube_content
             if card.colorcategory == 'l'
               a.list-group-item.autocard.lands.card-list-item(card=card.display_image card_flip=card.image_flip)= card.name
 
+  script(src='/js/utils.js')
   script(src='/js/deck.js')

--- a/views/cube/cube_deckbuilder.pug
+++ b/views/cube/cube_deckbuilder.pug
@@ -15,12 +15,13 @@ block cube_toolbar
             a#saveDeckButton.nav-link(href='#' ) Save Deck
           li.nav-item
             a.nav-link(href='#' data-toggle='modal', data-target='#basicsModal') Add Basic Lands
+          li.nav-item
+            span#customImageDisplayMenuItem.nav-link.text-sm-left.text-center
+              input#customImageDisplayToggle(type='checkbox')
+              label(for='customImageDisplayToggle') Show Custom Images
 
 block cube_content
   br
-  span#customImageDisplayMenuItem.nav-link.text-sm-left.text-center
-    input#customImageDisplayToggle(type='checkbox')
-    label(for='customImageDisplayToggle') Show custom images
   .card.card-hover#deckhover
     .card-header
       h4#deckName Deck

--- a/views/cube/cube_deckbuilder.pug
+++ b/views/cube/cube_deckbuilder.pug
@@ -18,6 +18,9 @@ block cube_toolbar
 
 block cube_content
   br
+  span#customImageDisplayMenuItem.nav-link.text-sm-left.text-center
+    input#customImageDisplayToggle(type='checkbox')
+    label(for='customImageDisplayToggle') Show custom images
   .card.card-hover#deckhover
     .card-header
       h4#deckName Deck

--- a/views/cube/cube_deckbuilder.pug
+++ b/views/cube/cube_deckbuilder.pug
@@ -163,5 +163,6 @@ block cube_content
         .modal-footer
           button#addBasicsButton.btn.btn-success(type='submit',value='Add') Add
           button.btn.btn-secondary(type='button', data-dismiss='modal') Close
+  script(src='/js/utils.js')
   script(src='/js/deckbuilder.js')
 

--- a/views/cube/cube_draft.pug
+++ b/views/cube/cube_draft.pug
@@ -13,10 +13,10 @@ block cube_content
   .card#packhover
     .card-header
       h4#packTitle
-      h6#packSubtitle
-      span#customImageDisplayMenuItem.nav-link.text-sm-left.text-center
+      div#customImageDisplayMenuItem.nav-link.text-sm-left.text-center
         input#customImageDisplayToggle(type='checkbox')
-        label(for='customImageDisplayToggle') Show custom images
+        label(for='customImageDisplayToggle') Show Custom Images
+      h6#packSubtitle
       //.form-check
         input#autopass.form-check-input(type='checkbox', value='true' checked)
         label.form-check-label(for='autopass') Autopass

--- a/views/cube/cube_draft.pug
+++ b/views/cube/cube_draft.pug
@@ -29,5 +29,6 @@ block cube_content
       h4 Picks
     .card-body
       #picksarea(style='margin: 3px;')
+  script(src='/js/utils.js')
   script(src='/js/draft.js')
 

--- a/views/cube/cube_draft.pug
+++ b/views/cube/cube_draft.pug
@@ -17,11 +17,11 @@ block cube_content
       span#customImageDisplayMenuItem.nav-link.text-sm-left.text-center
         input#customImageDisplayToggle(type='checkbox')
         label(for='customImageDisplayToggle') Show custom images
-        //.form-check
-          input#autopass.form-check-input(type='checkbox', value='true' checked)
-          label.form-check-label(for='autopass') Autopass
-          br
-          button.btn.btn-success#passpack(type='button')  Pass pack
+      //.form-check
+        input#autopass.form-check-input(type='checkbox', value='true' checked)
+        label.form-check-label(for='autopass') Autopass
+        br
+        button.btn.btn-success#passpack(type='button')  Pass pack
     #packarea(style='margin: 3px;')
   br
   .card.card-hover#pickshover

--- a/views/cube/cube_draft.pug
+++ b/views/cube/cube_draft.pug
@@ -14,6 +14,9 @@ block cube_content
     .card-header
       h4#packTitle
       h6#packSubtitle
+      span#customImageDisplayMenuItem.nav-link.text-sm-left.text-center
+        input#customImageDisplayToggle(type='checkbox')
+        label(for='customImageDisplayToggle') Show custom images
         //.form-check
           input#autopass.form-check-input(type='checkbox', value='true' checked)
           label.form-check-label(for='autopass') Autopass

--- a/views/cube/cube_draft.pug
+++ b/views/cube/cube_draft.pug
@@ -17,11 +17,11 @@ block cube_content
         input#customImageDisplayToggle(type='checkbox')
         label(for='customImageDisplayToggle') Show Custom Images
       h6#packSubtitle
-      //.form-check
-        input#autopass.form-check-input(type='checkbox', value='true' checked)
-        label.form-check-label(for='autopass') Autopass
-        br
-        button.btn.btn-success#passpack(type='button')  Pass pack
+        //.form-check
+          input#autopass.form-check-input(type='checkbox', value='true' checked)
+          label.form-check-label(for='autopass') Autopass
+          br
+          button.btn.btn-success#passpack(type='button')  Pass pack
     #packarea(style='margin: 3px;')
   br
   .card.card-hover#pickshover

--- a/views/cube/cube_layout.pug
+++ b/views/cube/cube_layout.pug
@@ -10,6 +10,10 @@ block content
           if cube.type
             span.d-none.d-sm-inline
               |  (#{cube.card_count} Card #{cube.type} Cube)
+      li.nav-item
+        span.nav-link.text-sm-left.text-center
+          input#customImageDisplayToggle(type='checkbox')
+          label(for='customImageDisplayToggle') Show custom images
       .d-flex.flex-row.flex-wrap
         li.nav-item
           a.nav-link(href='/cube/overview/'+cube_id, class=activeLink === 'overview' && 'active') Overview

--- a/views/cube/cube_layout.pug
+++ b/views/cube/cube_layout.pug
@@ -10,10 +10,6 @@ block content
           if cube.type
             span.d-none.d-sm-inline
               |  (#{cube.card_count} Card #{cube.type} Cube)
-      li.nav-item
-        span#customImageDisplayMenuItem.nav-link.text-sm-left.text-center
-          input#customImageDisplayToggle(type='checkbox')
-          label(for='customImageDisplayToggle') Show custom images
       .d-flex.flex-row.flex-wrap
         li.nav-item
           a.nav-link(href='/cube/overview/'+cube_id, class=activeLink === 'overview' && 'active') Overview

--- a/views/cube/cube_layout.pug
+++ b/views/cube/cube_layout.pug
@@ -11,7 +11,7 @@ block content
             span.d-none.d-sm-inline
               |  (#{cube.card_count} Card #{cube.type} Cube)
       li.nav-item
-        span.nav-link.text-sm-left.text-center
+        span#customImageDisplayMenuItem.nav-link.text-sm-left.text-center
           input#customImageDisplayToggle(type='checkbox')
           label(for='customImageDisplayToggle') Show custom images
       .d-flex.flex-row.flex-wrap

--- a/views/cube/cube_list.pug
+++ b/views/cube/cube_list.pug
@@ -48,7 +48,7 @@ block cube_toolbar
           li.nav-item
             span#customImageDisplayMenuItem.nav-link.text-sm-left.text-center
               input#customImageDisplayToggle(type='checkbox')
-              label(for='customImageDisplayToggle') Show custom images
+              label(for='customImageDisplayToggle') Show Custom Images
     #accordion.accordion
       if user
         if user.id == cube.owner

--- a/views/cube/cube_list.pug
+++ b/views/cube/cube_list.pug
@@ -45,6 +45,10 @@ block cube_toolbar
               a.dropdown-item(href='/cube/download/plaintext/'+cube_id) Card Names (.txt)
               a.dropdown-item(href='/cube/download/csv/'+cube_id) Comma Separated (.csv)
                 br
+          li.nav-item
+            span#customImageDisplayMenuItem.nav-link.text-sm-left.text-center
+              input#customImageDisplayToggle(type='checkbox')
+              label(for='customImageDisplayToggle') Show custom images
     #accordion.accordion
       if user
         if user.id == cube.owner

--- a/views/cube/cube_list.pug
+++ b/views/cube/cube_list.pug
@@ -401,6 +401,7 @@ block cube_content
         .modal-footer
           button.btn.btn-secondary(type='button', data-dismiss='modal') OK
 
+  script(src='/js/utils.js')
   script(src='/js/autocomplete.js')
   script(src='/js/sortfilter.js')
   script(src='/js/tags.js')


### PR DESCRIPTION
This pull request fixes #279 by implementing a toggle turning custom card images on and off on the list, draft, deckbuilder, and deck views. This toggle is only visible when a view would show at least one custom image, and it defaults to "on".