### PR TITLE
Add missing hyperlinks

### DIFF
--- a/views/info/contact.pug
+++ b/views/info/contact.pug
@@ -18,7 +18,7 @@ block content
           dt.col-3 Email
           dd.col-9
             p
-              a support@cubecobra.com
+              a(href='mailto:support@cubecobra.com') support@cubecobra.com
           dt.col-3 Discord
           dd.col-9
             p

--- a/views/info/ourstory.pug
+++ b/views/info/ourstory.pug
@@ -12,7 +12,7 @@ block content
 				|  I wanted a platform that had exactly the features that I cared about, and from talking to others in the cubing community, the current cube management tools left a lot
 				|  to be desired. I launched Cube Cobra with my initial minimum feature set in June 2019, and since then I've been adding features.
 				|  With my 1.3 update, I started sharing my project with the online cubing community and recieved a lot of positive encouragement and praise, which has further driven me
-				|  to create a cube management tool for cube designers, by a fellow cube designer. I ended up open sourcing Cube Cobra, as I believe that is the best route for the quality and longevity of the project.
+				|  to create a cube management tool for cube designers, by a fellow cube designer. I ended up #[a(href='https://github.com/dekkerglen/CubeCobra') open sourcing Cube Cobra], as I believe that is the best route for the quality and longevity of the project.
 		dt.col-3 Project Goals
 		dd.col-9
 			p The main goal of Cube Cobra is to create a cube management tool that doesn't need to be supplemented with any other tool such as excel, gatherer, or another cube management app.

--- a/views/info/privacy_policy.pug
+++ b/views/info/privacy_policy.pug
@@ -98,7 +98,7 @@ block content
     dt.col-3 Children's Privacy
     dd.col-9
       p Our Service does not address anyone under the age of 18 ("Children").
-      P We do not knowingly collect personally identifiable information from anyone under the age of 18. 
+      p We do not knowingly collect personally identifiable information from anyone under the age of 18. 
         | If you are a parent or guardian and you are aware that your Children has provided us with Personal Data, 
         | please contact us. If we become aware that we have collected Personal Data from children without verification of parental
         | consent, we take steps to remove that information from our servers.
@@ -106,10 +106,10 @@ block content
     dt.col-3 Changes To This Privacy Policy
     dd.col-9
       p We may update our Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy Policy on this page.
-      P We will let you know via email and/or a prominent notice on our Service, prior to the change becoming effective and update the "effective date" at the top of this Privacy Policy.
-      P You are advised to review this Privacy Policy periodically for any changes. Changes to this Privacy Policy are effective when they are posted on this page.
+      p We will let you know via email and/or a prominent notice on our Service, prior to the change becoming effective and update the "effective date" at the top of this Privacy Policy.
+      p You are advised to review this Privacy Policy periodically for any changes. Changes to this Privacy Policy are effective when they are posted on this page.
   dl.row
     dt.col-3 Contact Us
     dd.col-9
       p We may update our Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy Policy on this page.
-      P By email: #[a(href='mailto:support@cubecobra.com') support@cubecobra.com]
+      p By email: #[a(href='mailto:support@cubecobra.com') support@cubecobra.com]

--- a/views/info/privacy_policy.pug
+++ b/views/info/privacy_policy.pug
@@ -112,4 +112,4 @@ block content
     dt.col-3 Contact Us
     dd.col-9
       p We may update our Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy Policy on this page.
-      P By email: support@cubecobra.com
+      P By email: #[a(href='mailto:support@cubecobra.com') support@cubecobra.com]


### PR DESCRIPTION
Was reading the "Our Story" page and saw you had open sourced the project, but then couldn't find the link to the Github repo!

After digging around a bit, found it (obviously) and figured we should add link to it from the "Our Story" page. Also saw a few missing email links, so I went ahead and added them too.