### PR TITLE
Add text only versions to emails

### DIFF
--- a/routes/users_routes.js
+++ b/routes/users_routes.js
@@ -72,7 +72,11 @@ router.post('/lostpassword', function(req, res) {
             html: "A password reset was requested for the account that belongs to this email.<br> To proceed, click <a href=\"https://cubecobra.com/user/passwordreset/" +
               passwordReset._id + "\">here</a>.<br> Your recovery code is: " + passwordReset.code +
               "<br> This link expires in 15 minutes." +
-              "<br> If you did not request a password reset, ignore this email."
+              "<br> If you did not request a password reset, ignore this email.",
+            text: "A password reset was requested for the account that belongs to this email.\nTo proceed, go to https://cubecobra.com/user/passwordreset/" +
+              passwordReset._id + "\nYour recovery code is: " + passwordReset.code +
+              "\nThis link expires in 15 minutes." +
+              "\nIf you did not request a password reset, ignore this email."
           }
 
           smtpTransport.sendMail(mail, function(err, response) {
@@ -253,7 +257,10 @@ router.post('/register', function(req, res) {
                         subject: "Confirm Account",
                         html: "Hi " + newUser.username +
                           ",</br> Thanks for joining! To confirm your email, click <a href=\"https://cubecobra.com/user/register/confirm/" +
-                          newUser._id + "\">here</a>."
+                          newUser._id + "\">here</a>.",
+                        text: "Hi " + newUser.username +
+                          ",\nThanks for joining! To confirm your email, go to https://cubecobra.com/user/register/confirm/" +
+                          newUser._id
                       }
 
                       smtpTransport.sendMail(mail, function(error, response) {


### PR DESCRIPTION
I just found out about the site and I love it, but my email client complained about lacking a text version of the messages so I added them. Of course, in my joy of finding a nice mtg, open source (and in react!) project where I could contribute that I even wanted to use (I already started migrating from cube tutor), I missed #167.

So feel free to disregard this pull request, I just wanted to say thanks and lobby for both email formats in that feature ^^