### PR TITLE
Filter Search Functionality and Correctness Update

### DIFF
--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -52,7 +52,6 @@ $('#compareButton').click(function(e) {
 
 $('#filterButton').click(function(e) {
   var filterText = $('#filterInput').val();
-  console.log(filterText);
   updateFilters(filterText);
 });
 
@@ -1638,12 +1637,7 @@ function updateFilters(filterText) {
 
   if (filterText) {
     new_filters = [];
-    if (generateFilters(filterText.toLowerCase(), new_filters)) {
-      filters = new_filters;
-      updateCubeList();
-    } else {
-      //TODO: couldn't parse that query, display error?
-    }
+    generateFilters(filterText.toLowerCase(), new_filters)
   } else {
     document.getElementById('filterarea').innerHTML = '<p><em>No active filters.</em></p>';
   }
@@ -1684,7 +1678,6 @@ function findEndingQuotePosition(filterText, num) {
 }
 
 function tokenizeInput(filterText, tokens) {
-  console.log('tokeninzeInput called with: ' + filterText);
   filterText = filterText.trim();
   if (!filterText) {
     return true;
@@ -1714,7 +1707,7 @@ function tokenizeInput(filterText, tokens) {
     return tokenizeInput(filterText.slice(1), tokens);
   }
 
-  if (filterText.indexOf('or ') == 0) {
+  if (filterText.indexOf('or ') == 0 || (filterText.length == 2 && filterText.indexOf('or') == 0)) {
     tokens.push({type: 'or'});
     return tokenizeInput(filterText.slice(2), tokens);
   }
@@ -1772,14 +1765,15 @@ function tokenizeInput(filterText, tokens) {
   } else {
     category = firstTerm[0].split(operators_re)[0];
   }
-
-  filterText = filterText.slice(token.operand == 'none' ? token.arg.length : token.arg.length + token.operand.length + category.length );
+  filterText = filterText.slice((token.operand == 'none' ? (token.arg.length) : (token.arg.length + token.operand.length + category.length)) + (parens ? 2 : 0));
 
   if (!categoryMap.has(category)) {
     return false;
   }
+
+
   token.category = categoryMap.get(category);
-  
+  token.arg = simplifyArg(token.arg, token.category);
   if (token.operand && token.category && token.arg) {
     //replace any escaped quotes with normal quotes
     if (parens) token.arg = token.arg.replace(/\\"/g, '"');
@@ -1791,6 +1785,58 @@ function tokenizeInput(filterText, tokens) {
 
 }
 
+const colorMap = new Map([
+  ['white', 'w'],
+  ['blue', 'u'],
+  ['black', 'b'],
+  ['red', 'r'],
+  ['green', 'g'],
+  ['colorless', 'c'],
+  ['azorius', 'uw'],
+  ['dimir', 'ub'],
+  ['rakdos', 'rb'],
+  ['gruul', 'rg'],
+  ['selesnya', 'gw'],
+  ['orzhov', 'bw'],
+  ['izzet', 'ur'],
+  ['golgari', 'gb'],
+  ['boros', 'wr'],
+  ['simic', 'ug'],
+  ['bant', 'gwu'],
+  ['esper', 'wub'],
+  ['grixis', 'ubr'],
+  ['jund', 'brg'],
+  ['naya', 'rgw'],
+  ['abzan', 'wbg'],
+  ['jeskai', 'urw'],
+  ['sultai', 'bgu'],
+  ['mardu', 'rwb'],
+  ['temur', 'rug']
+]);
+
+//change arguments into their verifiable counteraprts, i.e. 'azorius' becomes 'uw'
+function simplifyArg(arg, category) {
+  let res = '';
+  switch (category) {
+    case 'color':
+    case 'identity':
+      if(colorMap.has(arg)){
+        res = colorMap.get(arg);
+      } else {
+        res = arg;
+      }
+      res = res.split('').map( (element) => element.toUpperCase());
+      break;
+    case 'mana':
+      res = parseManaCost(arg)
+      break;
+    default:
+      res = arg;
+      break;
+  }
+  return res;
+}
+
 //converts filter scryfall syntax string to global filter objects
 //returns true if decoding was successful, and filter object is populated, or false otherwise
 function generateFilters(filterText) {
@@ -1799,40 +1845,126 @@ function generateFilters(filterText) {
   if (tokenizeInput(filterText, tokens)) {
     if (verifyTokens(tokens)) {
       filters = [parseTokens(tokens)];
+      //TODO: generate a filter string, and return better errors to user
+      document.getElementById('filterarea').innerHTML = '<p><em>Filter Applied.</em></p>';
       updateCubeList();
+    } else {
+      document.getElementById('filterarea').innerHTML = '<p><em>Invalid Filter String.</em></p>';
     }
   } else {
-    return false;
+    document.getElementById('filterarea').innerHTML = '<p><em>Invalid Filter String.</em></p>';
   }
-  //return result;
 }
 
 const verifyTokens = (tokens) => {
+  console.log(tokens);
   let temp = tokens;
   let inBounds = (num) => {
     return num > -1 && num < temp.length;
   }
   let type = (i) => temp[i].type;
+  let token = (i) => temp[i];
+
   for (let i = 0; i < temp.length; i++) {
     if (type(i) == 'open') {
-      console.log('checking open paren')
       let closed = findClose(temp, i);
       if (!closed) return false;
       temp[closed].valid = true;
     }
     if (type(i) == 'close') {
-      console.log('checking close paren')
       if(!temp[i].valid) return false;
     }
     if (type(i) == 'or') {
-      console.log('checking or')
       if (!inBounds(i - 1) || !inBounds(i + 1)) return false;
       if (!(type(i - 1) == 'close' || type(i - 1) == 'token')) return false;
       if (!(type(i + 1) != 'open' || type(i + 1) != 'token')) return false;
     }
+    if (type(i) == 'token') {
+      switch(token(i).category) {
+        case 'color':
+        case 'identity':
+          let verifyColors = (element) => {
+            return element.search(/^[WUBRGC]$/) < 0;
+          }
+          if (token(i).arg.every(verifyColors)) {
+            return false;
+          }
+          break;
+        case 'cmc':
+        case 'power':
+        case 'toughness':
+          if(token(i).arg.search(/^\d+$/) < 0) return false;
+          break;
+        case 'mana':
+          let verifyMana = (element) => {
+            element.search(/^(\d+|[wubrgscxyz]|{([wubrg2]\-[wubrg]|[wubrg]\-p)})$/) < 0;
+          }
+          if (token(i).arg.every(verifyMana)) {
+            return false;
+          }
+          break;
+      }
+    }
 
   }
   return true;
+}
+
+const hybridMap = new Map([
+  ['u-w', 'w-u'],
+  ['b-w', 'w-b'],
+  ['b-u', 'u-b'],
+  ['r-u', 'u-r'],
+  ['r-b', 'b-r'],
+  ['g-b', 'b-g'],
+  ['g-r', 'r-g'],
+  ['w-r', 'r-w'],
+  ['w-g', 'g-w'],
+  ['u-g', 'g-u']
+]);
+
+function parseManaCost (cost) {
+  let res = [];
+  for (let i = 0; i < cost.length; i++) {
+    if (cost[i] == '{') {
+      let str = cost.slice(i+1, i+4).toLowerCase();
+      if (str.search(/[wubrg]\/p/) > -1) {
+        res.push(cost[i+1] + '-p');
+        i = i+4;
+      } else if (str.search(/2\/[wubrg]/) > -1) {
+        res.push('2-' + cost[i+3]);
+        i = i+4;
+      } else if (str.search(/[wubrg]\/[wubrg]/) > -1) {
+        let symbol = cost[i+1] + '-' + cost[i+3];
+        if (hybridMap.has(symbol)) {
+          symbol = hybridMap.get(symbol);
+        }
+        res.push(symbol);
+        i = i+4;
+      } else if (str.search(/^[wubrgscxyz]}/) > -1 ) {
+        res.push(cost[i+1]);
+        i = i+2;
+      } else if (str.search(/^[0-9]+}/) > -1) {
+        let num = str.match(/[0-9]+/)[0];
+        if (num.length <= 2) {
+          res.push(num);
+        }
+        i = i + num.length + 1;
+      }
+    } else if (cost[i].search(/[wubrgscxyz]/) > -1) {
+      res.push(cost[i]);
+    } else if (cost[i].search(/[0-9]/) > -1) {
+      let num = cost.slice(i).match(/[0-9]+/)[0];
+      if (num.length <= 2) {
+        res.push(num);
+      } else {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  }
+  return res;
 }
 
 const findClose = (tokens, pos) => {
@@ -1849,8 +1981,6 @@ const findClose = (tokens, pos) => {
 }
 
 const parseTokens = (tokens) => {
-  console.log('called parseTokens with: ');
-  console.log(tokens);
   let peek = () => tokens[0];
   let consume = peek;
 

--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -1712,6 +1712,10 @@ function tokenizeInput(filterText, tokens) {
     return tokenizeInput(filterText.slice(2), tokens);
   }
 
+  if (filterText.indexOf('and ') == 0 || (filterText.length == 3 && filterText.indexOf('and') == 0)) {
+    return tokenizeInput(filterText.slice(3), tokens);
+  }
+
   let token = {
     type: 'token',
     not: false,

--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -1861,7 +1861,6 @@ function generateFilters(filterText) {
 }
 
 const verifyTokens = (tokens) => {
-  console.log(tokens);
   let temp = tokens;
   let inBounds = (num) => {
     return num > -1 && num < temp.length;

--- a/public/js/sortfilter.js
+++ b/public/js/sortfilter.js
@@ -78,41 +78,6 @@ function arrayContainsOtherArray (arr1, arr2) {
   return arr2.every(v => arr1.includes(v));
 }
 
-function parseManaCost (cost) {
-  cost = cost.toLowerCase();
-  let res = [];
-  for (let i = 0; i < cost.length; i++) {
-    if (cost[i] == '{') {
-      let str = cost.slice(i, i+3).toLowerCase();
-      if (str.search(/[wubrg]\/p/) > -1) {
-        res.push(cost[i+1] + '-p');
-        i = i+5;
-      } else if (str.search(/2\/[wubrg]/) > -1) {
-        res.push('2-' + cost[i+3]);
-        i = i+5;
-      } else if (str.search(/[wubrg]\/[wubrg]/) > -1) {
-        res.push(cost[i+1] + '-' + cost[i+3]);
-        i = i+5;
-      }
-    } else if (cost[i] == 'c') {
-      res.push('c');
-    } else if (cost[i] == 's') {
-      res.push('s');
-    } else if (cost[i].search(/[wubrg]/) > -1) {
-      res.push(cost[i]);
-    } else if (cost[i].search(/[0-9]/) > -1) {
-      let num = cost.slice(i).match(/[0-9]+/)[0];
-      if (num.length <= 2) {
-        res.push(num);
-      } else {
-        return false;
-      }
-    } else {
-      return false;
-    }
-  }
-  return res;
-}
 
 function filterApply(card, filter) {
   let res = null;
@@ -122,51 +87,48 @@ function filterApply(card, filter) {
   if (filter.category == 'oracle' && card.details.oracle_text) {
     res = card.details.oracle_text.toLowerCase().indexOf(filter.arg) > -1;
   }
-  if (filter.category == 'color' && card.colors) {
-    let colors = filter.arg.split('').map( (element) => element.toUpperCase());
+  if (filter.category == 'color' && card.details.colors) {
     switch (filter.operand) {
       case ':':
       case '=':
-        res = areArraysEqualSets(card.colors, colors);
+        res = areArraysEqualSets(card.details.colors, filter.arg);
         break;
       case '<':
-        res = arrayContainsOtherArray(colors, card.colors) && card.colors.length < colors.length;
+        res = arrayContainsOtherArray(filter.arg, card.details.colors) && card.details.colors.length < filter.arg.length;
         break;
       case '>':
-        res = arrayContainsOtherArray(card.colors, colors) && card.colors.length > colors.length;
+        res = arrayContainsOtherArray(card.details.colors, filter.arg) && card.details.colors.length > filter.arg.length;
         break;
       case '<=':
-        res = arrayContainsOtherArray(colors, card.colors) && card.colors.length <= colors.length;
+        res = arrayContainsOtherArray(filter.arg, card.details.colors) && card.details.colors.length <= filter.arg.length;
         break;
       case '>=':
-        res = arrayContainsOtherArray(card.colors, colors) && card.colors.length >= colors.length;
+        res = arrayContainsOtherArray(card.details.colors, filter.arg) && card.details.colors.length >= filter.arg.length;
         break;
     }
   }
-  if (filter.category == 'identity' && card.details.color_identity) {
-    let colors = filter.arg.split('').map( (element) => element.toUpperCase());
+  if (filter.category == 'identity' && card.colors) {
     switch (filter.operand) {
       case ':':
       case '=':
-        res = areArraysEqualSets(card.details.color_identity, colors);
+        res = areArraysEqualSets(card.colors, filter.arg);
         break;
       case '<':
-        res = arrayContainsOtherArray(colors, card.details.color_identity) && card.details.color_identity.length < colors.length;
+        res = arrayContainsOtherArray(filter.arg, card.colors) && card.details.color_identity.length < filter.arg.length;
         break;
       case '>':
-        res = arrayContainsOtherArray(card.details.color_identity, colors) && card.details.color_identity.length > colors.length;
+        res = arrayContainsOtherArray(card.colors, filter.arg) && card.details.color_identity.length > filter.arg.length;
         break;
       case '<=':
-        res = arrayContainsOtherArray(colors, card.details.color_identity) && card.details.color_identity.length <= colors.length;
+        res = arrayContainsOtherArray(filter.arg, card.colors) && card.details.color_identity.length <= filter.arg.length;
         break;
       case '>=':
-        res = arrayContainsOtherArray(card.details.color_identity, colors) && card.details.color_identity.length >= colors.length;
+        res = arrayContainsOtherArray(card.colors, filter.arg) && card.details.color_identity.length >= filter.arg.length;
         break;
     }
   }
   if (filter.category == 'mana' && card.details.parsed_cost) {
-    let cost = parseManaCost(filter.arg);
-    res = areArraysEqualSets(card.details.parsed_cost, cost);
+    res = areArraysEqualSets(card.details.parsed_cost, filter.arg);
   }
   if (filter.category == 'cmc' && card.cmc) {
     switch (filter.operand) {


### PR DESCRIPTION
This PR accomplishes many things:
1) Move all token parsing logic into token parsing, before the parser
   would pass raw user strings to the filter logic, and it would fail
there if it was going to fail. Now all arguments are checked and put
into a form the filter can use without further processing.
2) Argument checking, all arguments for fields with only specifically
   formatted arguments allowed are now checked at the time of filter
generation. An invalid filter string error is supplied to the user if
their parsed filter fails any of these checks.
3) Implemented support for shard/wedge/guild names in color and color
   identity searches
4) fixed color searches to use the card's actual color, and
   color_identity to use either the color_identity, or the cube owner's
overridden color identity if available.
5) Handles the word 'and'. See the commit for a full description, but in short, it just ignores it, and that's okay, since and is the default, and OR has to be specified by 'OR'. I recommend we don't reference the word AND on our syntax page at all, but it will still work for people who are familiar with the scryfall syntax.

Barring anybody finding issues, I think this PR is ready for production with 2 addendums:
1) Regex attacks are possible with the current implementation, so a timeout function should be started when generateFilters is called, and the operation should be aborted if it goes over a certain number of seconds. I'm not sure how important that is specifically, since this is all happening on the client machine, and I'm not familiar enough with Regex to know what (if any) strings would trigger an issue. So far I've jammed a bunch of special regex characters into the search bar, and not run into any issues.
2) The UI needs to be implemented for advanced search and the syntax page, but @dekkerglen has said he would do that!