### PR TITLE
Filter cards by loyalty

### DIFF
--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -392,6 +392,9 @@ $('#applyAdvancedFilterButton').click(function(e) {
   }
 
   //loyalty
+  if ($('#filterLoyalty').val().length > 0) {
+    str += ' loy' + $('#filterLoyaltyOp').val() + $('#filterLoyalty').val();
+  }
 
   //manacost type
 
@@ -1076,7 +1079,9 @@ let categoryMap = new Map([
   ['status', 'status'],
   ['stat', 'status'],
   ['r', 'rarity'],
-  ['rarity', 'rarity']
+  ['rarity', 'rarity'],
+  ['loy', 'loyalty'],
+  ['loyalty', 'loyalty']
 ]);
 
 function findEndingQuotePosition(filterText, num) {
@@ -1320,6 +1325,7 @@ const verifyTokens = (tokens) => {
         case 'cmc':
         case 'power':
         case 'toughness':
+        case 'loyalty':
           if (token(i).arg.search(/^\d+$/) < 0) return false;
           break;
         case 'mana':

--- a/public/js/sortfilter.js
+++ b/public/js/sortfilter.js
@@ -207,6 +207,28 @@ function filterApply(card, filter) {
       }
     }
   }
+  if (filter.category == 'loyalty') {
+    if (card.details.loyalty) {
+      switch (filter.operand) {
+        case ':':
+        case '=':
+          res = card.details.loyalty == filter.arg;
+          break;
+        case '<':
+          res = card.details.loyalty < filter.arg;
+          break;
+        case '>':
+          res = card.details.loyalty > filter.arg;
+          break;
+        case '<=':
+          res = card.details.loyalty <= filter.arg;
+          break;
+        case '>=':
+          res = card.details.loyalty >= filter.arg;
+          break;
+      }
+    }
+  }
   if (filter.category == 'tag') {
     res = card.tags.some(element => {
       return element.toLowerCase() == filter.arg;

--- a/views/cube/cube_list.pug
+++ b/views/cube/cube_list.pug
@@ -174,6 +174,16 @@ block cube_content
             input#filterToughness.form-control(type='text', placeholder='Any value, e.g. "2"')
           .input-group.mb-3
             .input-group-prepend
+              span.input-group-text Loyalty
+            select.custom-select#filterLoyaltyOp
+              option(value='=' selected='') equal to
+              option(value='<') less than
+              option(value='>') greater than
+              option(value='<=') less than or equal to
+              option(value='>=') greater than or equal to
+            input#filterLoyalty.form-control(type='text', placeholder='Any value, e.g. "3"')
+          .input-group.mb-3
+            .input-group-prepend
               span.input-group-text Rarity
             select.custom-select#filterRarityOp
               option(value='=' selected='') equal to

--- a/views/info/filters.pug
+++ b/views/info/filters.pug
@@ -134,19 +134,23 @@ block content
       .card
         #power-toughness-syntax.card-header(data-toggle="collapse" data-target="#collapseSeven" aria-expanded="true" aria-controls="collapseSeven")
           button(class="btn btn-link" type="button" )
-            h5 Power and Toughness
+            h5 Power, Toughness, and Loyalty
         #collapseSeven.collapse(aria-labelledby="power-toughness-syntax" data-parent="#syntax-accordion")
           p You can use #[code pow:] or #[code power:] to search for cards with certain powers.
           p You can use #[code tou:] or #[code toughness:] to search for cards with certain toughness.
+          p You can use #[code loy:] or #[coode loyalty:] to search for cards with certain starting loyalty.
           p Operators supported: #[code :], #[code =], #[code <], #[code >], #[code <=], #[code >=].
           p #[strong Examples:]
           table.table
             tr
-              td(scope="col") #[code pow>7] 
+              td(scope="col") #[code pow>7]
               td(scope="col") Cards with greater than 7 power.
             tr
-              td(scope="col") #[code pow<5 tou<5] 
+              td(scope="col") #[code pow<5 tou<5]
               td(scope="col") Cards with both less than 5 power, and less than 5 toughness.
+            tr
+              td(scope="col") #[code loy:3 or loy:4]
+                td(scope="col") Cards with a starting loyalty of 3 or 4.
       .card
         #rarity-syntax.card-header(data-toggle="collapse" data-target="#collapseEight" aria-expanded="true" aria-controls="collapseEight")
           button(class="btn btn-link" type="button" )


### PR DESCRIPTION
# Overview

This update adds the ability to filter by loyalty.  The basic search, advanced search, and syntax page have been updated for the new functionality.  The filter works with `loy` or `loyalty` and supports `:`, `=`, `<`, `<=`, `>`, and `>=`.

This is part of #366.

# Screenshots

## Basic search

<img width="707" alt="Screen Shot 2019-09-21 at 5 06 49 PM" src="https://user-images.githubusercontent.com/1100717/65379304-00e83800-dc94-11e9-8cc2-c25326710f2d.png">

## Advanced search

<img width="789" alt="Screen Shot 2019-09-21 at 5 20 28 PM" src="https://user-images.githubusercontent.com/1100717/65379320-237a5100-dc94-11e9-8cab-5d06e7381af5.png">

## Syntax

<img width="760" alt="Screen Shot 2019-09-21 at 5 07 40 PM" src="https://user-images.githubusercontent.com/1100717/65379294-e8781d80-dc93-11e9-9975-0beeec6ef6d3.png">

