### PR TITLE
Fix three bugs with Add/Remove collapse.

### DIFF
--- a/public/js/autocomplete.js
+++ b/public/js/autocomplete.js
@@ -71,14 +71,13 @@ function autocompleteByTree(inp, tree, images, submit_button) {
       /*and and make the current item more visible:*/
       addActive(x);
     } else if (e.keyCode == 9) {
-      /*If the tab key is pressed, prevent the form from being submitted,*/
-      if (currentFocus > -1) {
-        /*and simulate a click on the "active" item:*/
-        e.preventDefault();
-        if (x) x[currentFocus].click();
-      } else {
-        /* The user is moving away from the input now hide the list*/
-        closeAllLists();
+      /*If the tab key is pressed, simulate a click on the active or top item.*/
+      if (x && x.length > 0) {
+        if (currentFocus > -1 && currentFocus < x.length) {
+          x[currentFocus].click();
+        } else if (currentFocus === -1) {
+          x[0].click();
+        }
       }
     } else if (e.keyCode == 13) {
       /*If the ENTER key is pressed, prevent the form from being submitted,*/

--- a/public/js/autocomplete.js
+++ b/public/js/autocomplete.js
@@ -70,7 +70,7 @@ function autocompleteByTree(inp, tree, images, submit_button) {
       currentFocus--;
       /*and and make the current item more visible:*/
       addActive(x);
-    } else if (e.keyCode == 9) {
+    } else if (e.keyCode == 9 || e.keyCode == 13) {
       /*If the tab key is pressed, simulate a click on the active or top item.*/
       if (x && x.length > 0) {
         if (currentFocus > -1 && currentFocus < x.length) {
@@ -79,16 +79,12 @@ function autocompleteByTree(inp, tree, images, submit_button) {
           x[0].click();
         }
       }
-    } else if (e.keyCode == 13) {
-      /*If the ENTER key is pressed, prevent the form from being submitted,*/
-      e.preventDefault();
-      if (currentFocus > -1) {
-        /*and simulate a click on the "active" item:*/
-        if (x) x[currentFocus].click();
-        temp_button = document.getElementById("justAddButton");
+      if (e.keyCode == 13) {
+        /*If the ENTER key was pressed, prevent the form from being submitted,*/
+        e.preventDefault();
+        var submit_button = document.getElementById(inp.getAttribute('data-button'));
         if (submit_button) {
           submit_button.click();
-          inp.focus();
         }
       }
     }

--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -457,6 +457,12 @@ function updateCollapse() {
 
   $('#changelist').html(val);
 
+  if (val.length > 0) {
+    $('.editForm').collapse("show");
+  } else {
+    $('.editForm').collapse("hide")
+  }
+
   autocard_init('dynamic-autocard');
   changes.forEach(function(change, index) {
     var clickx = document.getElementById("clickx" + index);

--- a/src/components/CardModalForm.js
+++ b/src/components/CardModalForm.js
@@ -201,7 +201,7 @@ class CardModalForm extends Component {
   }
 
   render() {
-    let { canEdit, children, ...props } = this.props;
+    let { canEdit, setOpenCollapse, children, ...props } = this.props;
     return (
       <CardModalContext.Provider value={this.openCardModal}>
         {children}

--- a/src/components/CardModalForm.js
+++ b/src/components/CardModalForm.js
@@ -150,6 +150,7 @@ class CardModalForm extends Component {
     updateCollapse();
     $('#navedit').collapse("show");
     $('.warnings').collapse("hide");
+    this.props.setOpenCollapse(() => 'edit');
     this.setState({ isOpen: false });
   }
  

--- a/src/components/EditCollapse.js
+++ b/src/components/EditCollapse.js
@@ -56,6 +56,11 @@ class EditCollapse extends Component {
     this.handlePostChange = this.handlePostChange.bind(this);
   }
 
+  componentDidMount() {
+    /* global */
+    updateCollapse();
+  }
+
   componentDidUpdate() {
     /* global */
     updateCollapse();
@@ -77,7 +82,7 @@ class EditCollapse extends Component {
           </Row>
           <Row>
             <Col xs="12" sm="auto">
-              <Form inline className="mb-2">
+              <Form inline className="mb-2" onSubmit={e => e.preventDefault()}>
                 <div className="autocomplete">
                   <Input type="text" className="mr-2" id="addInput" placeholder="Card to Add" autoComplete="off" />
                 </div>
@@ -85,7 +90,7 @@ class EditCollapse extends Component {
               </Form>
             </Col>
             <Col xs="12" sm="auto">
-              <Form inline className="mb-2">
+              <Form inline className="mb-2" onSubmit={e => e.preventDefault()}>
                 <div className="autocomplete">
                   <Input type="text" className="mr-2" id="removeInput" placeholder="Card to Remove" autoComplete="off" />
                 </div>

--- a/src/components/EditCollapse.js
+++ b/src/components/EditCollapse.js
@@ -82,19 +82,19 @@ class EditCollapse extends Component {
           </Row>
           <Row>
             <Col xs="12" sm="auto">
-              <Form inline className="mb-2" onSubmit={e => e.preventDefault()}>
+              <Form inline className="mb-2" onSubmit={e => { e.preventDefault(); /* global */ justAdd(); }}>
                 <div className="autocomplete">
-                  <Input type="text" className="mr-2" id="addInput" placeholder="Card to Add" autoComplete="off" />
+                  <Input type="text" className="mr-2" id="addInput" placeholder="Card to Add" autoComplete="off" data-lpignore />
                 </div>
-                <Button color="success" onClick={/* global */ justAdd}>Just Add</Button>
+                <Button color="success" type="submit">Just Add</Button>
               </Form>
             </Col>
             <Col xs="12" sm="auto">
-              <Form inline className="mb-2" onSubmit={e => e.preventDefault()}>
+              <Form inline className="mb-2" onSubmit={e => { e.preventDefault(); /* global */ remove(); }}>
                 <div className="autocomplete">
-                  <Input type="text" className="mr-2" id="removeInput" placeholder="Card to Remove" autoComplete="off" />
+                  <Input type="text" className="mr-2" id="removeInput" placeholder="Card to Remove" autoComplete="off" data-lpignore />
                 </div>
-                <Button color="success" onClick={/* global */ remove}>Remove/Replace</Button>
+                <Button color="success" type="submit">Remove/Replace</Button>
               </Form>
             </Col>
           </Row>

--- a/src/components/EditCollapse.js
+++ b/src/components/EditCollapse.js
@@ -54,6 +54,8 @@ class EditCollapse extends Component {
     };
 
     this.handlePostChange = this.handlePostChange.bind(this);
+    this.handleAdd = this.handleAdd.bind(this);
+    this.handleRemoveReplace = this.handleRemoveReplace.bind(this);
   }
 
   componentDidMount() {
@@ -70,6 +72,22 @@ class EditCollapse extends Component {
     this.setState({ postContent: event.target.value });
   }
 
+  handleAdd(event) {
+    event.preventDefault();
+    /* global */ justAdd();
+    document.getElementById('addInput').focus();
+  }
+
+  handleRemoveReplace(event) {
+    event.preventDefault();
+    const addInput = document.getElementById('addInput');
+    const removeInput = document.getElementById('removeInput');
+    const replace = addInput.value.length > 0;
+    /* global */ remove();
+    /* If replace, put focus back in addInput; otherwise leave it here. */
+    (replace ? addInput : removeInput).focus();
+  }
+
   render() {
     const { cubeID, ...props } = this.props;
     return (
@@ -82,19 +100,35 @@ class EditCollapse extends Component {
           </Row>
           <Row>
             <Col xs="12" sm="auto">
-              <Form inline className="mb-2" onSubmit={e => { e.preventDefault(); /* global */ justAdd(); }}>
+              <Form inline className="mb-2" onSubmit={this.handleAdd}>
                 <div className="autocomplete">
-                  <Input type="text" className="mr-2" id="addInput" placeholder="Card to Add" autoComplete="off" data-lpignore />
+                  <Input
+                    type="text"
+                    className="mr-2"
+                    id="addInput"
+                    placeholder="Card to Add"
+                    data-button="justAddButton"
+                    autoComplete="off"
+                    data-lpignore
+                  />
                 </div>
-                <Button color="success" type="submit">Just Add</Button>
+                <Button color="success" type="submit" id="justAddButton">Just Add</Button>
               </Form>
             </Col>
             <Col xs="12" sm="auto">
-              <Form inline className="mb-2" onSubmit={e => { e.preventDefault(); /* global */ remove(); }}>
+              <Form inline className="mb-2" onSubmit={this.handleRemoveReplace}>
                 <div className="autocomplete">
-                  <Input type="text" className="mr-2" id="removeInput" placeholder="Card to Remove" autoComplete="off" data-lpignore />
+                  <Input
+                    type="text"
+                    className="mr-2"
+                    id="removeInput"
+                    placeholder="Card to Remove"
+                    data-button="removeButton"
+                    autoComplete="off"
+                    data-lpignore
+                  />
                 </div>
-                <Button color="success" type="submit">Remove/Replace</Button>
+                <Button color="success" type="submit" id="removeButton">Remove/Replace</Button>
               </Form>
             </Col>
           </Row>

--- a/src/cube_list.js
+++ b/src/cube_list.js
@@ -76,7 +76,7 @@ class CubeList extends Component {
       <SortContext.Provider>
         <DisplayContext.Provider>
           <TagContext.Provider defaultTags={defaultTags}>
-            <CardModalForm canEdit={canEdit}>
+            <CardModalForm canEdit={canEdit} setOpenCollapse={this.setOpenCollapse}>
               <GroupModal cubeID={cubeID} canEdit={canEdit} setOpenCollapse={this.setOpenCollapse}>
                 <CubeListNavbar
                   canEdit={canEdit}

--- a/views/cube/cube_list.pug
+++ b/views/cube/cube_list.pug
@@ -313,4 +313,6 @@ block cube_content
   script(src='/js/sortfilter.js')
   script(src='/js/tags.js')
   script(src='/js/editcube.js')
+  // FIXME: this can be removed once edit collapse is in React.
+  script(src='/bower_components/bootstrap/dist/js/bootstrap.js')  
   script(src='/js/cube_list.bundle.js')


### PR DESCRIPTION
One of these is a critical bug; the other is more of a tweak. The first prevented users from adding or removing cards. The second bug failed to accept autocomplete input on hitting tab to the next field. The third is a regression that didn't accept input on enter.

Fixes #494.