### PR TITLE
curve view fixes

### DIFF
--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -87,6 +87,8 @@ $('#customImageDisplayToggle').click(function(e) {
 
 $('#viewSelect').change(function(e) {
   view = $('#viewSelect').val();
+  if (view === 'curve' ) $('#secondarySortCol').hide();
+  else $('#secondarySortCol').show();
   updateCubeList();
 });
 

--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -1102,7 +1102,10 @@ function init_groupcontextModal() {
     e.preventDefault();
     var category1 = e.target.getAttribute("primarysort");
     var category2 = e.target.getAttribute("secondarysort");
-    var matches = sortIntoGroups(sortIntoGroups(filteredCube(), sorts[0])[category1], sorts[1])[category2];
+    var category3 = e.target.getAttribute("tertiarysort");
+    var second_sort = (view === 'curve') ? 'CNC' : sorts[1];
+    var matches = sortIntoGroups(sortIntoGroups(filteredCube(), sorts[0])[category1], second_sort)[category2];
+    if (view === 'curve') matches = sortIntoGroups(matches, 'CMC2')[category3];
     if (matches.length == 1) {
       show_contextModal(matches[0]);
     } else {

--- a/src/components/AutocardListGroup.js
+++ b/src/components/AutocardListGroup.js
@@ -4,7 +4,7 @@ import { Col, ListGroup, ListGroupItem, Row } from 'reactstrap';
 
 import AutocardListItem from './AutocardListItem';
 
-const AutocardListGroup = ({ cards, heading, primary, secondary }) => {
+const AutocardListGroup = ({ cards, heading, primary, secondary, tertiary }) => {
   let groups = sortIntoGroups(cards, "CMC");
   return (
     <ListGroup className="list-outline">
@@ -14,6 +14,7 @@ const AutocardListGroup = ({ cards, heading, primary, secondary }) => {
         className="list-group-heading activateGroupContextModal"
         primarysort={primary}
         secondarysort={secondary}
+        tertiarysort={tertiary}
       >
         {heading}
       </ListGroupItem>

--- a/src/components/CurveView.js
+++ b/src/components/CurveView.js
@@ -4,7 +4,7 @@ import { Card, CardHeader, CardBody, Col, Container, Row } from 'reactstrap';
 
 import AutocardListGroup from './AutocardListGroup';
 
-const TypeRow = ({ cardType, groups, count }) => (
+const TypeRow = ({ cardType, groups, count, primary }) => (
   <Fragment key={cardType}>
     <Row className="mt-2">
       <h6 className="ml-1">{cardType} ({count})</h6>
@@ -16,6 +16,9 @@ const TypeRow = ({ cardType, groups, count }) => (
             <AutocardListGroup
               heading={`${cmc} (${(groups[cmc] || []).length})`}
               cards={groups[cmc] || []}
+              primary={primary}
+              secondary={cardType}
+              tertiary={cmc}
             />
           </div>
         )
@@ -24,19 +27,20 @@ const TypeRow = ({ cardType, groups, count }) => (
   </Fragment>
 );
 
-const ColorCard = ({ color, groups, count, typeCounts }) => (
+const ColorCard = ({ color, groups, count, typeCounts, primary }) => (
   <Card>
     <CardHeader>
       <h5>{color} {count}</h5>
     </CardHeader>
     <CardBody>
       {
-        getLabels(sorts[1]).filter(cardType => groups[cardType]).map(cardType =>
+        getLabels('CNC').filter(cardType => groups[cardType]).map(cardType =>
           <TypeRow
             key={cardType}
             cardType={cardType}
             groups={groups[cardType]}
             count={typeCounts[cardType]}
+            primary={primary}
           />
         )
       }
@@ -46,7 +50,6 @@ const ColorCard = ({ color, groups, count, typeCounts }) => (
 
 const CurveView = ({ cards, ...props }) => {
   sorts[0] = document.getElementById('primarySortSelect').value || 'Color Category';
-  sorts[1] = document.getElementById('secondarySortSelect').value || 'Types-Multicolor';
 
   // We call the groups color and type even though they might be other sorts.
   let groups = sortIntoGroups(cards, sorts[0]);
@@ -54,7 +57,7 @@ const CurveView = ({ cards, ...props }) => {
   let typeCounts = {};
 
   for (let color of Object.keys(groups)) {
-    groups[color] = sortIntoGroups(groups[color], sorts[1]);
+    groups[color] = sortIntoGroups(groups[color], 'CNC');
     colorCounts[color] = 0;
     typeCounts[color] = {};
     for (let cardType of Object.keys(groups[color])) {
@@ -90,6 +93,7 @@ const CurveView = ({ cards, ...props }) => {
               groups={groups[color]}
               count={colorCounts[color]}
               typeCounts={typeCounts[color]}
+              primary={color}
             />
           ))
         }

--- a/src/components/VisualSpoiler.js
+++ b/src/components/VisualSpoiler.js
@@ -8,7 +8,7 @@ const VisualSpoiler = ({ cards, ...props }) => (
   <Row noGutters className="mt-3 justify-content-center" {...props}>
     {
       cards.map(({ index, details }) =>
-        <Col className="w-auto flex-grow-0">
+        <Col key={index} className="w-auto flex-grow-0">
           <div key={index} className="visualSpoilerCardContainer">
             <AutocardImage key={index} index={index} {...details} />
           </div>

--- a/views/cube/cube_list.pug
+++ b/views/cube/cube_list.pug
@@ -111,8 +111,9 @@ block cube_toolbar
               p
                 em  Cards will be appear as duplicates if they fit in multiple categories. The counts will still only count each item once.
             .col
-              h5 Secondary Sort
-              select#secondarySortSelect.custom-select
+              #secondarySortCol
+                h5 Secondary Sort
+                select#secondarySortSelect.custom-select
           .row
             .col
               button.updateButton.btn.btn-success(type='button') Update Table


### PR DESCRIPTION
this fixes a couple issues in curve view
- secondary sort is ignored and uses Creature/Non-Creature instead
- selecting headers in curve view now opens the modal with that group selected like it does in table view
- hide secondary sort selector in curve view