### PR TITLE
add tag, status as filtering fields

### DIFF
--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -1659,7 +1659,8 @@ let categoryMap = new Map([
   ['tou', 'toughness'],
   ['toughness', 'toughness'],
   ['name', 'name'],
-  ['tag', 'tag']
+  ['tag', 'tag'],
+  ['status', 'status']
 ]);
 
 function findEndingQuotePosition(filterText, num) {

--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -1658,7 +1658,8 @@ let categoryMap = new Map([
   ['power','power'],
   ['tou', 'toughness'],
   ['toughness', 'toughness'],
-  ['name', 'name']
+  ['name', 'name'],
+  ['tag', 'tag']
 ]);
 
 function findEndingQuotePosition(filterText, num) {

--- a/public/js/sortfilter.js
+++ b/public/js/sortfilter.js
@@ -84,6 +84,9 @@ function filterApply(card, filter) {
   if (filter.category == 'name') {
     res = card.details.name_lower.indexOf(filter.arg) > -1;
   }
+  if (filter.category == 'status') {
+    res = card.status.toLowerCase() === filter.arg;
+  }
   if (filter.category == 'tag') {
     var lowerTags = [];
     card.tags.forEach(function(tag) {

--- a/public/js/sortfilter.js
+++ b/public/js/sortfilter.js
@@ -88,11 +88,9 @@ function filterApply(card, filter) {
     res = card.status.toLowerCase() === filter.arg;
   }
   if (filter.category == 'tag') {
-    var lowerTags = [];
-    card.tags.forEach(function(tag) {
-      lowerTags.push(tag.toLowerCase());
+    res = card.tags.some(tag => {
+      return tag.toLowerCase() === filter.arg;
     });
-    res = lowerTags.indexOf(filter.arg) > -1;
   }
   if (filter.category == 'oracle' && card.details.oracle_text) {
     res = card.details.oracle_text.toLowerCase().indexOf(filter.arg) > -1;

--- a/public/js/sortfilter.js
+++ b/public/js/sortfilter.js
@@ -84,6 +84,13 @@ function filterApply(card, filter) {
   if (filter.category == 'name') {
     res = card.details.name_lower.indexOf(filter.arg) > -1;
   }
+  if (filter.category == 'tag') {
+    var lowerTags = [];
+    card.tags.forEach(function(tag) {
+      lowerTags.push(tag.toLowerCase());
+    });
+    res = lowerTags.indexOf(filter.arg) > -1;
+  }
   if (filter.category == 'oracle' && card.details.oracle_text) {
     res = card.details.oracle_text.toLowerCase().indexOf(filter.arg) > -1;
   }


### PR DESCRIPTION
This pull request addresses part of https://github.com/dekkerglen/CubeCobra/issues/362 by adding `tag` as a filtering field. This fixes a regression in which this functionality was broken by https://github.com/dekkerglen/CubeCobra/commit/f04e6ca3fb67d59274a93221b402379d8f369ff0.