### PR TITLE
Fix issue where you had to double-click on dropdowns.

### DIFF
--- a/public/js/editcube.js
+++ b/public/js/editcube.js
@@ -214,7 +214,10 @@ function updateCollapse() {
   if (val.length > 0) {
     $('.editForm').collapse('show');
   } else {
-    $('.editForm').collapse('hide');
+    const el = $('.editForm');
+    if (el.collapse) {
+      el.collapse('hide');
+    }
   }
 
   autocard_init('dynamic-autocard');

--- a/views/cube/cube_list.pug
+++ b/views/cube/cube_list.pug
@@ -114,6 +114,4 @@ block cube_content
   script(src='/js/sortfilter.js')
   script(src='/js/tags.js')
   script(src='/js/editcube.js')
-  // FIXME: this can be removed once edit collapse is in React.
-  script(src='/bower_components/bootstrap/dist/js/bootstrap.js')  
   script(src='/js/cube_list.bundle.js')


### PR DESCRIPTION
Dropdown menus on the cube list page had to be clicked twice due to including bootstrap twice.