### PR TITLE
Handle half-integer CMCs and large CMCs.

### DIFF
--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -543,6 +543,9 @@ function getLabels(sort) {
     return ['0', '1', '2', '3', '4', '5', '6', '7', '8+'];
   } else if (sort == 'CMC2') {
     return ['0-1', '2', '3', '4', '5', '6', '7+'];
+  } else if (sort == 'CMC-Full') {
+    // All CMCs from 0-16, with halves included, plus Gleemax at 1,000,000.
+    return [...Array(33).keys()].map(x => (x / 2).toString()).concat(['1000000']);
   } else if (sort == 'Color') {
     return ['White', 'Blue', 'Black', 'Red', 'Green', 'Colorless'];
   } else if (sort == 'Type') {

--- a/public/js/sortfilter.js
+++ b/public/js/sortfilter.js
@@ -44,6 +44,14 @@ function price_bucket_label(index) {
   }
 }
 
+function cmcToNumber(cmc) {
+  if (isNaN(cmc)) {
+    return cmc.indexOf('.') > -1 ? parseFloat(cmc) : parseInt(cmc);
+  } else {
+    return cmc;
+  }
+}
+
 function cardIsLabel(card, label, sort) {
   if (sort == 'Color Category') {
     return GetColorCategory(card.type_line, card.colors) == label;
@@ -83,20 +91,23 @@ function cardIsLabel(card, label, sort) {
         return card.colors.length == 5;
     }
   } else if (sort == 'CMC') {
-    if (isNaN(card.cmc)) {
-      card.cmc = parseInt(card.cmc);
-    }
-    if (card.cmc >= 8) {
+    // Sort by CMC, but collapse all >= 8 into '8+' category.
+    const cmc = Math.round(cmcToNumber(card.cmc || card.details.cmc));
+    if (cmc >= 8) {
       return label == '8+';
     }
-    return card.cmc == label;
+    return cmc == label;
   } else if (sort == 'CMC2') {
-    if (card.cmc >= 7) {
+    const cmc = Math.round(cmcToNumber(card.cmc || card.details.cmc));
+    if (cmc >= 7) {
       return label == '7+';
-    } else if (card.cmc <= 1) {
+    } else if (cmc <= 1) {
       return label == '0-1';
     }
-    return card.cmc == label;
+    return cmc == label;
+  } else if (sort == 'CMC-Full') {
+    // Round to half-integer.
+    return Math.round(cmcToNumber(card.cmc || card.details.cmc) * 2) / 2 == label;
   } else if (sort == 'Supertype' || sort == 'Type') {
     if (card.type_line.includes('Contraption')) {
       return label == 'Contraption';

--- a/src/components/AutocardListGroup.js
+++ b/src/components/AutocardListGroup.js
@@ -5,8 +5,14 @@ import { Col, ListGroup, ListGroupItem, Row } from 'reactstrap';
 import AutocardListItem from './AutocardListItem';
 import GroupModalContext from './GroupModalContext';
 
+const alphaCompare = (a, b) => {
+  const textA = a.details.name.toUpperCase();
+  const textB = b.details.name.toUpperCase();
+  return (textA < textB) ? -1 : (textA > textB) ? 1 : 0;
+};
+
 const AutocardListGroup = ({ cards, heading, primary, secondary, tertiary }) => {
-  let groups = sortIntoGroups(cards, "CMC");
+  const groups = sortIntoGroups(cards, tertiary);
   return (
     <ListGroup className="list-outline">
       <GroupModalContext.Consumer>
@@ -24,26 +30,23 @@ const AutocardListGroup = ({ cards, heading, primary, secondary, tertiary }) => 
           </ListGroupItem>
         }
       </GroupModalContext.Consumer>
-      {
-        getLabels("CMC").filter(cmc => groups[cmc]).map(cmc => (
-          <Row key={cmc} noGutters className="cmc-group">
-            <Col>
-              {
-                groups[cmc].sort(function(a,b)
-                {
-                  const textA = a.details.name.toUpperCase();
-                  const textB =  b.details.name.toUpperCase();
-                  return (textA < textB) ? -1 : (textA > textB) ? 1 : 0;
-                }).map(card =>
-                  (<AutocardListItem key={card.details.name} card={card} />)
-                )
-              }
-            </Col>
-          </Row>
-        ))
-      }
+      {getLabels(tertiary).filter(cmc => groups[cmc]).map(cmc =>
+        <Row key={cmc} noGutters className="cmc-group">
+          <Col>
+            {groups[cmc].sort(alphaCompare).map(card =>
+              <AutocardListItem key={card.details.name} card={card} />
+            )}
+          </Col>
+        </Row>
+      )}
     </ListGroup>
   );
 }
+
+AutocardListGroup.defaultProps = {
+  primary: 'Color Category',
+  secondary: 'Types-Multicolor',
+  tertiary: 'CMC-Full',
+};
 
 export default AutocardListGroup;


### PR DESCRIPTION
This adds a new sort, CMC-Full, which is used only inside the AutocardListGroup component for dividing between CMC groups. It also handles half-integer CMCs correctly, which before just didn't appear in any view.

Fixes #586 and #585.