### PR TITLE
Fixing bug where private cubes are shown in recently updated list

### DIFF
--- a/app.js
+++ b/app.js
@@ -140,14 +140,16 @@ app.get('/', function(req, res) {
 
   if (req.user) user_id = req.user._id;
   Cube.find({
-    'card_count': {
-      $gt: 200
-    },
     $or: [{
-      'isListed': true
-    }, {
-      'isListed': null
-    }, {
+      $and: [{
+        'card_count': {
+          $gt: 200
+        }
+      }, {
+        'isListed': true
+      }]
+    },
+    {
       'owner': user_id
     }]
   }).sort({

--- a/app.js
+++ b/app.js
@@ -141,17 +141,18 @@ app.get('/', function(req, res) {
   if (req.user) user_id = req.user._id;
   Cube.find({
     $or: [{
-      $and: [{
-        'card_count': {
-          $gt: 200
-        }
-      }, {
-        'isListed': true
-      }]
-    },
-    {
-      'owner': user_id
-    }]
+        $and: [{
+          'card_count': {
+            $gt: 200
+          }
+        }, {
+          'isListed': true
+        }]
+      },
+      {
+        'owner': user_id
+      }
+    ]
   }).sort({
     'date_updated': -1
   }).limit(12).exec(function(err, result) {


### PR DESCRIPTION
This PR should fix bug #514 

I changed the cube find function to make sure the cube for "recents" has `isListed: true` and that `card_count` is greater than 200.

It also shows your own cubes still... 