### PR TITLE
Filter cards by artist

### DIFF
--- a/src/components/FilterCollapse.js
+++ b/src/components/FilterCollapse.js
@@ -39,7 +39,7 @@ const NumericField = ({ name, humanName, placeholder, valueOp, value, onChange, 
     <Input type="text" name={name} placeholder={placeholder} value={value} onChange={onChange} />
   </InputGroup>;
 
-const allFields = ['name', 'oracle', 'cmc', 'color', 'colorIdentity', 'mana', 'type', 'set', 'tag', 'status', 'price', 'priceFoil', 'power', 'toughness', 'loyalty', 'rarity'];
+const allFields = ['name', 'oracle', 'cmc', 'color', 'colorIdentity', 'mana', 'type', 'set', 'tag', 'status', 'price', 'priceFoil', 'power', 'toughness', 'loyalty', 'rarity', 'artist'];
 const numFields = ['cmc', 'price', 'priceFoil', 'power', 'toughness', 'loyalty', 'rarity'];
 
 const AdvancedFilterModal = ({ isOpen, toggle, apply, values, onChange, ...props }) =>
@@ -86,6 +86,7 @@ const AdvancedFilterModal = ({ isOpen, toggle, apply, values, onChange, ...props
         <NumericField name="toughness" humanName="Toughness" placeholder={'Any value, e.g. "2"'} value={values.toughness} onChange={onChange} />
         <NumericField name="loyalty" humanName="Loyalty" placeholder={'Any value, e.g. "3"'} value={values.loyalty} onChange={onChange} />
         <NumericField name="rarity" humanName="Rarity" placeholder={'Any rarity, e.g. "common"'} value={values.rarity} onChange={onChange} />
+        <TextField name="artist" humanName="Artist" placeholder={'Any text, e.g. "seb"'} value={values.artist} onChange={onChange} />
       </ModalBody>
       <ModalFooter>
         <Button color="danger" aria-label="Close" onClick={toggle}>Cancel</Button>

--- a/src/util/Filter.js
+++ b/src/util/Filter.js
@@ -31,6 +31,9 @@ let categoryMap = new Map([
   ['rarity', 'rarity'],
   ['loy', 'loyalty'],
   ['loyalty', 'loyalty'],
+  ['a', 'artist'],
+  ['art', 'artist'],
+  ['artist', 'artist']
 ]);
 
 function findEndingQuotePosition(filterText, num) {
@@ -264,6 +267,8 @@ const verifyTokens = (tokens) => {
         case 'rarity':
           if (token(i).arg.search(/^(common|uncommon|rare|mythic)$/) < 0) return false;
           break;
+        case 'artist':
+          return true;
       }
     }
 
@@ -650,6 +655,9 @@ function filterApply(card, filter) {
         res = rarity_order.indexOf(rarity) >= rarity_order.indexOf(filter.arg);
         break;
     }
+  }
+  if (filter.category == 'artist') {
+    res = card.details.artist.toLowerCase().indexOf(filter.arg.toLowerCase()) > -1;
   }
 
   if (filter.not) {

--- a/views/info/filters.pug
+++ b/views/info/filters.pug
@@ -172,3 +172,17 @@ block content
             tr
               td(scope="col") #[code r:common or r:rare]
               td(scope="col") Common or rare cards.
+      .card
+        #collapseArtist-syntax.card-header(data-toggle="collapse" data-target="#collapseArtist" aria-expanded="true" aria-controls="collapseArtist")
+          button(class="btn btn-link" type="button" )
+            h5 Artist
+        #collapseArtist.collapse(aria-labelledby="collapseArtist-syntax" data-parent="#syntax-accordion")
+          p You can use #[code a:], #[code art:], or #[code artist:] to search for cards illustrated by a specific artist.
+          p #[strong Examples:]
+            table.table
+              tr
+                td(scope="col") #[code a:"seb mckinnon"]
+                td(scope="col") All cards illustrated by Seb Mckinnon.
+              tr
+                td(scope="col") #[code a:reb]
+                td(scope="col") All cards illustrated by artists with "reb" in their name.


### PR DESCRIPTION
# Overview

This update adds the ability to filter by artist. The basic search, advanced search, and syntax page have been updated for the new functionality.  Filtering should work correctly on both the cube list and cube compare views.  The search is case-insensitive and supports partial matches.

This is part of #366.

# Screenshots

## Basic search

<img width="709" alt="Screen Shot 2019-09-25 at 8 45 11 PM" src="https://user-images.githubusercontent.com/1100717/65649860-454a3f80-dfd6-11e9-9b48-33963edff6f5.png">

## Advanced search

<img width="781" alt="Screen Shot 2019-09-25 at 8 45 28 PM" src="https://user-images.githubusercontent.com/1100717/65649863-4ed3a780-dfd6-11e9-9099-65c718ba3785.png">

## Syntax

<img width="795" alt="Screen Shot 2019-09-25 at 8 45 40 PM" src="https://user-images.githubusercontent.com/1100717/65649865-53985b80-dfd6-11e9-9e40-dcb9b114ecea.png">
