### PR TITLE
Fixed up code for percentages in Type Breakdown

### DIFF
--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -420,3 +420,19 @@ div.card {
   body.busy-cursor {
 	cursor: progress;
   }
+
+
+/* Styles for Analysis */
+
+.breakdown .percent {
+  display: inline-block;
+  font-size: 0.875rem;
+  color: #535A5F;
+  margin-left: 0.5em;
+}
+.breakdown .percent::before {
+  content: "(";
+}
+.breakdown .percent::after {
+  content: ")";
+}

--- a/src/components/TypeAnalysis.js
+++ b/src/components/TypeAnalysis.js
@@ -24,7 +24,7 @@ const TypeAnalysis = ({ typeByColor, ...props }) => (
           <tr>
             <th scope="col" />
             {colors.map(([name, _, short]) =>
-              <th scope="col">
+              <th key={name + "col"} scope="col">
                 {name === 'Total' ? 'Total' :
                   <img key={short} src={`/content/symbols/${short}.png`} alt={name} title={name} />
                 }
@@ -32,18 +32,19 @@ const TypeAnalysis = ({ typeByColor, ...props }) => (
             )}
           </tr>
         </thead>
-        <tbody>
+        <tbody className="breakdown">
           {types.map(type =>
-            <tr>
+            <tr key={type + "row"}>
               <th scope="row">{type}</th>
               {colors.map(([name, path, _]) => {
-                count = typeByColor[type][path];
-                color_total = typeByColor['Total'];
-                if (name !== 'Total' && path !== 'Total' && count > 1 && color_total > count) {
-                  percent = Number.parseFloat(count / color_total * 100.0).toFixed(1);
-                  return <td>{count}<span class="percent">{percent}%</span></td>;
+                const reactKey = type + path;
+                const count = typeByColor[type][path];
+                const colorTotal = typeByColor['Total'][path];
+                if (name !== 'Total' && path !== 'Total' && count > 1 && colorTotal > count) {
+                  const percent = Math.round(count / colorTotal * 100.0);
+                  return <td key={reactKey}>{count}<span className="percent">{percent}%</span></td>;
                 } else {
-                  return <td>{count}</td>;
+                  return <td key={reactKey}>{count}</td>;
                 }
               })}
             </tr>


### PR DESCRIPTION
Actual working code for the Type Breakdown percentages.

Saw React was giving some warnings about keys as well, so added a key until it stopped complaining.

Included some quick css changes, percentages surrounded with brackets, slightly smaller and lighter (but still within accessibility guidelines).