### PR TITLE
Correct privacy policy link to TOS

### DIFF
--- a/views/info/privacy_policy.pug
+++ b/views/info/privacy_policy.pug
@@ -16,7 +16,7 @@ block content
       p We use your data to provide and improve the Service. By using the Service, you agree to the collection and use of 
         | information in accordance with this policy. Unless otherwise defined in this Privacy Policy, terms used in this Privacy 
         | Policy have the same meanings as in our Terms and Conditions, accessible from 
-        a(href='cubecobra.com/tos') here
+        a(href='/tos') here
         a .
   dl.row
     dt.col-3 Information Collection And Use


### PR DESCRIPTION
This update fixes the Privacy Policy's link to the Terms of Service.

To test:
1. Click the Privacy Policy link in the site footer.
2. Click the link at the end of the introduction.
3. Confirm that the Terms and Conditions page displays.

Fixes #384.