### PR TITLE
#546 Status Filter in Advanced view issue

### DIFF
--- a/src/components/FilterCollapse.js
+++ b/src/components/FilterCollapse.js
@@ -76,8 +76,8 @@ const AdvancedFilterModal = ({ isOpen, toggle, apply, values, onChange, ...props
             <InputGroupText>Status</InputGroupText>
           </InputGroupAddon>
           <Input type="select" name="status" value={values.status} onChange={onChange}>
-            {['', 'Not Owned', 'Ordered', 'Owned', 'Premium Owned'].map(status =>
-              <option key={status}>{status}</option>
+            {['', '\"Not Owned\"', 'Ordered', 'Owned', '\"Premium Owned\"'].map(status =>
+              <option key={ status }>{status.replace(/[""]+/g, '')}</option>
             )}
           </Input>
         </InputGroup>
@@ -163,7 +163,7 @@ class FilterCollapse extends Component {
 
   handleChange(event) {
     const target = event.target;
-    const value = ['checkbox', 'radio'].includes(target.type) ? target.checked : target.value;
+    var value = ['checkbox', 'radio'].includes(target.type) ? target.checked : target.value;
     const name = target.name;
     const extra = {};
 

--- a/src/components/FilterCollapse.js
+++ b/src/components/FilterCollapse.js
@@ -163,7 +163,7 @@ class FilterCollapse extends Component {
 
   handleChange(event) {
     const target = event.target;
-    var value = ['checkbox', 'radio'].includes(target.type) ? target.checked : target.value;
+    const value = ['checkbox', 'radio'].includes(target.type) ? target.checked : target.value;
     const name = target.name;
     const extra = {};
 

--- a/src/components/FilterCollapse.js
+++ b/src/components/FilterCollapse.js
@@ -76,8 +76,8 @@ const AdvancedFilterModal = ({ isOpen, toggle, apply, values, onChange, ...props
             <InputGroupText>Status</InputGroupText>
           </InputGroupAddon>
           <Input type="select" name="status" value={values.status} onChange={onChange}>
-            {['', '\"Not Owned\"', 'Ordered', 'Owned', '\"Premium Owned\"'].map(status =>
-              <option key={ status }>{status.replace(/[""]+/g, '')}</option>
+            {['', 'Not Owned', 'Ordered', 'Owned', 'Premium Owned'].map(status =>
+              <option key={ status }>{status}</option>
             )}
           </Input>
         </InputGroup>
@@ -131,6 +131,10 @@ class FilterCollapse extends Component {
     const tokens = [];
     for (const name of allFields) {
       if (this.state[name]) {
+        if (name == "status")
+        {
+          this.state[name] = "\"" + this.state[name] + "\"";
+        }
         const op = numFields.includes(name) ? (this.state[name + 'Op'] || '=') : ':';
         tokens.push(name + op + this.state[name]);
       }

--- a/src/components/FilterCollapse.js
+++ b/src/components/FilterCollapse.js
@@ -77,7 +77,7 @@ const AdvancedFilterModal = ({ isOpen, toggle, apply, values, onChange, ...props
           </InputGroupAddon>
           <Input type="select" name="status" value={values.status} onChange={onChange}>
             {['', 'Not Owned', 'Ordered', 'Owned', 'Premium Owned'].map(status =>
-              <option key={ status }>{status}</option>
+              <option key={status}>{status}</option>
             )}
           </Input>
         </InputGroup>

--- a/src/components/FilterCollapse.js
+++ b/src/components/FilterCollapse.js
@@ -130,7 +130,7 @@ class FilterCollapse extends Component {
     // Advanced Filter change. Render to filter input.
     const tokens = [];
     for (const name of allFields) {
-      if (this.state[name]) {        
+      if (this.state[name]) {
         const op = numFields.includes(name) ? (this.state[name + 'Op'] || '=') : ':';
         tokens.push(name + op + this.state[name]);
       }

--- a/src/components/FilterCollapse.js
+++ b/src/components/FilterCollapse.js
@@ -130,11 +130,7 @@ class FilterCollapse extends Component {
     // Advanced Filter change. Render to filter input.
     const tokens = [];
     for (const name of allFields) {
-      if (this.state[name]) {
-        if (name == "status")
-        {
-          this.state[name] = "\"" + this.state[name] + "\"";
-        }
+      if (this.state[name]) {        
         const op = numFields.includes(name) ? (this.state[name + 'Op'] || '=') : ':';
         tokens.push(name + op + this.state[name]);
       }

--- a/src/util/Filter.js
+++ b/src/util/Filter.js
@@ -575,11 +575,11 @@ function filterApply(card, filter) {
   }
   if (filter.category == 'tag') {
     res = card.tags.some(element => {
-      return element.toLowerCase() == filter.arg;
+      return element.toLowerCase() == filter.arg.toLowerCase();
     });
   }
   if (filter.category == 'status') {
-    if (card.status == filter.arg) {
+    if (card.status.toLowerCase() == filter.arg.toLowerCase()) {
       res = true;
     }
   }

--- a/src/util/Filter.js
+++ b/src/util/Filter.js
@@ -579,7 +579,7 @@ function filterApply(card, filter) {
     });
   }
   if (filter.category == 'status') {
-    if (card.status.toLowerCase() == filter.arg) {
+    if (card.status == filter.arg) {
       res = true;
     }
   }


### PR DESCRIPTION
I tried two approaches to get the status filter working with Advanced View

1) The one in this PR was to add the quotes to the statuses that have more than one word, then remove the quotes on the dropdown options.  This doesn't seem to work as the value which goes in the Filter textbox ends up with no quotes.  If you remove the replace function, then the quotes show up in the dropdown, but also correctly show up in the Filter textbox

2) Forcing the quotes to be added after the status is selected in the dropdown within the HandleChange function.  This worked in that the Filter textbox shows the status with quotes around it, but breaks the dropdown prepopulation presumably since it doesn't match the original text which has no quotes