### PR TITLE
add python-version to gitignore for users of pyenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 private/
 /dist/
 
+.python-version
+
 # Created by https://www.gitignore.io/api/node,komodoedit,webstorm+all,visualstudio,visualstudiocode
 # Edit at https://www.gitignore.io/?templates=node,komodoedit,webstorm+all,visualstudio,visualstudiocode
 


### PR DESCRIPTION
This pull request adds the `.python-version` file generated by pyenv to the gitignore. This is useful for developers who use pyenv/python to facilitate their work on CubeCobra.