### PR TITLE
Enable Single Char Rarity Args With Map

### DIFF
--- a/src/util/Filter.js
+++ b/src/util/Filter.js
@@ -215,9 +215,6 @@ function simplifyArg(arg, category) {
       res = parseManaCost(res)
       break;
     case 'rarity':
-      console.log(rarityMap);
-      console.log(res);
-      console.log(rarityMap.get(res));
       res = rarityMap.get(res) || res;
       break;
   }

--- a/src/util/Filter.js
+++ b/src/util/Filter.js
@@ -194,6 +194,13 @@ const colorMap = new Map([
   ['temur', 'rug']
 ]);
 
+const rarityMap = new Map([
+    ['c', 'common'],
+    ['u', 'uncommon'],
+    ['r', 'rare'],
+    ['m', 'mythic']
+]);
+
 //change arguments into their verifiable counteraprts, i.e. 'azorius' becomes 'uw'
 function simplifyArg(arg, category) {
   let res = '';
@@ -209,6 +216,14 @@ function simplifyArg(arg, category) {
       break;
     case 'mana':
       res = parseManaCost(arg)
+      break;
+    case 'rarity':
+      let argLower = arg.toLowerCase()
+      if (rarityMap.has(argLower)) {
+        res = rarityMap.get(argLower);
+      } else {
+        res = arg;
+      }
       break;
     default:
       res = arg;

--- a/src/util/Filter.js
+++ b/src/util/Filter.js
@@ -195,34 +195,30 @@ const colorMap = new Map([
 ]);
 
 const rarityMap = new Map([
-    ['c', 'common'],
-    ['u', 'uncommon'],
-    ['r', 'rare'],
-    ['m', 'mythic']
-]);
-
-const simplifyCategoryMaps = new Map([
-    ['color', colorMap],
-    ['identity', colorMap],
-    ['rarity', rarityMap]
+  ['c', 'common'],
+  ['u', 'uncommon'],
+  ['r', 'rare'],
+  ['m', 'mythic']
 ]);
 
 
 //change arguments into their verifiable counteraprts, i.e. 'azorius' becomes 'uw'
 function simplifyArg(arg, category) {
-  let res = arg;
-  if (simplifyCategoryMaps.has(category)) {
-      let map = simplifyCategoryMaps.get(category);
-      let argLower = arg.toLowerCase()
-      res = map.has(argLower) ? map.get(argLower) : arg;
-  }
+  let res = arg.toLowerCase();
   switch (category) {
     case 'color':
     case 'identity':
+      res = colorMap.get(res) || res;
       res = res.toUpperCase().split('');
       break;
     case 'mana':
       res = parseManaCost(res)
+      break;
+    case 'rarity':
+      console.log(rarityMap);
+      console.log(res);
+      console.log(rarityMap.get(res));
+      res = rarityMap.get(res) || res;
       break;
   }
   return res;

--- a/src/util/Filter.js
+++ b/src/util/Filter.js
@@ -201,32 +201,28 @@ const rarityMap = new Map([
     ['m', 'mythic']
 ]);
 
+const simplifyCategoryMaps = new Map([
+    ['color', colorMap],
+    ['identity', colorMap],
+    ['rarity', rarityMap]
+]);
+
+
 //change arguments into their verifiable counteraprts, i.e. 'azorius' becomes 'uw'
 function simplifyArg(arg, category) {
-  let res = '';
+  let res = arg;
+  if (simplifyCategoryMaps.has(category)) {
+      let map = simplifyCategoryMaps.get(category);
+      let argLower = arg.toLowerCase()
+      res = map.has(argLower) ? map.get(argLower) : arg;
+  }
   switch (category) {
     case 'color':
     case 'identity':
-      if (colorMap.has(arg.toLowerCase())) {
-        res = colorMap.get(arg.toLowerCase());
-      } else {
-        res = arg;
-      }
       res = res.toUpperCase().split('');
       break;
     case 'mana':
-      res = parseManaCost(arg)
-      break;
-    case 'rarity':
-      let argLower = arg.toLowerCase()
-      if (rarityMap.has(argLower)) {
-        res = rarityMap.get(argLower);
-      } else {
-        res = arg;
-      }
-      break;
-    default:
-      res = arg;
+      res = parseManaCost(res)
       break;
   }
   return res;


### PR DESCRIPTION
Add a map to use in simplifyArg to enable queries using just the first character of a rarity as the argument. An example would be `r:m` for finding mythics. A possible implementation for #537.