### PR TITLE
Filter cards by rarity

### DIFF
--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -627,6 +627,12 @@ $('#applyAdvancedFilterButton').click(function(e) {
 
   //artist
 
+  // rarity
+  if($('#filterRarity').val().length > 0)
+  {
+    str += ' r'+$('#filterRarityOp').val()+$('#filterRarity').val();
+  }
+
   $('#filterInput').val(str);
   $('#filterModal').modal('hide');
   filterButton.click();
@@ -1788,7 +1794,9 @@ let categoryMap = new Map([
   ['p','price'],
   ['pf','pricefoil'],
   ['status','status'],
-  ['stat','status']
+  ['stat','status'],
+  ['r', 'rarity'],
+  ['rarity', 'rarity']
 ]);
 
 function findEndingQuotePosition(filterText, num) {
@@ -2039,6 +2047,9 @@ const verifyTokens = (tokens) => {
           if (token(i).arg.every(verifyMana)) {
             return false;
           }
+          break;
+        case 'rarity':
+          if (token(i).arg.search(/^(common|uncommon|rare|mythic)$/) < 0) return false;
           break;
       }
     }

--- a/public/js/sortfilter.js
+++ b/public/js/sortfilter.js
@@ -1,6 +1,7 @@
 
 
 var price_buckets = [.25, .5, 1, 2, 3, 4, 5, 7, 10, 15, 20, 25, 30, 40, 50, 75, 100];
+var rarity_order = ['common', 'uncommon', 'rare', 'mythic'];
 
 function GetColorCategory(type, colors) {
   if (type.toLowerCase().includes('land')) {
@@ -274,6 +275,29 @@ function filterApply(card, filter) {
           res = price >= filter.arg;
           break;
       }
+    }
+  }
+  if(filter.category == 'rarity')
+  {
+    let rarity = card.details.rarity;
+    switch(filter.operand)
+    {
+      case ':':
+      case '=':
+        res = rarity == filter.arg;
+        break;
+      case '<':
+        res = rarity_order.indexOf(rarity) < rarity_order.indexOf(filter.arg);
+        break;
+      case '>':
+        res = rarity_order.indexOf(rarity) > rarity_order.indexOf(filter.arg);
+        break;
+      case '<=':
+        res = rarity_order.indexOf(rarity) <= rarity_order.indexOf(filter.arg);
+        break;
+      case '>=':
+        res = rarity_order.indexOf(rarity) >= rarity_order.indexOf(filter.arg);
+        break;
     }
   }
 

--- a/views/cube/cube_list.pug
+++ b/views/cube/cube_list.pug
@@ -317,7 +317,17 @@ block cube_content
               option(value='<=') less than or equal to
               option(value='>=') greater than or equal to
               option(value='!') not equal to
-            input#filterToughness.form-control(type='text', placeholder='Any value, e.g. "2"')       
+            input#filterToughness.form-control(type='text', placeholder='Any value, e.g. "2"')
+          .input-group.mb-3
+            .input-group-prepend
+              span.input-group-text Rarity
+            select.custom-select#filterRarityOp
+              option(value='=' selected='') equal to
+              option(value='<') less than
+              option(value='>') greater than
+              option(value='<=') less than or equal to
+              option(value='>=') greater than or equal to
+            input#filterRarity.form-control(type='text', placeholder='Any rarity, e.g. "common"')
         .modal-footer
           button.btn.btn-danger(type='button', data-dismiss='modal', aria-label='Close') Cancel
           button.btn.btn-success#applyAdvancedFilterButton(type='button') Apply

--- a/views/info/filters.pug
+++ b/views/info/filters.pug
@@ -147,3 +147,21 @@ block content
             tr
               td(scope="col") #[code pow<5 tou<5] 
               td(scope="col") Cards with both less than 5 power, and less than 5 toughness.
+      .card
+        #rarity-syntax.card-header(data-toggle="collapse" data-target="#collapseEight" aria-expanded="true" aria-controls="collapseEight")
+          button(class="btn btn-link" type="button" )
+            h5 Rarity
+        #collapseEight.collapse(aria-labelledby="rarity-syntax" data-parent="#syntax-accordion")
+          p You can use #[code r:] or #[code rarity:] to search for cards with a specific rarity.
+          p Operators supported: #[code :], #[code =], #[code <], #[code >], #[code <=], #[code >=].
+          p #[strong Examples:]
+          table.table
+            tr
+              td(scope="col") #[code r:common]
+              td(scope="col") Common cards.
+            tr
+              td(scope="col") #[code r<=uncommon]
+              td(scope="col") Common or uncommon cards.
+            tr
+              td(scope="col") #[code r:common or r:rare]
+              td(scope="col") Common or rare cards.


### PR DESCRIPTION
# Overview

This update adds the ability to filter by rarity.  The basic search, advanced search, and syntax page have been updated for the new functionality.  The filter works with `r` or `rarity` and supports `:`, `=`, `<`, `<=`, `>`, and `>=`.

This is part of #366.

# Screenshots

## Basic search
<img width="614" alt="Screen Shot 2019-09-16 at 9 37 42 PM" src="https://user-images.githubusercontent.com/1100717/65004998-5f946700-d8cc-11e9-999f-5f71641b21d9.png">

## Advanced search
<img width="784" alt="Screen Shot 2019-09-16 at 9 37 51 PM" src="https://user-images.githubusercontent.com/1100717/65004999-5f946700-d8cc-11e9-81c4-e807c161533f.png">

## Syntax
<img width="737" alt="Screen Shot 2019-09-16 at 9 38 03 PM" src="https://user-images.githubusercontent.com/1100717/65005001-5f946700-d8cc-11e9-8aa1-68680a792250.png">
