### PR TITLE
fix colorless in color filtering

### DIFF
--- a/public/js/sortfilter.js
+++ b/public/js/sortfilter.js
@@ -91,7 +91,11 @@ function filterApply(card, filter) {
     switch (filter.operand) {
       case ':':
       case '=':
-        res = areArraysEqualSets(card.details.colors, filter.arg);
+        if (filter.arg.length == 1 && filter.arg[0] == 'C') {
+          res = !card.details.colors.length;
+        } else {
+          res = areArraysEqualSets(card.details.colors, filter.arg);
+        }
         break;
       case '<':
         res = arrayContainsOtherArray(filter.arg, card.details.colors) && card.details.colors.length < filter.arg.length;
@@ -111,7 +115,11 @@ function filterApply(card, filter) {
     switch (filter.operand) {
       case ':':
       case '=':
-        res = areArraysEqualSets(card.colors, filter.arg);
+        if (filter.arg.length == 1 && filter.arg[0] == 'C') {
+          res = !card.details.colors.length;
+        } else {
+          res = areArraysEqualSets(card.colors, filter.arg);
+        }
         break;
       case '<':
         res = arrayContainsOtherArray(filter.arg, card.colors) && card.details.color_identity.length < filter.arg.length;


### PR DESCRIPTION
This commit fixes colorless in color filtering slightly. It currently
only works for the `:` and `=` operators. There are some weird edge
cases, like `c>c` should return all cards that aren't colorless. I don't
have time to implement those edge cases right now, but they will be in a
future update.