### PR TITLE
feat(views): [Fixes #528] add button for new sample pack

### DIFF
--- a/views/cube/cube_samplepack.pug
+++ b/views/cube/cube_samplepack.pug
@@ -9,8 +9,9 @@ block cube_content
         .row
           .col-md-6
             h5.card-title Sample Pack
-          .col-md-6
-            a.float-right(href=`/cube/samplepackimage/${cube_id}/${seed}`) Get Image
+          .col-md-6.text-right
+            a.btn.btn-success.mr-2(href=`/cube/samplepack/${cube_id}`) New Pack
+            a.btn.btn-success(href=`/cube/samplepackimage/${cube_id}/${seed}`) Get Image
       .card-body
         .samplepack.row
           if pack


### PR DESCRIPTION
Add a button to generate a new Sample Pack.

<img width="954" alt="random-pack" src="https://user-images.githubusercontent.com/15820761/67648862-4213dd80-f90d-11e9-85ce-d5cf40ae606f.png">

Note that this doesn't fix the existing alignment issue on mobile. Which probably just involves centering the buttons when the column wraps.

<img width="317" alt="random-pack-sml" src="https://user-images.githubusercontent.com/15820761/67648863-4213dd80-f90d-11e9-8f24-b5812efff160.png">

The vast majority of the buttons on this site are `success`, which I guess works for the green color scheme. I'm not particularly fond of having two success buttons next to each other, so I'd recommend either modifying the `info` or `secondary` button colors to allow for some more flexibility while keeping the color scheme. Or going with `light`, which matches the existing display pretty well - though I think I'd flip the buttons if that's the choice.

<img width="234" alt="random-pack-light" src="https://user-images.githubusercontent.com/15820761/67648960-9b7c0c80-f90d-11e9-8631-c901c0430fdd.png">
