### PR TITLE
feat(views): add link to drafter profile on decks

### DIFF
--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -2399,16 +2399,32 @@ router.get('/deck/:id', function(req, res) {
           req.flash('danger', 'Cube not found');
           res.status(404).render('misc/404', {});
         } else {
-          var owner_name = "Unknown";
-          var drafter_name = "Anonymous";
-          User.findById(deck.owner, function(err, drafter) {
-            if (drafter) {
-              drafter_name = drafter.username;
+          let owner = {
+            name: 'Unknown',
+            id: null,
+            profileUrl: null
+          };
+
+          let drafter = {
+            name: 'Anonymous',
+            id: null,
+            profileUrl: null
+          };
+
+          User.findById(deck.owner, function(err, deckUser) {
+            if (deckUser) {
+              drafter.name = deckUser.username;
+              drafter.id = deckUser._id;
+              drafter.profileUrl = `/user/view/${deckUser._id}`;
             }
-            User.findById(cube.owner, function(err, owner) {
-              if (owner) {
-                owner_name = owner.username;
+
+            User.findById(cube.owner, function(err, cubeUser) {
+              if (cubeUser) {
+                owner.name = cubeUser.username;
+                owner.id = cubeUser._id;
+                owner.profileUrl = `/user/view/${cubeUser._id}`;
               }
+
               var player_deck = [];
               var bot_decks = [];
               if (typeof deck.cards[deck.cards.length - 1][0] === 'object') {
@@ -2441,10 +2457,10 @@ router.get('/deck/:id', function(req, res) {
                   oldformat: true,
                   cube: cube,
                   cube_id: get_cube_id(cube),
-                  owner: owner_name,
+                  owner: owner,
                   activeLink: 'playtest',
-                  title: `${abbreviate(cube.name)} - ${drafter_name}'s deck`,
-                  drafter: drafter_name,
+                  title: `${abbreviate(cube.name)} - ${drafter.name}'s deck`,
+                  drafter: drafter,
                   cards: player_deck,
                   bot_decks: bot_decks,
                   bots: bot_names,
@@ -2486,10 +2502,10 @@ router.get('/deck/:id', function(req, res) {
                   oldformat: false,
                   cube: cube,
                   cube_id: get_cube_id(cube),
-                  owner: owner_name,
+                  owner: owner,
                   activeLink: 'playtest',
-                  title: `${abbreviate(cube.name)} - ${drafter_name}'s deck`,
-                  drafter: drafter_name,
+                  title: `${abbreviate(cube.name)} - ${drafter.name}'s deck`,
+                  drafter: drafter,
                   deck: JSON.stringify(deck.playerdeck),
                   bot_decks: bot_decks,
                   bots: bot_names,

--- a/views/cube/cube_deck.pug
+++ b/views/cube/cube_deck.pug
@@ -6,7 +6,11 @@ block cube_content
   br
   if oldformat
     .container
-      h4 Drafted by #{drafter}
+      if drafter.profileUrl
+        h4 Drafted by 
+          a(href=drafter.profileUrl) #{drafter.name}
+      else
+        h4 Drafted by #{drafter.name}
       br
       .row
         each card, i in cards
@@ -15,7 +19,11 @@ block cube_content
   else
     .card.card-hover#deckhover
       .card-header
-        h4 Drafted by #{drafter}
+        if drafter.profileUrl
+          h4 Drafted by 
+            a(href=drafter.profileUrl) #{drafter.name}
+        else
+          h4 Drafted by #{drafter.name}
         span#customImageDisplayMenuItem
           input#customImageDisplayToggle(type='checkbox')
           label(for='customImageDisplayToggle') Show Custom Images


### PR DESCRIPTION
Adds a link to the drafter's profile to the deck display page.

<img width="447" alt="decks-profile-link" src="https://user-images.githubusercontent.com/15820761/67647458-cca60e00-f908-11e9-9d63-3df67d8e781e.png">

<img width="441" alt="decks-profile-link-anon" src="https://user-images.githubusercontent.com/15820761/67647492-e34c6500-f908-11e9-845c-49cc4a62254e.png">
