### PR TITLE
Add browserslist and set up core-js.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1849,6 +1849,13 @@
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+        }
       }
     },
     "babel-types": {
@@ -8393,6 +8400,14 @@
         "lodash": "~4.17.12",
         "memoize-one": "~5.0.1",
         "prop-types": "~15.7.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+          "dev": true
+        }
       }
     },
     "react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "author": "Gwen Dekker",
   "license": "ISC",
+  "browserslist": "> 1.0%, not dead",
   "dependencies": {
     "bad-words": "^3.0.3",
     "bcryptjs": "^2.4.3",
@@ -20,6 +21,7 @@
     "cheerio": "^1.0.0-rc.3",
     "connect-flash": "^0.1.1",
     "connect-mongodb-session": "^2.2.0",
+    "core-js": "^2.6.9",
     "express": "^4.17.1",
     "express-fileupload": "^1.1.5",
     "express-messages": "^1.0.1",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -27,7 +27,10 @@ module.exports = {
         exclude: /node_modules/,
         query: {
           presets: [
-            '@babel/preset-env',
+            ['@babel/preset-env', {
+              'useBuiltIns': 'usage',
+              'corejs': 2,
+            }],
             '@babel/preset-react',
           ],
         },


### PR DESCRIPTION
This change should make it such that all of our webpacked React code supports any browsers with a >1.0% share, and that any missing features are polyfilled. This fixes an issue reported in #428 with Object.fromEntries not being implemented on Edge and other older browsers
