### PR TITLE
limit size of card list in groupcontextmodalarea and scroll overflow

### DIFF
--- a/public/css/editcube.css
+++ b/public/css/editcube.css
@@ -117,3 +117,8 @@
 .invalid-filter:focus {
   color: red;
 }
+
+#groupContextModalAreaContainer {
+  overflow: scroll;
+  height: 41.6em;
+}

--- a/views/cube/cube_list.pug
+++ b/views/cube/cube_list.pug
@@ -174,7 +174,7 @@ block cube_content
             button.close(type='button', data-dismiss='modal', aria-label='Close')
               span(aria-hidden='true') ×
           .row.no-gutters
-            .col-4(style='padding: 4px;')
+            .col-4#groupContextModalAreaContainer(style='padding: 4px;')
               #groupContextModalArea
               .price-area
             .col-8


### PR DESCRIPTION
This pull request fixes https://github.com/dekkerglen/CubeCobra/issues/270 by limiting the height of the card list in the mass edit modal and scrolling the overflow when present.