### PR TITLE
Allow half values for cmc as well as negative values for power/toughness

### DIFF
--- a/src/util/Filter.js
+++ b/src/util/Filter.js
@@ -250,9 +250,13 @@ const verifyTokens = (tokens) => {
             return false;
           }
           break;
-        case 'cmc':
         case 'power':
         case 'toughness':
+          if (token(i).arg.search(/^[-\+]?((\d+(\.5)?)|(\.5))$/) < 0) return false;
+          break;
+        case 'cmc':
+          if (token(i).arg.search(/^\+?((\d+(\.5)?)|(\.5))$/) < 0) return false;
+          break;
         case 'loyalty':
           if (token(i).arg.search(/^\d+$/) < 0) return false;
           break;


### PR DESCRIPTION
Fix for #681 plus the fractional part. Note [[little girl]] does not show up with `power:0.5`, but will show up with `power:.5` which is why the regexes got so complicated. 