### PR TITLE
undo global state change after test

### DIFF
--- a/__tests__/serverjs/updatecards.test.js
+++ b/__tests__/serverjs/updatecards.test.js
@@ -99,6 +99,7 @@ test("updateCardbase creates the expected files", () => {
   });
   var downloadMock = jest.fn();
   downloadMock.mockReturnValue(noopPromise);
+  var initialDownloadDefaultCards = updatecards.downloadDefaultCards;
   updatecards.downloadDefaultCards = downloadMock;
   return updatecards.updateCardbase(cardsFixturePath).then(function() {
     expect(fs.existsSync('private/cardtree.json')).toBe(true);
@@ -109,6 +110,7 @@ test("updateCardbase creates the expected files", () => {
     expect(fs.existsSync('private/nameToId.json')).toBe(true);
     expect(fs.existsSync('private/full_names.json')).toBe(true);
   });
+  updatecards.downloadDefaultCards = initialDownloadDefaultCards;
 });
 
 test("addCardToCatalog successfully adds a card's information to the internal structures", () => {


### PR DESCRIPTION
This pull request makes the `updateCardBase` test reset global state to its pre-test state, helping subsequent tests avoid confusing errors.