### PR TITLE
init nameToId to the correct datatype

### DIFF
--- a/__tests__/serverjs/updatecards.test.js
+++ b/__tests__/serverjs/updatecards.test.js
@@ -165,7 +165,7 @@ test("initializeCatalog clears the updatecards structures", () => {
     updatecards.initializeCatalog();
     expect(Object.keys(updatecards.catalog.dict).length).toBe(0);
     expect(updatecards.catalog.names.length).toBe(0);
-    expect(updatecards.catalog.nameToId.length).toBe(0);
+    expect(Object.keys(updatecards.catalog.nameToId).length).toBe(0);
     expect(updatecards.catalog.full_names.length).toBe(0);
     expect(Object.keys(updatecards.catalog.imagedict).length).toBe(0);
     expect(Object.keys(updatecards.catalog.cardimages).length).toBe(0);

--- a/serverjs/updatecards.js
+++ b/serverjs/updatecards.js
@@ -8,7 +8,7 @@ var _catalog = {};
 function initializeCatalog() {
   _catalog.dict = {};
   _catalog.names = [];
-  _catalog.nameToId = [];
+  _catalog.nameToId = {};
   _catalog.full_names = [];
   _catalog.imagedict = {};
   _catalog.cardimages = {};


### PR DESCRIPTION
This pull request fixes https://github.com/dekkerglen/CubeCobra/issues/492 by setting `nameToId` to an object instead of a list, which is what the rest of the module's code expects.