### PR TITLE
Enforce a maximum cube alias length

### DIFF
--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -1642,9 +1642,13 @@ router.post('/editoverview/:id', ensureAuth, function(req, res) {
         req.flash('danger', 'Cube name should not use profanity.');
         res.redirect('/cube/overview/' + req.params.id);
       } else {
+        let urlAliasMaxLength = 100;
         if (req.body.urlAlias && cube.urlAlias !== req.body.urlAlias) {
           if (!req.body.urlAlias.match(/^[0-9a-zA-Z_]*$/)) {
             req.flash('danger', 'Custom URL must contain only alphanumeric characters or underscores.');
+            res.redirect('/cube/overview/' + req.params.id);
+          } else if (req.body.urlAlias.length > urlAliasMaxLength) {
+            req.flash('danger', 'Custom URL may not be longer than ' + urlAliasMaxLength + ' characters.');
             res.redirect('/cube/overview/' + req.params.id);
           } else {
             if (util.has_profanity(req.body.urlAlias)) {


### PR DESCRIPTION
# Overview

This update enforces a maximum length on custom cube aliases.  The current limit is 100 characters.  The alias is only validated when it has changed; any cube with an alias over the new limit can be saved without triggering an error if the alias remains unchanged.

Fixes #263 

# Testing

1. Log in and navigate to a cube.
2. Click the "Edit Overview" button.
3. Enter a custom cube alias of exactly 100 characters
4. Click "Save".
5. The changes should save and the URL for the current cube should update.
6. Click the "Edit Overview" button.
7. Enter a custom cube alias of 101 characters.
8. Click "Save".
9. An error message with the maximum length should be displayed and the custom cube alias should not update.
