### PR TITLE
add disclaimer about custom image rights

### DIFF
--- a/views/layout.pug
+++ b/views/layout.pug
@@ -85,7 +85,7 @@ html
 					br
 					a Custom card images displayed in Cube Cobra are subject to the license terms under which they were uploaded to their hosts.
 					br
-					a Cube Cobra is not responsible for custom card images that contain objectionable material or violate copyrights.
+					a Cube Cobra is not responsible for the content of custom card images.
 					br
 					a To report a custom card image violation, message the development team on 
 					a(href='https://discord.gg/Hn39bCU') Discord.

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -83,6 +83,13 @@ html
 					br
 					a This site is not affiliated nor endorsed by Scryfall LLC. This site endeavours to adhere to the Scryfall data guidelines. 
 					br
+					a Custom card images displayed in Cube Cobra are subject to the license terms under which they were uploaded to their hosts.
+					br
+					a Cube Cobra is not responsible for custom card images that contain objectionable material or violate copyrights.
+					br
+					a To report a custom card image violation, message the development team on 
+					a(href='https://discord.gg/Hn39bCU') Discord.
+					br
 					a All other content Copyright &copy; 2019 Cube Cobra
 					br
 					a(href='/privacy') Privacy Privacy 


### PR DESCRIPTION
This pull request fixes https://github.com/dekkerglen/CubeCobra/issues/325 by adding a disclaimer to the site footer describing Cube Cobra's stance on displaying custom images from users.