### PR TITLE
Save current changelist in localStorage.

### DIFF
--- a/src/components/ChangelistContext.js
+++ b/src/components/ChangelistContext.js
@@ -1,21 +1,34 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 const ChangelistContext = React.createContext([]);
 
-export const ChangelistContextProvider = (props) => {
-  const [changes, setChanges] = useState([]);
-  const addChange = useCallback((change) => {
-    setChanges((changes) => {
-      const highestId = Math.max(changes.map((change) => change.id));
-      return [
-        ...changes,
-        {
-          ...change,
-          id: highestId + 1,
-        },
-      ];
-    });
+export const ChangelistContextProvider = ({ cubeID, ...props }) => {
+  const storageKey = `changelist-${cubeID}`;
+
+  const [changes, setChanges] = useState(() => {
+    if (localStorage && typeof cubeID !== 'undefined') {
+      return JSON.parse(localStorage.getItem(storageKey) || '[]');
+    } else {
+      return [];
+    }
   });
+
+  useEffect(() => {
+    if (localStorage && typeof cubeID !== 'undefined') {
+      localStorage.setItem(storageKey, JSON.stringify(changes));
+    }
+  }, [changes]);
+
+  const addChange = useCallback((change) => {
+    const highestId = Math.max(changes.map((change) => change.id));
+    setChanges([
+      ...changes,
+      {
+        ...change,
+        id: highestId + 1,
+      },
+    ]);
+  }, [changes]);
   const removeChange = useCallback((changeId) => {
     setChanges((changes) => changes.filter((change) => change.id !== changeId));
   });

--- a/src/components/ChangelistContext.js
+++ b/src/components/ChangelistContext.js
@@ -19,16 +19,19 @@ export const ChangelistContextProvider = ({ cubeID, ...props }) => {
     }
   }, [changes]);
 
-  const addChange = useCallback((change) => {
-    const highestId = Math.max(changes.map((change) => change.id));
-    setChanges([
-      ...changes,
-      {
-        ...change,
-        id: highestId + 1,
-      },
-    ]);
-  }, [changes]);
+  const addChange = useCallback(
+    (change) => {
+      const highestId = Math.max(changes.map((change) => change.id));
+      setChanges([
+        ...changes,
+        {
+          ...change,
+          id: highestId + 1,
+        },
+      ]);
+    },
+    [changes],
+  );
   const removeChange = useCallback((changeId) => {
     setChanges((changes) => changes.filter((change) => change.id !== changeId));
   });

--- a/src/cube_list.js
+++ b/src/cube_list.js
@@ -23,9 +23,16 @@ class CubeList extends Component {
   constructor(props) {
     super(props);
 
+    let openCollapse = null;
+    if (props.cubeID && localStorage.getItem(`changelist-${props.cubeID}`)) {
+      openCollapse = 'edit';
+    } else if (Hash.get('f', false)) {
+      openCollapse = 'filter';
+    }
+
     this.state = {
       cubeView: Hash.get('view', 'table'),
-      openCollapse: Hash.get('f', false) ? 'filter' : null,
+      openCollapse,
       filter: [],
     };
 
@@ -71,7 +78,7 @@ class CubeList extends Component {
             defaultShowTagColors={defaultShowTagColors}
             defaultTags={defaultTags}
           >
-            <ChangelistContextProvider>
+            <ChangelistContextProvider cubeID={cubeID}>
               <CardModalForm canEdit={canEdit} setOpenCollapse={this.setOpenCollapse}>
                 <GroupModal cubeID={cubeID} canEdit={canEdit} setOpenCollapse={this.setOpenCollapse}>
                   <CubeListNavbar


### PR DESCRIPTION
This prevents site crashes, etc. from wiping out peoples' changelists, a complaint we've gotten in the past.