### PR TITLE
add basic travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
     - "stable"
+
 before_install: "npm install jest"
 install: "npm install"
 script: "npm run test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+    - "stable"
+before_install: "npm install jest"
+install: "npm install"
+script: "npm run test"


### PR DESCRIPTION
This pull request adds a `.travis.yml` file, which when combined with the standard Travis/GitHub Apps integration, causes the unit test suite to run every time a pull request is opened. Test pass/fail status is displayed in the GitHub interface. This provides the basis of passing tests being a requirement of pull requests being merged into development. As test coverage increases, this integration will continue to provide value as the pass/fail status becomes more indicative of whether or not a given pull request causes a regression.

The integration should be tested before merge. I've tested it [on my fork](https://github.com/emmett9001/CubeCobra/pull/6/checks?check_run_id=222932964), and it works great. However, since I am not an admin on dekkerglen/CubeCobra, I cannot set up this integration on the main repository myself. @dekkerglen, once you've set up a Travis CI account, you can use the [GitHub Apps integration flow](https://travis-ci.com/account/repositories) on Travis to set up the integration. Once you've done this, let me know and I can add another commit to this branch, which will trigger a new test run. This will allow us to see the integration in action, and tweak its behavior to our liking.

Related to https://github.com/dekkerglen/CubeCobra/issues/395