### PR TITLE
Add Forge and XMage export formats

### DIFF
--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -1283,6 +1283,48 @@ router.get('/download/csv/:id', function(req, res) {
   });
 });
 
+router.get('/download/forge/:id', function(req, res) {
+  Cube.findOne(build_id_query(req.params.id), function(err, cube) {
+    if (!cube) {
+      req.flash('danger', 'Cube not found');
+      res.redirect('/404/');
+    } else {
+      res.setHeader('Content-disposition', 'attachment; filename=' + cube.name.replace(/\W/g, '') + '.dck');
+      res.setHeader('Content-type', 'text/plain');
+      res.charset = 'UTF-8';
+      res.write('[metadata]\r\n');
+      res.write('Name=' + cube.name + '\r\n');
+      res.write('[Main]\r\n');
+      cube.cards.forEach(function(card, index) {
+        var name = carddb.carddict[card.cardID].name;
+        var set = carddb.carddict[card.cardID].set;
+        res.write('1 ' + name + '|' + set.toUpperCase() + '\r\n');
+      });
+      res.end();
+    }
+  });
+});
+
+router.get('/download/xmage/:id', function(req, res) {
+  Cube.findOne(build_id_query(req.params.id), function(err, cube) {
+    if (!cube) {
+      req.flash('danger', 'Cube not found');
+      res.redirect('/404/');
+    } else {
+      res.setHeader('Content-disposition', 'attachment; filename=' + cube.name.replace(/\W/g, '') + '.dck');
+      res.setHeader('Content-type', 'text/plain');
+      res.charset = 'UTF-8';
+      cube.cards.forEach(function(card, index) {
+        var name = carddb.carddict[card.cardID].name;
+        var set = carddb.carddict[card.cardID].set;
+        var collectorNumber = carddb.carddict[card.cardID].collector_number;
+        res.write('1 [' + set.toUpperCase() + ':' + collectorNumber + '] ' + name + '\r\n');
+      });
+      res.end();
+    }
+  });
+});
+
 router.get('/download/plaintext/:id', function(req, res) {
   Cube.findOne(build_id_query(req.params.id), function(err, cube) {
     if (!cube) {

--- a/views/cube/cube_list.pug
+++ b/views/cube/cube_list.pug
@@ -44,6 +44,8 @@ block cube_toolbar
             .dropdown-menu(aria-labelledby='exportdropdown')
               a.dropdown-item(href='/cube/download/plaintext/'+cube_id) Card Names (.txt)
               a.dropdown-item(href='/cube/download/csv/'+cube_id) Comma Separated (.csv)
+              a.dropdown-item(href='/cube/download/forge/'+cube_id) Forge (.dck)
+              a.dropdown-item(href='/cube/download/xmage/'+cube_id) XMage (.dck)
                 br
           li.nav-item
             span#customImageDisplayMenuItem.nav-link.text-sm-left.text-center


### PR DESCRIPTION
# Overview

This update adds export formats suitable for Forge and XMage.  Both applications use `.dck` files, though the formats differ.  I tested a non-singleton cube and both applications import it correctlkly even though multiples are listed individually with quantity = 1.

Fixes #305.

# File formats

## Forge

```
[metadata]
Name=$CUBE_NAME
[Main]
1 $CARD_NAME|$SET
```

## XMage

```
1 [$SET:$COLLECTOR_NUMBER] $CARD_NAME
```

# Testing

1. Navigate to the cube of your choice, the click on the "List" tab.
2. Click on the "Export" menu.
3. The menu should have two new options: `Forge (.dck)` and `XMage (.dck)`.
4. Export the Forge file, save it to a known location, and confirm that it conforms to the format above.
5. Repeat for the XMage format.