### PR TITLE
show image_flip on hover

### DIFF
--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -1057,6 +1057,14 @@ function show_contextModal(card) {
   $('.price-area').html(priceHtml);
   $('#contextModalTitle').html(card.details.name);
   $('#contextModalImg').attr('src', card.details.display_image);
+  if (card.details.image_flip !== undefined) {
+    $('#contextModalImg').mouseover(function() {
+      $(this).attr('src', card.details.image_flip);
+    });
+    $('#contextModalImg').mouseout(function() {
+      $(this).attr('src', card.details.display_image);
+    });
+  }
   $('#contextModalVersionSelect').html('');
   var statusHTML = "";
   var statuses = getLabels('Status');


### PR DESCRIPTION
This pull request fixes https://github.com/dekkerglen/CubeCobra/issues/323 by showing the back face of double-faced cards on mouseover in the card edit modal.