### PR TITLE
Scryfall Search Syntax

### DIFF
--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -1643,19 +1643,19 @@ function updateFilters(filterText) {
 
 let categoryMap = new Map([
   ['m', 'mana'],
-  ['mana',' mana'],
-  ['cmc',' cmc'],
-  ['c',' color'],
-  ['color',' color'],
-  ['ci',' identity'],
-  ['id',' identity'],
-  ['identity',' identity'],
-  ['t',' type'],
-  ['type',' type'],
-  ['o',' oracle'],
-  ['oracle',' oracle'],
-  ['pow',' power'],
-  ['power',' power'],
+  ['mana','mana'],
+  ['cmc','cmc'],
+  ['c','color'],
+  ['color','color'],
+  ['ci','identity'],
+  ['id','identity'],
+  ['identity','identity'],
+  ['t','type'],
+  ['type','type'],
+  ['o','oracle'],
+  ['oracle','oracle'],
+  ['pow','power'],
+  ['power','power'],
   ['tou', 'toughness'],
   ['toughness', 'toughness'],
   ['name', 'name']
@@ -1751,6 +1751,9 @@ function tokenizeInput(filterText, tokens) {
     let quotes_re = new RegExp('"([^"\\\\]*(?:\\\\.[^"\\\\]*)*)"');
     token.arg = filterText.match(quotes_re)[1];
     parens = true;
+  } else if (operand != 'none'){
+    //it's just a plain word, ignore closing parens at end of word
+    token.arg = firstTerm[0].split(')')[0].split(operators_re)[1];
   } else {
     //it's just a plain word, ignore closing parens at end of word
     token.arg = firstTerm[0].split(')')[0];

--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -63,6 +63,11 @@ $('#filterInput').keyup(function(e) {
   }
 });
 
+$('#resetButton').click(function(e) {
+  filters = [];
+  updateCubeList();
+});
+
 $('#customImageDisplayToggle').click(function(e) {
   console.log("clicked");
   var enabled = $(this).prop('checked'),
@@ -1151,33 +1156,14 @@ function columnLength(sort, label) {
   return res;
 }
 
-function getFilterObj() {
-  var filterobj = {};
-  filters.forEach(function(filter, index) {
-    if (!filterobj[filter.category]) {
-      filterobj[filter.category] = {
-        in: [],
-        out: []
-      };
-    }
-    if (filter.not) {
-      filterobj[filter.category].out.push(filter);
-    } else {
-      filterobj[filter.category].in.push(filter);
-    }
-  });
-  return filterobj;
-}
-
 function filteredCube() {
   if (filters.length == 0) {
     return cube;
   }
-  filterobj = getFilterObj();
 
   var res = [];
   cube.forEach(function(card, index) {
-    if (filterCard(card, filterobj)) {
+    if (filterCard(card, filters)) {
       res.push(card);
     }
   });
@@ -1809,11 +1795,11 @@ function generateFilters(filterText) {
   } else {
     return false;
   }
-  let result = [];
   if(verifyTokens(tokens)) {
-    result = parseTokens(tokens);
+    filters = [parseTokens(tokens)];
+    updateCubeList();
   }
-  console.log(result);
+  console.log(filters);
   //return result;
 }
 

--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -1726,7 +1726,6 @@ function tokenizeInput(filterText, tokens) {
 
   //find operand
   let operand = firstTerm[0].match(operators_re);
-  console.log(operand);
   if(operand) {
     operand = operand[0];
     token.operand = operand;
@@ -1757,7 +1756,6 @@ function tokenizeInput(filterText, tokens) {
     token.arg = firstTerm[0].split(')')[0];
   }
 
-  console.log('arg found: ' + token.arg);
 
   let category = '';
   //find category
@@ -1770,10 +1768,8 @@ function tokenizeInput(filterText, tokens) {
   if (!categoryMap.has(category)) {
     return false;
   }
-
   token.category = categoryMap.get(category);
   
-  console.log(token);
   if (token.operand && token.category && token.arg) {
     filterText = filterText.split(token.arg + (parens ? '"' : ''))[1];
     //replace any escaped quotes with normal quotes
@@ -1790,17 +1786,15 @@ function tokenizeInput(filterText, tokens) {
 //returns true if decoding was successful, and filter object is populated, or false otherwise
 function generateFilters(filterText) {
   let tokens = [];
-  tokenizeInput(filterText, tokens);
-  if(tokens) {
-    console.log(tokens);
+  
+  if (tokenizeInput(filterText, tokens)) {
+    if (verifyTokens(tokens)) {
+      filters = [parseTokens(tokens)];
+      updateCubeList();
+    }
   } else {
     return false;
   }
-  if(verifyTokens(tokens)) {
-    filters = [parseTokens(tokens)];
-    updateCubeList();
-  }
-  console.log(filters);
   //return result;
 }
 

--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -1,8 +1,3 @@
-var filterTemplate = '<div class="input-group mb-3 filter-item" data-index="#{index}"><div class="input-group-prepend"><span class="input-group-text">#{filterName}</span></div>' +
-  '<select class="custom-select" id="#{filterID}" data-index="#{filterindex}" aria-label="Example select with button addon">' +
-  '#{items}</select><div class="input-group-append"><div class="input-group-text"><input type="checkbox" data-index="#{checkboxindex}" id="#{checkbox}"/><a style="padding-left: 5px">Not </a></div>' +
-  '<button class="btn btn-outline-secondary filter-button" data-index="#{buttonindex}" type="button">Remove</button></div></div>';
-var filterItemTemplate = '<option value="#{value}">#{label}</option>';
 var canEdit = $('#edittoken').val();
 var listGranularity = 50;
 var listPosition = 0;
@@ -55,18 +50,17 @@ $('#compareButton').click(function(e) {
   if (id_b) window.location.href = '/cube/compare/' + id_a + '/to/' + id_b;
 });
 
-$('#addFilterButton').click(function(e) {
-  var filterType = $('#filterType').val();
-  filters.push({
-    category: filterType,
-    value: getLabels(filterType)[0],
-    not: false
-  });
-  updateFilters();
+$('#filterButton').click(function(e) {
+  var filterText = $('#filterInput').val();
+  console.log(filterText);
+  updateFilters(filterText);
 });
 
-$('.updateButton').click(function(e) {
-  updateCubeList();
+$('#filterInput').keyup(function(e) {
+  if (e.keyCode === 13 && $('#addInput').val().length == 0) {
+    e.preventDefault();
+    filterButton.click();
+  }
 });
 
 $('#customImageDisplayToggle').click(function(e) {
@@ -192,6 +186,7 @@ if (canEdit) {
       }
     }
 
+    //TODO: Remove this
     var filterobj = null;
     if (filters.length > 0) {
       filterobj = getFilterObj();
@@ -205,7 +200,7 @@ if (canEdit) {
 
     let data = {
       selected: groupSelect,
-      filters: filterobj,
+      //filters: filterobj,
       updated: updated,
     };
 
@@ -1644,74 +1639,136 @@ function renderListView() {
     });
 }
 
-function updateFilters() {
-  sort_categories = getSorts();
+function updateFilters(filterText) {
+  
 
-  if (filters.length <= 0) {
-    document.getElementById('filterarea').innerHTML = '<p><em>No active filters.</em></p>';
-  } else {
-    var filterhtml = "";
-    filters.forEach(function(filter, index) {
-      var itemshtml = "";
-      var labels = getLabels(filter.category);
-      labels.forEach(function(label, l_index) {
-        itemshtml += filterItemTemplate.replace('#{value}', label).replace('#{label}', label);
+  if (filterText) {
+    filters = [];
+    if (generateFilters(filterText)) {
+      let result = '<p><ul>';
+      filters.forEach(function(filter) {
+        result += '<li>';
       });
-      filterhtml += filterTemplate.replace('#{items}', itemshtml)
-        .replace('#{filterID}', filter.category + index)
-        .replace('#{filterName}', filter.category)
-        .replace('#{index}', index)
-        .replace('#{buttonindex}', index)
-        .replace('#{checkbox}', 'checkbox' + filter.category + index)
-        .replace('#{filterindex}', index)
-        .replace('#{checkboxindex}', index);
-    });
-    $('#filterarea').html(filterhtml);
-
-    //setup filter control events
-    filters.forEach(function(filter, index) {
-      var element = document.getElementById(filter.category + index);
-      element.selectedIndex = getLabels(filter.category).indexOf(filter.value);
-      element.addEventListener('change', (e) => {
-        filters[e.target.getAttribute('data-index')].value = e.target.value;
-      });
-
-      element = document.getElementById('checkbox' + filter.category + index);
-      element.checked = filter.not;
-      element.addEventListener('change', (e) => {
-        filters[e.target.getAttribute('data-index')].not = e.target.checked;
-      });
-    });
-
-    filterRemoveButtons = document.getElementsByClassName('filter-button');
-    for (var i = 0; i < filterRemoveButtons.length; i++) {
-      filterRemoveButtons[i].addEventListener('click', (e) => {
-        filters.splice(e.target.getAttribute('data-index'), 1);
-        updateFilters();
-      })
+      updateCubeList();
+    } else {
+      //TODO: couldn't parse that query, display error?
     }
+  } else {
+    document.getElementById('filterarea').innerHTML = '<p><em>No active filters.</em></p>';
   }
 }
 
-function buildFilterArea() {
-  sort_categories = getSorts();
-  var sorthtml = "";
-  sort_categories.forEach(function(category, index) {
-    sorthtml += filterItemTemplate.replace('#{value}', category).replace('#{label}', category);
-  });
+let categoryMap = new Map([
+  ['m', 'mana'],
+  ['mana',' mana'],
+  ['cmc',' cmc'],
+  ['c',' color'],
+  ['color',' color'],
+  ['ci',' identity'],
+  ['id',' identity'],
+  ['identity',' identity'],
+  ['t',' type'],
+  ['type',' type'],
+  ['o',' oracle'],
+  ['oracle',' oracle'],
+  ['pow',' power'],
+  ['power',' power'],
+  ['tou', 'toughness'],
+  ['toughness', 'toughness'],
+  ['name', 'name']
+]);
 
-  document.getElementById('filterType').innerHTML = sorthtml;
-  sorthtml += filterItemTemplate.replace('#{value}', 'Unsorted').replace('#{label}', 'Unsorted');
-  document.getElementById('secondarySortSelect').innerHTML = sorthtml;
-  document.getElementById('primarySortSelect').innerHTML = sorthtml;
-  if (document.getElementById("sort1").value.length > 0 && document.getElementById("sort2").value.length > 0) {
-    document.getElementById('primarySortSelect').selectedIndex = sort_categories.indexOf(document.getElementById("sort1").value);
-    document.getElementById('secondarySortSelect').selectedIndex = sort_categories.indexOf(document.getElementById("sort2").value);
-  } else {
-    document.getElementById('primarySortSelect').selectedIndex = sort_categories.indexOf('Color Category');
-    document.getElementById('secondarySortSelect').selectedIndex = sort_categories.indexOf('Types-Multicolor');
+
+//converts filter scryfall syntax string to global filter objects
+//returns true if decoding was successful, and filter object is populated, or false otherwise
+function generateFilters(filterText) {
+  console.log('generateFilters called with: ' + filterText);
+  if(!filterText) {
+    console.log(filters);
+    return true;
   }
 
+  const operators = '>=|<=|<|>|:|='
+  //split string based on list of operators
+  let operators_re = new RegExp('(?:' + operators + ')');
+
+  let not = false;
+  if (filterText.search('-') == 0) {
+    not = true;
+    filterText = filterText.slice(1);
+  }
+
+  //grab only first argument in string
+  let filterTextSplit = filterText.split(' ', 1);
+
+  //returns :,=,<, or >, or null
+  let operand = filterTextSplit[0].match(operators_re);
+  //remove operand from array, and store as plain string
+  console.log(operand);
+  if(operand) {
+    operand = operand[0];
+  }
+
+  let category = '';
+  let arg = '';
+  let parens = false;
+
+  //if this is a string with operand, rather than a name
+  if (operand) {
+    category = filterTextSplit[0].split(operators_re)[0];
+  
+    arg = '';
+    parens = false;
+    //if the first field contains a parentheses, and there are at least 2 parentheses, grab the arg from parentheses
+    console.log('checking for parens: ' + (filterText.search('"') > -1) + ' and for 2+ parens: ' + (filterText.split('"').length > 2));
+    if (filterText.search('"') > -1 && filterText.split('"').length > 2) {
+      //match first text inside quotes, ignoring escaped quotes
+      let quotes_re = new RegExp('"([^"\\\\]*(?:\\\\.[^"\\\\]*)*)"');
+      parens = true;
+      //replace escaped quotes with plain quotes
+      arg = filterText.match(quotes_re)[1].replace(/\\"/, '"');
+      console.log('parens arg is: ' + arg);
+    } else { //otherwise the arg is whatever is after the operator
+      arg = filterTextSplit[0].split(operators_re)[1];
+    }
+  } else { //this argument is a name
+    operand = 'none';
+    category = 'name';
+    arg = filterTextSplit[0];
+  }
+
+  if (!categoryMap.has(category)) {
+    filters = [];
+    return false;
+  }
+  category = categoryMap.get(category);
+  
+  //if this argument was parsed successfully
+  if(arg && operand && category) {
+    //cut this argument out of the string
+    filterText = filterText.split(arg + (parens ? '"' : '') + ' ')[1];
+
+    //convert category to singular name, avoid aliases in data object
+
+    //add this argument to filters object
+    filters.push({
+      arg: arg,
+      operand: operand,
+      category: category,
+      not: not,
+    });
+    //recursively handle next argument
+    return generateFilters(filterText);
+    console.log('calling generate filters with text: ' + filterText);
+  } else { //argument was not parsed successfully, abandon parsing
+    filters = [];
+    return false;
+  }
+
+}
+
+function buildFilterArea() {
+  //TODO: remove this
   updateFilters();
 }
 
@@ -1720,7 +1777,7 @@ window.onload = function() {
   if (prev_handler) {
     prev_handler();
   }
-  buildFiltersFromQsargs();
+  //buildFiltersFromQsargs();
   buildFilterArea();
   updateCubeList();
   activateTags();

--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -1716,7 +1716,6 @@ function tokenizeInput(filterText, tokens) {
     not: false,
   };
 
-  console.log('created token');
   //find not
   if (filterText.indexOf('-') == 0) {
     token.not = true;
@@ -1727,6 +1726,7 @@ function tokenizeInput(filterText, tokens) {
 
   //find operand
   let operand = firstTerm[0].match(operators_re);
+  console.log(operand);
   if(operand) {
     operand = operand[0];
     token.operand = operand;
@@ -1746,16 +1746,14 @@ function tokenizeInput(filterText, tokens) {
     token.arg = filterText.match(quotes_re)[1];
     parens = true;
   } else if (firstTerm[0].search(quoteOp_re) > -1 && filterText.split('"').length > 2) {
-    //check if there is a paren after an operatr
+    //check if there is a paren after an operator
     //TODO: make sure the closing paren isn't before the operator
     let quotes_re = new RegExp('"([^"\\\\]*(?:\\\\.[^"\\\\]*)*)"');
     token.arg = filterText.match(quotes_re)[1];
     parens = true;
-  } else if (operand != 'none'){
-    //it's just a plain word, ignore closing parens at end of word
+  } else if (token.operand != 'none'){
     token.arg = firstTerm[0].split(')')[0].split(operators_re)[1];
   } else {
-    //it's just a plain word, ignore closing parens at end of word
     token.arg = firstTerm[0].split(')')[0];
   }
 

--- a/public/js/sortfilter.js
+++ b/public/js/sortfilter.js
@@ -33,7 +33,7 @@ function GetColorCategory(type, colors) {
 
 function filterCard(card, filters) {
   console.log('filter card called with: ');
-  console.log('filters');
+  console.log(filters);
   
   if(filters.length == 1) {
     if(filters[0].type == 'token') {
@@ -51,10 +51,62 @@ function filterCard(card, filters) {
 
 }
 
+function areArraysEqualSets(a1, a2) {
+    let superSet = {};
+    for (let i = 0; i < a1.length; i++) {
+          const e = a1[i] + typeof a1[i];
+          superSet[e] = 1;
+        }
+
+    for (let i = 0; i < a2.length; i++) {
+          const e = a2[i] + typeof a2[i];
+          if (!superSet[e]) {
+                  return false;
+                }
+          superSet[e] = 2;
+        }
+
+    for (let e in superSet) {
+          if (superSet[e] === 1) {
+                  return false;
+                }
+        }
+
+    return true;
+}
+
+function arrayContainsOtherArray (arr1, arr2) {
+  return arr2.every(v => arr1.includes(v));
+}
+
 function filterApply(card, filter) {
   let res = null;
   if (filter.category == 'name') {
-    res = card.details.name.toLowerCase().indexOf(filter.arg) > -1;
+    res = card.details.name_lower.indexOf(filter.arg) > -1;
+  }
+  if (filter.category == 'oracle' && card.details.oracle_text) {
+    res = card.details.oracle_text.toLowerCase().indexOf(filter.arg) > -1;
+  }
+  if (filter.category == 'color' && card.colors) {
+    let colors = filter.arg.split('').map( (element) => element.toUpperCase());
+    switch (filter.operand) {
+      case ':':
+      case '=':
+        res = areArraysEqualSets(card.colors, colors);
+        break;
+      case '<':
+        res = arrayContainsOtherArray(colors, card.colors) && card.colors.length < colors.length;
+        break;
+      case '>':
+        res = arrayContainsOtherArray(card.colors, colors) && card.colors.length > colors.length;
+        break;
+      case '<=':
+        res = arrayContainsOtherArray(colors, card.colors) && card.colors.length <= colors.length;
+        break;
+      case '>=':
+        res = arrayContainsOtherArray(card.colors, colors) && card.colors.length >= colors.length;
+        break;
+    }
   }
 
   if(filter.not) {

--- a/public/js/sortfilter.js
+++ b/public/js/sortfilter.js
@@ -31,37 +31,37 @@ function GetColorCategory(type, colors) {
   }
 }
 
-function filterCard(card, filterobj) {
-  //first filter out everything in this category
-  //then filter in everything that matches one of the ins
-
-  var filterout = false;
-  var filterin = false;
-  var hasFilterIn = false;
-  for (var category in filterobj) {
-    if (filterobj.hasOwnProperty(category)) {
-      filterobj[category].out.forEach(function(option, index) {
-        if (cardIsLabel(card, option.value, option.category)) {
-          filterout = true;
-        }
-      });
-      if (!filterout) {
-        filterobj[category].in.forEach(function(option, index) {
-          hasFilterIn = true;
-          if (cardIsLabel(card, option.value, option.category)) {
-            filterin = true;
-          }
-        });
-      }
+function filterCard(card, filters) {
+  console.log('filter card called with: ');
+  console.log('filters');
+  
+  if(filters.length == 1) {
+    if(filters[0].type == 'token') {
+      return filterApply(card, filters[0]);
+    } else {
+      return filterCard(card, filters[0]);
+    }
+  } else {
+    if(filters.type == 'or') {
+      return (filters[0].type == 'token' ? filterApply(card, filters[0]) : filterCard(filters[0])) || (filters[1].type == 'token' ? filterApply(card, filters[1]) : filterCard(filters[1]))
+    } else {
+      return (filters[0].type == 'token' ? filterApply(card, filters[0]) : filterCard(filters[0])) && (filters[1].type == 'token' ? filterApply(card, filters[1]) : filterCard(filters[1]))
     }
   }
-  if (filterout) {
-    return false;
+
+}
+
+function filterApply(card, filter) {
+  let res = null;
+  if (filter.category == 'name') {
+    res = card.details.name.toLowerCase().indexOf(filter.arg) > -1;
   }
-  if (!hasFilterIn) {
-    return true;
+
+  if(filter.not) {
+    return !res;
+  } else {
+    return res;
   }
-  return filterin;
 }
 
 

--- a/public/js/sortfilter.js
+++ b/public/js/sortfilter.js
@@ -52,6 +52,7 @@ function filterCard(card, filters) {
 }
 
 function areArraysEqualSets(a1, a2) {
+    if(a1.length != a2.length) return false;
     let superSet = {};
     for (let i = 0; i < a1.length; i++) {
           const e = a1[i] + typeof a1[i];
@@ -77,6 +78,42 @@ function areArraysEqualSets(a1, a2) {
 
 function arrayContainsOtherArray (arr1, arr2) {
   return arr2.every(v => arr1.includes(v));
+}
+
+function parseManaCost (cost) {
+  cost = cost.toLowerCase();
+  let res = [];
+  for (let i = 0; i < cost.length; i++) {
+    if (cost[i] == '{') {
+      let str = cost.slice(i, i+3).toLowerCase();
+      if (str.search(/[wubrg]\/p/) > -1) {
+        res.push(cost[i+1] + '-p');
+        i = i+5;
+      } else if (str.search(/2\/[wubrg]/) > -1) {
+        res.push('2-' + cost[i+3]);
+        i = i+5;
+      } else if (str.search(/[wubrg]\/[wubrg]/) > -1) {
+        res.push(cost[i+1] + '-' + cost[i+3]);
+        i = i+5;
+      }
+    } else if (cost[i] == 'c') {
+      res.push('c');
+    } else if (cost[i] == 's') {
+      res.push('s');
+    } else if (cost[i].search(/[wubrg]/) > -1) {
+      res.push(cost[i]);
+    } else if (cost[i].search(/[0-9]/) > -1) {
+      let num = cost.slice(i).match(/[0-9]+/)[0];
+      if (num.length <= 2) {
+        res.push(num);
+      } else {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  }
+  return res;
 }
 
 function filterApply(card, filter) {
@@ -106,6 +143,100 @@ function filterApply(card, filter) {
       case '>=':
         res = arrayContainsOtherArray(card.colors, colors) && card.colors.length >= colors.length;
         break;
+    }
+  }
+  if (filter.category == 'identity' && card.details.color_identity) {
+    let colors = filter.arg.split('').map( (element) => element.toUpperCase());
+    switch (filter.operand) {
+      case ':':
+      case '=':
+        res = areArraysEqualSets(card.details.color_identity, colors);
+        break;
+      case '<':
+        res = arrayContainsOtherArray(colors, card.details.color_identity) && card.details.color_identity.length < colors.length;
+        break;
+      case '>':
+        res = arrayContainsOtherArray(card.details.color_identity, colors) && card.details.color_identity.length > colors.length;
+        break;
+      case '<=':
+        res = arrayContainsOtherArray(colors, card.details.color_identity) && card.details.color_identity.length <= colors.length;
+        break;
+      case '>=':
+        res = arrayContainsOtherArray(card.details.color_identity, colors) && card.details.color_identity.length >= colors.length;
+        break;
+    }
+  }
+  if (filter.category == 'mana' && card.details.parsed_cost) {
+    let cost = parseManaCost(filter.arg);
+    res = areArraysEqualSets(card.details.parsed_cost, cost);
+  }
+  if (filter.category == 'cmc' && card.cmc) {
+    switch (filter.operand) {
+      case ':':
+      case '=':
+        res = filter.arg == card.cmc;
+        break;
+      case '<':
+        res = card.cmc < filter.arg;
+        break;
+      case '>':
+        res = card.cmc > filter.arg;
+        break;
+      case '<=':
+        res = card.cmc <= filter.arg;
+        break;
+      case '>=':
+        res = card.cmc >= filter.arg;
+        break;
+    }
+  }
+  if (filter.category == 'type' && card.details.type) {
+    if (card.details.type.toLowerCase().indexOf(filter.arg) > -1) {
+      res = true;
+    }
+  }
+  if (filter.category == 'power') {
+    if (card.details.power) {
+      switch (filter.operand) {
+        case ':':
+        case '=':
+          res = filter.arg == card.details.power;
+          break;
+        case '<':
+          res = card.details.power < filter.arg;
+          break;
+        case '>':
+          res = card.details.power > filter.arg;
+          break;
+        case '<=':
+          res = card.details.power <= filter.arg;
+          break;
+        case '>=':
+          res = card.details.power >= filter.arg;
+          break;
+      }
+    }
+  }
+  if (filter.category == 'toughness') {
+    if (card.details.toughness) {
+      switch (filter.operand) {
+        case ':':
+        case '=':
+          res = filter.arg == card.details.toughness;
+          break;
+        case '<':
+          res = card.details.toughness < filter.arg;
+          break;
+        case '>':
+          res = card.details.toughness > filter.arg;
+          break;
+        case '<=':
+          res = card.details.toughness <= filter.arg;
+          break;
+        case '>=':
+          res = card.details.toughness >= filter.arg;
+          break;
+      }
     }
   }
 

--- a/views/cube/cube_list.pug
+++ b/views/cube/cube_list.pug
@@ -127,10 +127,10 @@ block cube_toolbar
             .col
               .input-group.mb-3
                 .input-group-prepend
-                  span.input-group-text Filter Type
-                select#filterType.custom-select(aria-label='Example select with button addon')
+                  label.input-group-text(for='filterInput') Search
+                input.form-control#filterInput(type='text', placeholder='Use Scryfall Search Syntax')
                 .input-group-append
-                  button#addFilterButton.btn.btn-success(type='button') Add Filter
+                  button#filterButton.btn.btn-success(type='button') Filter
               h5 Filters
               #filterarea
           .row

--- a/views/cube/cube_list.pug
+++ b/views/cube/cube_list.pug
@@ -135,7 +135,8 @@ block cube_toolbar
               #filterarea
           .row
             .col
-              button.updateButton.btn.btn-success(type='button') Update Table
+              button#resetButton.btn.btn-success(type='button') Reset Filters
+              button#advancedSearchButton.btn.btn-success(type='button') Advanced Search
               br
               br
       #navcompare.collapse(data-parent='#accordion')


### PR DESCRIPTION
In Response to #3, this first commit adds the search bar and parsing.

- [X] Change UI to add search Bar
- [ ] Change UI to add advanced search fillable fileds
- [X] Implement parsing for scryfall-like search text
- [x] Implement tokenizer and parser to resolve no parens statements
- [x] Implement logic for filter objects created by parser
- [ ] Add protections against Regex attacks
- [ ] Create Syntax Page
- [ ] finish verifyTokens to include argument checking
- [ ] finish manaParse to handle {C} as well as C

I think this is ready for testing on dev, progress is marked above. @dekkerglen has agreed to pick up the UI when he has time, and I'm not sure how to protect against Regex, so hopefully somebody else can pick that up. 

Currently the following options and their aliases are implemented, and I think they have feature parity with scryfall. 
['m', 'mana'],
    ['mana','mana'],
    ['cmc','cmc'],
    ['c','color'],
    ['color','color'],
    ['ci','identity'],
    ['id','identity'],
    ['identity','identity'],
    ['t','type'],
    ['type','type'],
    ['o','oracle'],
    ['oracle','oracle'],
    ['pow','power'],
    ['power','power'],
    ['tou', 'toughness'],
    ['toughness', 'toughness'],
    ['name', 'name']