### PR TITLE
Fix ID generation in delete cube route

### DIFF
--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -2520,11 +2520,9 @@ router.delete('/remove/:id', ensureAuth, function(req, res) {
     res.redirect('/' + req.params.id);
   }
 
-  let query = {
-    _id: req.params.id
-  };
+  let query = build_id_query(req.params.id)
 
-  Cube.findOne(build_id_query(req.params.id), function(err, cube) {
+  Cube.findOne(query, function(err, cube) {
     if (err || !cube || (cube.owner != req.user._id)) {
       req.flash('danger', 'Cube not found');
       res.redirect('/404/');


### PR DESCRIPTION
# Overview

This update fixes an ID generation issue in the delete cube route.

Fixes #260

# Testing

1. Log in and create a new cube.
2. Delete the cube.
3. Navigate to your profile and confirm that the deleted cube no longer exists.
