### PR TITLE
remove shuffle() implementation by replacing it with library function

### DIFF
--- a/serverjs/draftutil.js
+++ b/serverjs/draftutil.js
@@ -1,17 +1,4 @@
-function shuffle(array) {
-  var currentIndex = array.length;
-  var temporaryValue, randomIndex;
-  while (0 !== currentIndex) {
-    randomIndex = Math.floor(Math.random() * currentIndex);
-    currentIndex -= 1;
-    temporaryValue = array[currentIndex];
-    array[currentIndex] = array[randomIndex];
-    array[randomIndex] = temporaryValue;
-  }
-
-  return array;
-
-}
+var util = require('./util.js');
 
 var methods = {
   getDraftBots: function(params) {
@@ -25,7 +12,7 @@ var methods = {
       colors.push('R');
       colors.push('G');
     }
-    shuffle(colors);
+    util.shuffle(colors);
     for (i = 0; i < params.seats - 1; i++) {
       var colorcombo = [colors.pop(), colors.pop()];
       draftbots.push(colorcombo);

--- a/serverjs/draftutil.js
+++ b/serverjs/draftutil.js
@@ -12,7 +12,7 @@ var methods = {
       colors.push('R');
       colors.push('G');
     }
-    util.shuffle(colors);
+    colors = util.shuffle(colors);
     for (i = 0; i < params.seats - 1; i++) {
       var colorcombo = [colors.pop(), colors.pop()];
       draftbots.push(colorcombo);


### PR DESCRIPTION
This pull request removes a homegrown implementation of an array shuffling function by replacing it with a library function. This means we don't need to write unit tests for this functionality.

Related to #395 