### PR TITLE
Remove 'New' on adding cards

### DIFF
--- a/__tests__/serverjs/util.js
+++ b/__tests__/serverjs/util.js
@@ -83,8 +83,7 @@ test("addCardToCube adds a well-formed object", () => {
     util.addCardToCube(testCube, testCard, undefined, addedTmsp);
     expect(testCube.cards.length).toBe(initialLength + 1);
     const result = testCube.cards[0];
-    expect(result.tags.length).toBe(1);
-    expect(result.tags).toBe([]);
+    expect(result.tags.length).toBe(0);
     expect(result.status).toBe("Not Owned");
     expect(result.colors).toBe(testCard.color_identity);
     expect(result.cmc).toBe(testCard.cmc);

--- a/__tests__/serverjs/util.js
+++ b/__tests__/serverjs/util.js
@@ -84,7 +84,7 @@ test("addCardToCube adds a well-formed object", () => {
     expect(testCube.cards.length).toBe(initialLength + 1);
     const result = testCube.cards[0];
     expect(result.tags.length).toBe(1);
-    expect(result.tags[0]).toBe("New");
+    expect(result.tags).toBe([]);
     expect(result.status).toBe("Not Owned");
     expect(result.colors).toBe(testCard.color_identity);
     expect(result.cmc).toBe(testCard.cmc);

--- a/serverjs/util.js
+++ b/serverjs/util.js
@@ -87,7 +87,7 @@ function binaryInsert(value, array, startVal, endVal) {
 
 function addCardToCube(cube, card_details, idOverride, addedTmspOverride) {
   cube.cards.push({
-    tags: ['New'],
+    tags: [],
     status: "Not Owned",
     colors: card_details.color_identity,
     cmc: card_details.cmc,


### PR DESCRIPTION
This updates remove the default adding of the 'New' tag.

Not 100% sure if this is how we want to do this, as we've received a lot of feedback complaining about the 'New' tag, but people who appreciate it probably haven't spoken up.

I personally think it's ok to remove, as you can still see what's new from the blog history.