### PR TITLE
fix broken remove functionality in group edit modal

### DIFF
--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -1010,11 +1010,11 @@ function renderGroupContext() {
     }
     let color_class = (show_tag_colors) ? getCardTagColorClass(card) : getCardColorClass(card);
     if (card.details.image_flip) {
-      cardlist += '<li cardID="' + card.cardID + '" style="font-size: 15px;" class="card-list-item list-group-item autocard ' + color_class + '" card="' + card.details.display_image + '" card_flip="' + card.details.image_flip + '" card_tags="' + card.tags + '">';
+      cardlist += '<li data-index="' + index + '" cardID="' + card.cardID + '" style="font-size: 15px;" class="groupModalRm card-list-item list-group-item autocard ' + color_class + '" card="' + card.details.display_image + '" card_flip="' + card.details.image_flip + '" card_tags="' + card.tags + '">';
     } else {
-      cardlist += '<li cardID="' + card.cardID + '" style="font-size: 15px;" class="card-list-item list-group-item autocard ' + color_class + '" card="' + card.details.display_image + '" card_tags="' + card.tags + '">';
+      cardlist += '<li data-index="' + index + '" cardID="' + card.cardID + '" style="font-size: 15px;" class="groupModalRm card-list-item list-group-item autocard ' + color_class + '" card="' + card.details.display_image + '" card_tags="' + card.tags + '">';
     }
-    cardlist += '<a data-index="' + index + '" class="groupModalRm clickx" href="#">×</a><a>  ';
+    cardlist += '×<a>  ';
     cardlist += card.details.name;
     cardlist += '</a></li>';
   });


### PR DESCRIPTION
This pull request fixes https://github.com/dekkerglen/CubeCobra/issues/359 by making the "x" button in the group edit modal card listing work properly. It causes the entire card listing in the modal sidebar, including the `x` and the card name to respond to clicks by removing the card from the listing.