### PR TITLE
Tweak global and cube list navbars for mobile and tablet.

### DIFF
--- a/src/components/CubeListNavbar.js
+++ b/src/components/CubeListNavbar.js
@@ -152,7 +152,7 @@ class CubeListNavbar extends Component {
                     {canEdit ? 'Set Tag Colors' : 'View Tag Colors'}
                   </DropdownItem>
                   <DisplayContext.Consumer>
-                    {({ showCustomImages, toggleShowCustomImages }) => !canEdit ? '' :
+                    {({ showCustomImages, toggleShowCustomImages }) => !hasCustomImages ? '' :
                       <DropdownItem onClick={toggleShowCustomImages}>
                         {showCustomImages ? 'Hide Custom Images' : 'Show Custom Images'}
                       </DropdownItem>

--- a/src/components/CubeListNavbar.js
+++ b/src/components/CubeListNavbar.js
@@ -139,7 +139,7 @@ class CubeListNavbar extends Component {
                 <NavLink href="#" data-target="compare" onClick={this.handleOpenCollapse}>Compare</NavLink>
               </NavItem>
               {!canEdit ? '' :
-                <NavItem className="d-none d-lg-block">
+                <NavItem className={cubeView === 'list' ? undefined : 'd-none d-lg-block'}>
                   <NavLink href="#" onClick={this.handleMassEdit}>
                     {cubeView === 'list' ? 'Edit Selected' : 'Mass Edit'}
                   </NavLink>

--- a/src/components/CubeListNavbar.js
+++ b/src/components/CubeListNavbar.js
@@ -108,18 +108,20 @@ class CubeListNavbar extends Component {
     return (
       <div className="usercontrols">
         <Navbar expand="md" className="navbar-light">
-          <div className="view-style-select">
-            <Label className="sr-only" for="viewSelect">Cube View Style</Label>
-            <Input type="select" id="viewSelect" value={cubeView} onChange={this.handleChangeCubeView}>
-              <option value="table">Table View</option>
-              <option value="spoiler">Visual Spoiler</option>
-              {!canEdit ? '' :
-                <option value="list">List View</option>
-              }
-              <option value="curve">Curve View</option>
-            </Input>
+          <div className="d-flex flex-row flex-nowrap justify-content-between" style={{ flexGrow: 1 }}>
+            <div className="view-style-select">
+              <Label className="sr-only" for="viewSelect">Cube View Style</Label>
+              <Input type="select" id="viewSelect" value={cubeView} onChange={this.handleChangeCubeView}>
+                <option value="table">Table View</option>
+                <option value="spoiler">Visual Spoiler</option>
+                {!canEdit ? '' :
+                  <option value="list">List View</option>
+                }
+                <option value="curve">Curve View</option>
+              </Input>
+            </div>
+            <NavbarToggler onClick={this.toggle} />
           </div>
-          <NavbarToggler onClick={this.toggle} />
           <Collapse isOpen={this.state.isOpen} navbar>
             <Nav className="ml-auto" navbar>
               {!canEdit ? '' :
@@ -137,51 +139,44 @@ class CubeListNavbar extends Component {
                 <NavLink href="#" data-target="compare" onClick={this.handleOpenCollapse}>Compare</NavLink>
               </NavItem>
               {!canEdit ? '' :
-                <NavItem>
+                <NavItem className="d-none d-lg-block">
                   <NavLink href="#" onClick={this.handleMassEdit}>
                     {cubeView === 'list' ? 'Edit Selected' : 'Mass Edit'}
                   </NavLink>
                 </NavItem>
               }
-              <NavItem>
-                <NavLink href="#" onClick={/* global */ tagColorsModal}>
-                  {canEdit ? 'Set Tag Colors' : 'View Tag Colors'}
-                </NavLink>
-              </NavItem>
-              {!canEdit ? '' :
-                <UncontrolledDropdown nav inNavbar>
-                  <DropdownToggle nav caret>Bulk Upload</DropdownToggle>
-                  <DropdownMenu right>
+              <UncontrolledDropdown nav inNavbar>
+                <DropdownToggle nav caret>Display</DropdownToggle>
+                <DropdownMenu right>
+                  <DropdownItem onClick={/* global */ tagColorsModal}>
+                    {canEdit ? 'Set Tag Colors' : 'View Tag Colors'}
+                  </DropdownItem>
+                  <DisplayContext.Consumer>
+                    {({ showCustomImages, toggleShowCustomImages }) => !canEdit ? '' :
+                      <DropdownItem onClick={toggleShowCustomImages}>
+                        {showCustomImages ? 'Hide Custom Images' : 'Show Custom Images'}
+                      </DropdownItem>
+                    }
+                  </DisplayContext.Consumer>
+                </DropdownMenu>
+              </UncontrolledDropdown>
+              <UncontrolledDropdown nav inNavbar>
+                <DropdownToggle nav caret>{canEdit ? 'Import/Export' : 'Export'}</DropdownToggle>
+                <DropdownMenu right>
+                  {!canEdit ? '' : <>
+                    <DropdownItem disabled>Export</DropdownItem>
                     <DropdownItem data-toggle="modal" data-target="#pasteBulkModal">Paste Text</DropdownItem>
                     <DropdownItem data-toggle="modal" data-target="#uploadBulkModal">Upload File</DropdownItem>
                     <DropdownItem data-toggle="modal" data-target="#importModal">Import from CubeTutor</DropdownItem>
-                  </DropdownMenu>
-                </UncontrolledDropdown>
-              }
-              <UncontrolledDropdown nav inNavbar>
-                <DropdownToggle nav caret>Export</DropdownToggle>
-                <DropdownMenu right>
+                    <DropdownItem divider />
+                    <DropdownItem disabled>Import</DropdownItem>
+                  </>}
                   <DropdownItem href={`/cube/download/plaintext/${cubeID}`}>Card Names (.txt)</DropdownItem>
                   <DropdownItem href={`/cube/download/csv/${cubeID}`}>Comma-Separated (.csv)</DropdownItem>
                   <DropdownItem href={`/cube/download/forge/${cubeID}`}>Forge (.dck)</DropdownItem>
                   <DropdownItem href={`/cube/download/xmage/${cubeID}`}>XMage (.dck)</DropdownItem>
                 </DropdownMenu>
               </UncontrolledDropdown>
-              <NavItem className={hasCustomImages ? undefined : 'd-none'}>
-                <DisplayContext.Consumer>
-                  {({ showCustomImages, toggleShowCustomImages }) =>
-                    <NavLink id="customImageDisplayMenuItem" className="d-flex align-items-baseline text-sm-left text-center">
-                      <Input
-                        type="checkbox"
-                        className="mr-1 ml-0 my-0 position-static d-block"
-                        checked={showCustomImages}
-                        onChange={toggleShowCustomImages}
-                      />
-                      <Label for="customImageDisplayToggle" className="m-0" onClick={toggleShowCustomImages}>Show Custom Images</Label>
-                    </NavLink>
-                  }
-                </DisplayContext.Consumer>
-              </NavItem>
             </Nav>
           </Collapse>
         </Navbar>

--- a/src/components/PagedTable.js
+++ b/src/components/PagedTable.js
@@ -40,10 +40,12 @@ class PagedTable extends Component {
           </PaginationItem>
         )}
       </Pagination>
-      <Table {...props}>
-        {children}
-        <tbody>{displayRows}</tbody>
-      </Table>
+      <div className="table-responsive">
+        <Table {...props}>
+          {children}
+          <tbody>{displayRows}</tbody>
+        </Table>
+      </div>
     </>;
   }
 }

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -33,7 +33,7 @@ html
 						img(src="/content/banner.png" style='height: 45px; margin: 0 0' alt="Cube Cobra: a site for Magic: the Gathering Cubing")
 				button.navbar-toggler(type='button', data-toggle='collapse', data-target='#navbar', aria-controls='navbar', aria-expanded='false', aria-label='Toggle navigation')
 					span.navbar-toggler-icon
-			#navbar.collapse.navbar-collapse
+			#navbar.collapse.navbar-collapse(style='flex: 10000 1 auto')
 				ul.navbar-nav.mr-auto
 					form(method='POST', action='/search').form-inline
 						.input-group.mt-2.mb-sm-2
@@ -55,7 +55,9 @@ html
 						li.nav-item
 							a.nav-link.d-none.d-lg-block(href="#", data-toggle='modal', data-target='#cubeModal') New Cube
 						li.nav-item
-							a.nav-link(href="/user/view/"+user.id) Your Profile
+							a.nav-link(href="/user/view/"+user.id)
+								span.d-none.d-lg-inline Your
+								|  Profile
 						li.nav-item.dropdown
 							a#navbarDropdownMenuLink.nav-link.dropdown-toggle(href='#', role='button', data-toggle='dropdown', aria-haspopup='true', aria-expanded='false')
 								|  #{user.username}  

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -27,11 +27,12 @@ html
 		script(src='/jquery-ui/jquery-ui.min.js')
 	body
 		nav.navbar.navbar-expand-md.navbar-dark.bg-dark
-			.text-truncate
-				a(href='/')
-					img(src="/content/banner.png" style='height: 45px; margin: 0 0' alt="Cube Cobra: a site for Magic: the Gathering Cubing")
-			button.navbar-toggler(type='button', data-toggle='collapse', data-target='#navbar', aria-controls='navbar', aria-expanded='false', aria-label='Toggle navigation')
-				span.navbar-toggler-icon
+			.d-flex.flex-row.flex-nowrap.justify-content-between(style='flex: 1 1 auto; min-width: 0')
+				.overflow-hidden
+					a(href='/')
+						img(src="/content/banner.png" style='height: 45px; margin: 0 0' alt="Cube Cobra: a site for Magic: the Gathering Cubing")
+				button.navbar-toggler(type='button', data-toggle='collapse', data-target='#navbar', aria-controls='navbar', aria-expanded='false', aria-label='Toggle navigation')
+					span.navbar-toggler-icon
 			#navbar.collapse.navbar-collapse
 				ul.navbar-nav.mr-auto
 					form(method='POST', action='/search').form-inline

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -53,7 +53,7 @@ html
 							a.dropdown-item(href='/donate') Donate
 					if user
 						li.nav-item
-							a.nav-link(href="#", data-toggle='modal', data-target='#cubeModal') Create New Cube
+							a.nav-link.d-none.d-lg-block(href="#", data-toggle='modal', data-target='#cubeModal') New Cube
 						li.nav-item
 							a.nav-link(href="/user/view/"+user.id) Your Profile
 						li.nav-item.dropdown

--- a/views/user/user_view.pug
+++ b/views/user/user_view.pug
@@ -9,6 +9,13 @@ block content
 				a.nav-link.active(href='/user/view/'+user_limited.id) Cubes
 			li.nav-item(style='padding-right:10px;')
 				a.nav-link(href='/user/decks/'+user_limited.id) Decks
+	if user && user.id == user_limited.id
+		.usercontrols
+			nav.navbar.navbar-light
+				ul.navbar-nav
+					li.nav-item
+						a.nav-link(href="#", data-toggle='modal', data-target='#cubeModal') Create New Cube
+
 	include ../flash
 
 	if user_limited.about
@@ -17,8 +24,7 @@ block content
 			.card-body
 				h5 About:
 				p=user_limited.about
-				if user
-					if user.id == user_limited.id
+				if user && user.id == user_limited.id
 					a.btn.btn-success(href='/user/account') Update
 	br
 	.row


### PR DESCRIPTION
This PR improves the display properties of the global and cube list navbars on smaller screens. Choices that I've made that people may want to discuss:

- Hides the global "Create New Cube" button in the navbar on smaller screens, in lieu of a similar button on the user homepage (the one that "Your Profile" links to).
- Hides the Mass Edit button on smaller screens, since this is also accessible via List View and the dropdown. The Edit Selected button still always appears on List View.
- The CubeCobra logo now clips slightly on very small screens to prevent the navbar toggler from wrapping to the next line.

Fixes #316.

<img width="1072" alt="Screen Shot 2019-09-19 at 2 36 23 PM" src="https://user-images.githubusercontent.com/548999/65271327-f5a5d880-daea-11e9-8143-092d41c6c930.png">
<img width="924" alt="Screen Shot 2019-09-19 at 2 36 30 PM" src="https://user-images.githubusercontent.com/548999/65271328-f5a5d880-daea-11e9-89a5-4fc333787ec8.png">
<img width="723" alt="Screen Shot 2019-09-19 at 2 36 36 PM" src="https://user-images.githubusercontent.com/548999/65271329-f5a5d880-daea-11e9-861c-13893189fe80.png">
<img width="287" alt="Screen Shot 2019-09-19 at 2 36 45 PM" src="https://user-images.githubusercontent.com/548999/65271330-f5a5d880-daea-11e9-84c5-0be72b22f1f6.png">
