### PR TITLE
don't mouseover for single-faced cards, even after DFC modal

### DIFF
--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -1079,6 +1079,8 @@ function show_contextModal(card) {
   $('.price-area').html(priceHtml);
   $('#contextModalTitle').html(card.details.name);
   $('#contextModalImg').attr('src', card.details.display_image);
+  $("#contextModalImg").off("mouseover");
+  $("#contextModalImg").off("mouseout");
   if (card.details.image_flip !== undefined) {
     $('#contextModalImg').mouseover(function() {
       $(this).attr('src', card.details.image_flip);


### PR DESCRIPTION
This pull request fixes https://github.com/dekkerglen/CubeCobra/issues/380 by removing all mouseover/mouseout listeners on the edit modal preview image before adding new ones.