### PR TITLE
Fix bottom of autocard popup lingering

### DIFF
--- a/public/js/autocard.js
+++ b/public/js/autocard.js
@@ -138,14 +138,14 @@ function autocard_show_card(card_image, card_flip, show_art_crop, tags) {
 }
 
 function autocard_hide_card() {
-  document.getElementById("autocard_popup").innerHTML = '';
-  document.getElementById("autocard_popup2").innerHTML = '';
-  document.getElementById("autocard_popup_info").innerHTML = '';
-
   // clear any load events that haven't fired yet so that they don't fire after the card should be hidden
   if (autocardTimeout) autocardTimeout = clearTimeout(autocardTimeout);
   $(document.getElementById("autocard_popup")).find('img').off('load');
   $(document.getElementById("autocard_popup2")).find('img').off('load');
+
+  document.getElementById("autocard_popup").innerHTML = '';
+  document.getElementById("autocard_popup2").innerHTML = '';
+  document.getElementById("autocard_popup_info").innerHTML = '';
 
   $(document.getElementById("autocard_popup")).hide();
   $(document.getElementById("autocard_popup2")).hide();


### PR DESCRIPTION
This issue (#552) was caused by the image unloading handler being run
erroneously after the autocard_hide handler attempts to remove its
events. This is difficult to spot in most cases but becomes easily
reproducible if the tester disables caching and sets throttling to
something very low (on Firefox/Windows 10, "Regular 2G" did the trick...
set this after the cube list loads or you could be waiting a while).
On fast network connections, this would rarely be an issue, as the image
would load properly faster than the user could move their mouse off the
image, and browser caching prevents them from trying again on the same
card.

The issue was that innerHtml on the image container was being cleared
before the event handlers were canceled. Clearing this property removes
the child nodes from the document, meaning the queries in the lines
afterward do not find them and thus do not remove the event handler. 
The event handler fires, showing the (now-empty) popup if the
tags variable was captured with something in it.

Clearing the events properly fixes the bug, and it can no longer be
reproduced even with throttling/nocache.