### PR TITLE
Deck Updates

### DIFF
--- a/models/deck.js
+++ b/models/deck.js
@@ -59,8 +59,8 @@ let deckSchema = mongoose.Schema({
   },
   comments: {
     type: [Comment],
-    default: []
-  }
+    default: [],
+  },
 });
 
 let Deck = (module.exports = mongoose.model('Deck', deckSchema));

--- a/models/deck.js
+++ b/models/deck.js
@@ -1,5 +1,25 @@
 let mongoose = require('mongoose');
 
+//this pattern lets us define comment recursively
+var Comment = new mongoose.Schema();
+Comment.add({
+  owner: String,
+  ownerName: String,
+  content: String,
+  index: Number,
+  timePosted: Date,
+  comments: [Comment],
+  updated: Boolean,
+  image: {
+    type: String,
+    default: 'https://img.scryfall.com/cards/art_crop/front/0/c/0c082aa8-bf7f-47f2-baf8-43ad253fd7d7.jpg?1562826021',
+  },
+  artist: {
+    type: String,
+    default: 'Allan Pollack',
+  },
+});
+
 // Cube schema
 let deckSchema = mongoose.Schema({
   cards: [[]],
@@ -37,6 +57,10 @@ let deckSchema = mongoose.Schema({
     type: Boolean,
     default: false,
   },
+  comments: {
+    type: [Comment],
+    default: []
+  }
 });
 
 let Deck = (module.exports = mongoose.model('Deck', deckSchema));

--- a/models/deck.js
+++ b/models/deck.js
@@ -29,6 +29,10 @@ let deckSchema = mongoose.Schema({
     type: String,
     default: '',
   },
+  description: {
+    type: String,
+    default: 'No description available.',
+  },
   newformat: {
     type: Boolean,
     default: false,

--- a/public/js/deleteconfirm.js
+++ b/public/js/deleteconfirm.js
@@ -19,7 +19,7 @@ $('.delete-cube').on('click', function(e) {
     if (!response.ok) {
       console.log(response);
     } else {
-      window.location.href = '';
+      window.location.href = '/';
     }
   });
 });

--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -2545,7 +2545,7 @@ router.post('/submitdeck/:id', async (req, res) => {
     var [user, cubeOwner] = await Promise.all([userq, cubeOwnerq]);
 
     var owner = user ? user.username : 'Anonymous';
-    deck.name = "Draft of " + cube.name;
+    deck.name = 'Draft of ' + cube.name;
     deck.username = owner;
     deck.cubename = cube.name;
     cube.decks.push(deck._id);

--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -2830,6 +2830,8 @@ router.get('/deck/:id', async (req, res) => {
         cards: player_deck,
         bot_decks: bot_decks,
         bots: bot_names,
+        name: deck.name,
+        description: deck.description,
         metadata: generateMeta(
           `Cube Cobra Deck: ${cube.name}`,
           cube.type ? `${cube.card_count} Card ${cube.type} Cube` : `${cube.card_count} Card Cube`,
@@ -2872,6 +2874,8 @@ router.get('/deck/:id', async (req, res) => {
         sideboard: JSON.stringify(deck.playersideboard),
         bot_decks: bot_decks,
         bots: bot_names,
+        name: deck.name,
+        description: deck.description,
         metadata: generateMeta(
           `Cube Cobra Deck: ${cube.name}`,
           cube.type ? `${cube.card_count} Card ${cube.type} Cube` : `${cube.card_count} Card Cube`,

--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -2832,6 +2832,7 @@ router.get('/deck/:id', async (req, res) => {
         bots: bot_names,
         name: deck.name,
         description: deck.description,
+        owner: deck.owner,
         metadata: generateMeta(
           `Cube Cobra Deck: ${cube.name}`,
           cube.type ? `${cube.card_count} Card ${cube.type} Cube` : `${cube.card_count} Card Cube`,
@@ -2876,6 +2877,7 @@ router.get('/deck/:id', async (req, res) => {
         bots: bot_names,
         name: deck.name,
         description: deck.description,
+        owner: deck.owner,
         metadata: generateMeta(
           `Cube Cobra Deck: ${cube.name}`,
           cube.type ? `${cube.card_count} Card ${cube.type} Cube` : `${cube.card_count} Card Cube`,

--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -2473,7 +2473,7 @@ router.post('/submitdeck/:id', async (req, res) => {
     var [user, cubeOwner] = await Promise.all([userq, cubeOwnerq]);
 
     var owner = user ? user.username : 'Anonymous';
-    deck.name = owner + "'s draft of " + cube.name + ' on ' + deck.date.toLocaleString('en-US');
+    deck.name = "Draft of " + cube.name;
     deck.username = owner;
     deck.cubename = cube.name;
     cube.decks.push(deck._id);

--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -2858,6 +2858,7 @@ router.get('/deck/:id', async (req, res) => {
       for (i = 0; i < deck.bots.length; i++) {
         bot_names.push('Seat ' + (i + 2) + ': ' + deck.bots[i][0] + ', ' + deck.bots[i][1]);
       }
+      console.log(deck);
       return res.render('cube/cube_deck', {
         oldformat: false,
         deckid: deck._id,
@@ -2868,6 +2869,7 @@ router.get('/deck/:id', async (req, res) => {
         title: `${abbreviate(cube.name)} - ${drafter.name}'s deck`,
         drafter: drafter,
         deck: JSON.stringify(deck.playerdeck),
+        sideboard: JSON.stringify(deck.playersideboard),
         bot_decks: bot_decks,
         bots: bot_names,
         metadata: generateMeta(

--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -2413,11 +2413,15 @@ router.post('/editdeck/:id', async (req, res) => {
     }
 
     var newdeck = JSON.parse(req.body.draftraw);
+    var name = JSON.parse(req.body.name);
+    var description = sanitize(JSON.parse(req.body.description));
 
     deck.cards = newdeck.cards;
     deck.playerdeck = newdeck.playerdeck;
     deck.playersideboard = newdeck.playersideboard;
     deck.cols = newdeck.cols;
+    deck.name = name;
+    deck.description = description;
 
     await deck.save();
 
@@ -2861,7 +2865,6 @@ router.get('/deck/:id', async (req, res) => {
       for (i = 0; i < deck.bots.length; i++) {
         bot_names.push('Seat ' + (i + 2) + ': ' + deck.bots[i][0] + ', ' + deck.bots[i][1]);
       }
-      console.log(deck);
       return res.render('cube/cube_deck', {
         oldformat: false,
         deckid: deck._id,

--- a/src/components/BlogPost.js
+++ b/src/components/BlogPost.js
@@ -111,7 +111,7 @@ class BlogPost extends React.Component {
         </div>
         {this.props.loggedIn && (
           <CardBody className="px-4 pt-2 pb-0 border-top">
-            <CommentEntry id={post._id} position={[]} onPost={this.onPost}>
+            <CommentEntry id={post._id} position={[]} onPost={this.onPost} submitUrl={`/cube/api/postcomment`}>
               <h6 className="comment-button mb-2 text-muted clickable">Add Comment</h6>
             </CommentEntry>
           </CardBody>
@@ -128,6 +128,7 @@ class BlogPost extends React.Component {
               loggedIn={this.props.loggedIn}
               submitEdit={this.submitEdit}
               focused={this.props.focused}
+              submitUrl={`/cube/api/postcomment`}
             />
           </CardBody>
         )}

--- a/src/components/Comment.js
+++ b/src/components/Comment.js
@@ -179,7 +179,12 @@ class Comment extends React.Component {
             </Collapse>
             {this.props.position.length < 20 && this.props.loggedIn && (
               <div>
-                <CommentEntry id={this.props.id} position={this.props.position} onPost={this.onPost}  submitUrl={this.props.submitUrl}>
+                <CommentEntry
+                  id={this.props.id}
+                  position={this.props.position}
+                  onPost={this.onPost}
+                  submitUrl={this.props.submitUrl}
+                >
                   <span className="comment-button mb-2 text-muted clickable">Reply</span>
                 </CommentEntry>
               </div>

--- a/src/components/Comment.js
+++ b/src/components/Comment.js
@@ -179,7 +179,7 @@ class Comment extends React.Component {
             </Collapse>
             {this.props.position.length < 20 && this.props.loggedIn && (
               <div>
-                <CommentEntry id={this.props.id} position={this.props.position} onPost={this.onPost}>
+                <CommentEntry id={this.props.id} position={this.props.position} onPost={this.onPost}  submitUrl={this.props.submitUrl}>
                   <span className="comment-button mb-2 text-muted clickable">Reply</span>
                 </CommentEntry>
               </div>
@@ -199,6 +199,7 @@ class Comment extends React.Component {
               loggedIn={this.props.loggedIn}
               submitEdit={this.props.submitEdit}
               focused={this.props.focused && this.props.focused.length > 0 ? this.props.focused : this.props.focused}
+              submitUrl={this.props.submitUrl}
             />
           </div>
         )}

--- a/src/components/CommentEntry.js
+++ b/src/components/CommentEntry.js
@@ -26,7 +26,7 @@ class CommentEntry extends React.Component {
         inputValue: '',
       });
 
-      const response = await csrfFetch(`/cube/api/postcomment`, {
+      const response = await csrfFetch(this.props.submitUrl, {
         method: 'POST',
         body: JSON.stringify({
           id: this.props.id,

--- a/src/components/CommentsSection.js
+++ b/src/components/CommentsSection.js
@@ -36,6 +36,7 @@ class CommentsSection extends React.Component {
                     userid={this.props.userid}
                     loggedIn={this.props.loggedIn}
                     submitEdit={this.props.submitEdit}
+                    submitUrl={this.props.submitUrl}
                   />
                 ))}
             ></PagedList>

--- a/src/components/DeckPreview.js
+++ b/src/components/DeckPreview.js
@@ -8,33 +8,24 @@ class DeckPreview extends React.Component {
   }
 
   render() {
+    const maxLength = 35;
+
     const deck = this.props.deck;
+    if(deck.name.length > maxLength) {
+      deck.name = deck.name.slice(0,maxLength - 3)+'...';
+    }
     return (
       <a className="no-underline-hover" href={'/cube/deck/' + deck._id}>
         <div className="border-top pb-2 pt-3 px-2 deck-preview">
-          {
-            deck.name.length <= 30 ?
-            <h6 className="card-subtitle mb-2 text-muted">
-              <a href={'/cube/deck/' + deck._id}>
-                {deck.name}
-              </a>
-              {' by '}
-              {deck.owner ? <a href={'/user/view/' + deck.owner}>{deck.username}</a> : <a>Anonymous</a>}{' '}
-              {' - '}
-              <AgeText date={deck.date} />
-            </h6>
-
-            :
-            <h6 className="card-subtitle mb-2 text-muted">
-              {deck.owner ? <a href={'/user/view/' + deck.owner}>{deck.username}</a> : <a>Anonymous</a>}{' '}
-              <a href={'/cube/deck/' + deck._id}>
-                {'drafted '}
-                {deck.cubename}
-              </a>
-              {' - '}
-              <AgeText date={deck.date} />
-            </h6>
-          }
+          <h6 className="card-subtitle mb-2 text-muted">
+            <a href={'/cube/deck/' + deck._id}>
+              {deck.name}
+            </a>
+            {' by '}
+            {deck.owner ? <a href={'/user/view/' + deck.owner}>{deck.username}</a> : <a>Anonymous</a>}{' '}
+            {' - '}
+            <AgeText date={deck.date} />
+          </h6>
         </div>
       </a>
     );

--- a/src/components/DeckPreview.js
+++ b/src/components/DeckPreview.js
@@ -11,19 +11,16 @@ class DeckPreview extends React.Component {
     const maxLength = 35;
 
     const deck = this.props.deck;
-    if(deck.name.length > maxLength) {
-      deck.name = deck.name.slice(0,maxLength - 3)+'...';
+    if (deck.name.length > maxLength) {
+      deck.name = deck.name.slice(0, maxLength - 3) + '...';
     }
     return (
       <a className="no-underline-hover" href={'/cube/deck/' + deck._id}>
         <div className="border-top pb-2 pt-3 px-2 deck-preview">
           <h6 className="card-subtitle mb-2 text-muted">
-            <a href={'/cube/deck/' + deck._id}>
-              {deck.name}
-            </a>
+            <a href={'/cube/deck/' + deck._id}>{deck.name}</a>
             {' by '}
-            {deck.owner ? <a href={'/user/view/' + deck.owner}>{deck.username}</a> : <a>Anonymous</a>}{' '}
-            {' - '}
+            {deck.owner ? <a href={'/user/view/' + deck.owner}>{deck.username}</a> : <a>Anonymous</a>} {' - '}
             <AgeText date={deck.date} />
           </h6>
         </div>

--- a/src/components/DeckPreview.js
+++ b/src/components/DeckPreview.js
@@ -12,15 +12,29 @@ class DeckPreview extends React.Component {
     return (
       <a className="no-underline-hover" href={'/cube/deck/' + deck._id}>
         <div className="border-top pb-2 pt-3 px-2 deck-preview">
-          <h6 className="card-subtitle mb-2 text-muted">
-            {deck.owner ? <a href={'/user/view/' + deck.owner}>{deck.username}</a> : <a>Anonymous</a>}{' '}
-            <a href={'/cube/deck/' + deck._id}>
-              {'drafted '}
-              {deck.cubename}
-            </a>
-            {' - '}
-            <AgeText date={deck.date} />
-          </h6>
+          {
+            deck.name.length <= 30 ?
+            <h6 className="card-subtitle mb-2 text-muted">
+              <a href={'/cube/deck/' + deck._id}>
+                {deck.name}
+              </a>
+              {' by '}
+              {deck.owner ? <a href={'/user/view/' + deck.owner}>{deck.username}</a> : <a>Anonymous</a>}{' '}
+              {' - '}
+              <AgeText date={deck.date} />
+            </h6>
+
+            :
+            <h6 className="card-subtitle mb-2 text-muted">
+              {deck.owner ? <a href={'/user/view/' + deck.owner}>{deck.username}</a> : <a>Anonymous</a>}{' '}
+              <a href={'/cube/deck/' + deck._id}>
+                {'drafted '}
+                {deck.cubename}
+              </a>
+              {' - '}
+              <AgeText date={deck.date} />
+            </h6>
+          }
         </div>
       </a>
     );

--- a/src/components/Deckbuilder.js
+++ b/src/components/Deckbuilder.js
@@ -13,15 +13,7 @@ import DynamicFlash from './DynamicFlash';
 import ErrorBoundary from './ErrorBoundary';
 import TextEntry from './TextEntry';
 
-import {
-  Card,
-  CardHeader,
-  CardBody,
-  Row,
-  Col,
-  CardTitle,
-  CardText
-} from 'reactstrap';
+import { Card, CardHeader, CardBody, Row, Col, CardTitle, CardText } from 'reactstrap';
 
 const canDrop = (source, target) => true;
 
@@ -124,24 +116,21 @@ const Deckbuilder = ({ initialDeck, basics }) => {
             <CardHeader>
               <CardTitle className="mb-0 d-flex flex-row align-items-end">
                 <h4 className="mb-0 mr-auto">About</h4>
-              </CardTitle>             
+              </CardTitle>
             </CardHeader>
-            <CardBody>              
-            <h6>Deck Name</h6>
-            <input
-              className="form-control"
-              name="name"
-              type="text"
-              value={name}
-              onChange={e => setName(e.target.value)}
-            ></input>
-            <br />
-            
-            <h6>Description</h6>
-            <TextEntry
-              content={description}
-              handleChange={e => setDescription(e.target.value)}
-            />
+            <CardBody>
+              <h6>Deck Name</h6>
+              <input
+                className="form-control"
+                name="name"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              ></input>
+              <br />
+
+              <h6>Description</h6>
+              <TextEntry content={description} handleChange={(e) => setDescription(e.target.value)} />
             </CardBody>
           </Card>
         </Col>

--- a/src/components/Deckbuilder.js
+++ b/src/components/Deckbuilder.js
@@ -11,6 +11,17 @@ import DndProvider from './DndProvider';
 import { subtitle } from './DraftView';
 import DynamicFlash from './DynamicFlash';
 import ErrorBoundary from './ErrorBoundary';
+import TextEntry from './TextEntry';
+
+import {
+  Card,
+  CardHeader,
+  CardBody,
+  Row,
+  Col,
+  CardTitle,
+  CardText
+} from 'reactstrap';
 
 const canDrop = (source, target) => true;
 
@@ -100,10 +111,41 @@ const Deckbuilder = ({ initialDeck, basics }) => {
   currentDeck.playerdeck = [...deck[0], ...deck[1]];
   currentDeck.playersideboard = sideboard[0];
 
+  const [name, setName] = useState(initialDeck.name);
+  const [description, setDescription] = useState(initialDeck.description);
+
   return (
     <DisplayContextProvider>
-      <DeckbuilderNavbar deck={currentDeck} addBasics={addBasics} />
+      <DeckbuilderNavbar deck={currentDeck} addBasics={addBasics} name={name} description={description} />
       <DynamicFlash />
+      <Row className="mt-3">
+        <Col>
+          <Card>
+            <CardHeader>
+              <CardTitle className="mb-0 d-flex flex-row align-items-end">
+                <h4 className="mb-0 mr-auto">About</h4>
+              </CardTitle>             
+            </CardHeader>
+            <CardBody>              
+            <h6>Deck Name</h6>
+            <input
+              className="form-control"
+              name="name"
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+            ></input>
+            <br />
+            
+            <h6>Description</h6>
+            <TextEntry
+              content={description}
+              handleChange={e => setDescription(e.target.value)}
+            />
+            </CardBody>
+          </Card>
+        </Col>
+      </Row>
       <ErrorBoundary>
         <DndProvider>
           <DeckStacks

--- a/src/components/DeckbuilderNavbar.js
+++ b/src/components/DeckbuilderNavbar.js
@@ -79,7 +79,7 @@ BasicsModal.propTypes = {
   handleAddBasics: PropTypes.func,
 };
 
-const DeckbuilderNavbar = ({ deck, addBasics }) => {
+const DeckbuilderNavbar = ({ deck, addBasics, name, description }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [basicsModalOpen, setBasicsModalOpen] = useState(false);
 
@@ -122,6 +122,8 @@ const DeckbuilderNavbar = ({ deck, addBasics }) => {
               </NavLink>
               <CSRFForm className="d-none" innerRef={saveForm} method="POST" action={`/cube/editdeck/${deck._id}`}>
                 <Input type="hidden" name="draftraw" value={JSON.stringify(deck)} />
+                <Input type="hidden" name="name" value={JSON.stringify(name)} />
+                <Input type="hidden" name="description" value={JSON.stringify(description)} />
               </CSRFForm>
             </NavItem>
             <NavItem>

--- a/src/components/DraftDeck.js
+++ b/src/components/DraftDeck.js
@@ -94,8 +94,10 @@ const DraftDeck = ({ oldFormat, drafter, cards, deck, sideboard, botDecks, bots,
     stackedSideboard = [];
   } else {
     stackedDeck = [deck.slice(0, 8), deck.slice(8, 16)];    
-    stackedSideboard = [sideboard.slice(0, 8)]; 
+    stackedSideboard = [sideboard.slice(0, 16)]; 
   }
+
+  console.log(stackedSideboard);
 
   // Cut off empty columns at the end.
   let lastFull;
@@ -148,25 +150,13 @@ const DraftDeck = ({ oldFormat, drafter, cards, deck, sideboard, botDecks, bots,
           </Collapse>
         </Navbar>
       </div>
-      <DynamicFlash />
-      <Row className="mt-3">
-        <Col>
-          <DeckStacksStatic cards={stackedDeck} title={name} subtitle={subtitle(deck.flat().flat())} />
-        </Col>
-      </Row>
-      {(stackedSideboard && stackedSideboard.length > 0) &&
-        <Row className="mt-3">
-          <Col>
-            <DeckStacksStatic cards={stackedSideboard} title={"Sideboard"} />
-          </Col>
-        </Row>
-      }
+      <DynamicFlash />      
       <Row className="mt-3">
         <Col>
           <Card>
             <CardHeader>
               <CardTitle className="mb-0 d-flex flex-row align-items-end">
-                <h4 className="mb-0 mr-auto">About</h4>
+                <h4 className="mb-0 mr-auto">{name}</h4>
                 <h6 className="mb-0 font-weight-normal d-none d-sm-block">
                   Drafted by {drafter.profileUrl ? <a href={drafter.profileUrl}>{drafter.name}</a> : drafter.name}
                 </h6>
@@ -178,6 +168,18 @@ const DraftDeck = ({ oldFormat, drafter, cards, deck, sideboard, botDecks, bots,
           </Card>
         </Col>
       </Row>
+      <Row className="mt-3">
+        <Col>
+          <DeckStacksStatic cards={stackedDeck} title={"Deck"} subtitle={subtitle(deck.flat().flat())} />
+        </Col>
+      </Row>
+      {(stackedSideboard && stackedSideboard.length > 0) &&
+        <Row className="mt-3">
+          <Col>
+            <DeckStacksStatic cards={stackedSideboard} title={"Sideboard"} />
+          </Col>
+        </Row>
+      }
       <h4 className="mt-3">Bot Decks</h4>
       <Row className="row-low-padding">
         {botDecks.map((deck, botIndex) => (

--- a/src/components/DraftDeck.js
+++ b/src/components/DraftDeck.js
@@ -71,8 +71,21 @@ DeckStacksStatic.propTypes = {
   cards: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.object))).isRequired,
 };
 
-const DraftDeck = ({ oldFormat, drafter, cards, deck, sideboard, botDecks, bots, canEdit, description, name, comments, deckid, userid }) => {
-
+const DraftDeck = ({
+  oldFormat,
+  drafter,
+  cards,
+  deck,
+  sideboard,
+  botDecks,
+  bots,
+  canEdit,
+  description,
+  name,
+  comments,
+  deckid,
+  userid,
+}) => {
   const [commentList, setCommentList] = useState(comments);
   const [childExpanded, setChildCollapse] = useState(false);
 
@@ -90,21 +103,21 @@ const DraftDeck = ({ oldFormat, drafter, cards, deck, sideboard, botDecks, bots,
     const newList = commentList.slice();
     newList.push(comment);
     setCommentList(newList);
-  }
+  };
   const saveEdit = function(comments, position, comment) {
     if (position.length == 1) {
       comments[position[0]] = comment;
     } else if (position.length > 1) {
       saveEdit(comments[position[0]].comments, position.slice(1), comment);
     }
-  }
+  };
   const submitEdit = async function(comment, position) {
     //update current state
     saveEdit(this.props.post.comments, position, comment);
-  }
+  };
   const toggleChildCollapse = function() {
     setChildCollapse(!childExpanded);
-  }
+  };
 
   let stackedDeck;
   let stackedSideboard;
@@ -112,8 +125,8 @@ const DraftDeck = ({ oldFormat, drafter, cards, deck, sideboard, botDecks, bots,
     stackedDeck = sortDeck(cards);
     stackedSideboard = [];
   } else {
-    stackedDeck = [deck.slice(0, 8), deck.slice(8, 16)];    
-    stackedSideboard = [sideboard.slice(0, 16)]; 
+    stackedDeck = [deck.slice(0, 8), deck.slice(8, 16)];
+    stackedSideboard = [sideboard.slice(0, 16)];
   }
 
   // Cut off empty columns at the end.
@@ -167,7 +180,7 @@ const DraftDeck = ({ oldFormat, drafter, cards, deck, sideboard, botDecks, bots,
           </Collapse>
         </Navbar>
       </div>
-      <DynamicFlash />      
+      <DynamicFlash />
       <Row className="mt-3">
         <Col>
           <Card>
@@ -177,10 +190,10 @@ const DraftDeck = ({ oldFormat, drafter, cards, deck, sideboard, botDecks, bots,
                 <h6 className="mb-0 font-weight-normal d-none d-sm-block">
                   Drafted by {drafter.profileUrl ? <a href={drafter.profileUrl}>{drafter.name}</a> : drafter.name}
                 </h6>
-              </CardTitle>             
+              </CardTitle>
             </CardHeader>
             <CardBody>
-              <CardText dangerouslySetInnerHTML={{ __html:description }} />
+              <CardText dangerouslySetInnerHTML={{ __html: description }} />
             </CardBody>
             <CardBody className="px-4 pt-2 pb-0 border-top">
               <CommentEntry id={deckid} position={[]} onPost={onPost} submitUrl={`/cube/api/postdeckcomment`}>
@@ -208,16 +221,16 @@ const DraftDeck = ({ oldFormat, drafter, cards, deck, sideboard, botDecks, bots,
       </Row>
       <Row className="mt-3">
         <Col>
-          <DeckStacksStatic cards={stackedDeck} title={"Deck"} subtitle={subtitle(deck.flat().flat())} />
+          <DeckStacksStatic cards={stackedDeck} title={'Deck'} subtitle={subtitle(deck.flat().flat())} />
         </Col>
       </Row>
-      {(stackedSideboard && stackedSideboard.length > 0) &&
+      {stackedSideboard && stackedSideboard.length > 0 && (
         <Row className="mt-3">
           <Col>
-            <DeckStacksStatic cards={stackedSideboard} title={"Sideboard"} />
+            <DeckStacksStatic cards={stackedSideboard} title={'Sideboard'} />
           </Col>
         </Row>
-      }
+      )}
       <h4 className="mt-3">Bot Decks</h4>
       <Row className="row-low-padding">
         {botDecks.map((deck, botIndex) => (

--- a/src/components/DraftDeck.js
+++ b/src/components/DraftDeck.js
@@ -136,6 +136,11 @@ const DraftDeck = ({ oldFormat, drafter, cards, deck, botDecks, bots, canEdit })
           <DeckStacksStatic cards={stackedDeck} title={title} subtitle={subtitle(deck.flat().flat())} />
         </Col>
       </Row>
+      <Row className="mt-3">
+        <Col>
+          <DeckStacksStatic cards={stackedDeck} title={"Sideboard"} />
+        </Col>
+      </Row>
       <h4 className="mt-3">Bot Decks</h4>
       <Row className="row-low-padding">
         {botDecks.map((deck, botIndex) => (

--- a/src/components/DraftDeck.js
+++ b/src/components/DraftDeck.js
@@ -8,7 +8,6 @@ import {
   CardTitle,
   Col,
   Collapse,
-  Input,
   ListGroup,
   ListGroupItem,
   Nav,
@@ -17,6 +16,7 @@ import {
   NavItem,
   NavLink,
   Row,
+  CardText,
 } from 'reactstrap';
 
 import { sortDeck } from '../util/Util';
@@ -69,7 +69,7 @@ DeckStacksStatic.propTypes = {
   cards: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.object))).isRequired,
 };
 
-const DraftDeck = ({ oldFormat, drafter, cards, deck, sideboard, botDecks, bots, canEdit }) => {
+const DraftDeck = ({ oldFormat, drafter, cards, deck, sideboard, botDecks, bots, canEdit, description, name }) => {
   const [isOpen, setIsOpen] = useState(false);
   const toggleNavbar = useCallback(
     (event) => {
@@ -81,11 +81,11 @@ const DraftDeck = ({ oldFormat, drafter, cards, deck, sideboard, botDecks, bots,
 
   const title = (
     <Fragment>
-      Drafted by {drafter.profileUrl ? <a href={drafter.profileUrl}>{drafter.name}</a> : drafter.name}
+      
     </Fragment>
   );
 
-  console.log(deck);
+  console.log(description);
 
   let stackedDeck;
   let stackedSideboard;
@@ -110,7 +110,7 @@ const DraftDeck = ({ oldFormat, drafter, cards, deck, sideboard, botDecks, bots,
   }
 
   let lastFullSB;
-  for (const row of stackedDeck) {
+  for (const row of stackedSideboard) {
     for (lastFullSB = row.length - 1; lastFullSB >= 0; lastFullSB--) {
       if (row[lastFullSB] && row[lastFullSB].length > 0) {
         break;
@@ -151,7 +151,7 @@ const DraftDeck = ({ oldFormat, drafter, cards, deck, sideboard, botDecks, bots,
       <DynamicFlash />
       <Row className="mt-3">
         <Col>
-          <DeckStacksStatic cards={stackedDeck} title={title} subtitle={subtitle(deck.flat().flat())} />
+          <DeckStacksStatic cards={stackedDeck} title={name} subtitle={subtitle(deck.flat().flat())} />
         </Col>
       </Row>
       {(stackedSideboard && stackedSideboard.length > 0) &&
@@ -161,6 +161,23 @@ const DraftDeck = ({ oldFormat, drafter, cards, deck, sideboard, botDecks, bots,
           </Col>
         </Row>
       }
+      <Row className="mt-3">
+        <Col>
+          <Card>
+            <CardHeader>
+              <CardTitle className="mb-0 d-flex flex-row align-items-end">
+                <h4 className="mb-0 mr-auto">About</h4>
+                <h6 className="mb-0 font-weight-normal d-none d-sm-block">
+                  Drafted by {drafter.profileUrl ? <a href={drafter.profileUrl}>{drafter.name}</a> : drafter.name}
+                </h6>
+              </CardTitle>             
+            </CardHeader>
+            <CardBody>
+              <CardText dangerouslySetInnerHTML={{ __html:description }} />
+            </CardBody>
+          </Card>
+        </Col>
+      </Row>
       <h4 className="mt-3">Bot Decks</h4>
       <Row className="row-low-padding">
         {botDecks.map((deck, botIndex) => (

--- a/src/components/DraftDeck.js
+++ b/src/components/DraftDeck.js
@@ -45,7 +45,7 @@ const DeckStacksStatic = ({ title, subtitle, cards, ...props }) => (
           {row.map((column, index2) => (
             <Col key={index2} className="mt-3 card-stack col-md-1-5 col-low-padding" xs={3}>
               <div className="w-100 text-center mb-1">
-                <b>{column.length}</b>
+                <b>{column.length > 0 ? column.length : ''}</b>
               </div>
               <div className="stack">
                 {column.map((card, index3) => (
@@ -69,7 +69,7 @@ DeckStacksStatic.propTypes = {
   cards: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.object))).isRequired,
 };
 
-const DraftDeck = ({ oldFormat, drafter, cards, deck, botDecks, bots, canEdit }) => {
+const DraftDeck = ({ oldFormat, drafter, cards, deck, sideboard, botDecks, bots, canEdit }) => {
   const [isOpen, setIsOpen] = useState(false);
   const toggleNavbar = useCallback(
     (event) => {
@@ -85,11 +85,16 @@ const DraftDeck = ({ oldFormat, drafter, cards, deck, botDecks, bots, canEdit })
     </Fragment>
   );
 
+  console.log(deck);
+
   let stackedDeck;
+  let stackedSideboard;
   if (oldFormat) {
     stackedDeck = sortDeck(cards);
+    stackedSideboard = [];
   } else {
-    stackedDeck = [deck.slice(0, 8), deck.slice(8, 16)];
+    stackedDeck = [deck.slice(0, 8), deck.slice(8, 16)];    
+    stackedSideboard = [sideboard.slice(0, 8)]; 
   }
 
   // Cut off empty columns at the end.
@@ -101,6 +106,17 @@ const DraftDeck = ({ oldFormat, drafter, cards, deck, botDecks, bots, canEdit })
       }
     }
     const startCut = lastFull + 1;
+    row.splice(startCut, row.length - startCut);
+  }
+
+  let lastFullSB;
+  for (const row of stackedDeck) {
+    for (lastFullSB = row.length - 1; lastFullSB >= 0; lastFullSB--) {
+      if (row[lastFullSB] && row[lastFullSB].length > 0) {
+        break;
+      }
+    }
+    const startCut = lastFullSB + 1;
     row.splice(startCut, row.length - startCut);
   }
 
@@ -138,11 +154,13 @@ const DraftDeck = ({ oldFormat, drafter, cards, deck, botDecks, bots, canEdit })
           <DeckStacksStatic cards={stackedDeck} title={title} subtitle={subtitle(deck.flat().flat())} />
         </Col>
       </Row>
-      <Row className="mt-3">
-        <Col>
-          <DeckStacksStatic cards={stackedDeck} title={"Sideboard"} />
-        </Col>
-      </Row>
+      {(stackedSideboard && stackedSideboard.length > 0) &&
+        <Row className="mt-3">
+          <Col>
+            <DeckStacksStatic cards={stackedSideboard} title={"Sideboard"} />
+          </Col>
+        </Row>
+      }
       <h4 className="mt-3">Bot Decks</h4>
       <Row className="row-low-padding">
         {botDecks.map((deck, botIndex) => (

--- a/views/cube/cube_deck.pug
+++ b/views/cube/cube_deck.pug
@@ -20,7 +20,7 @@ block scripts
       sideboard: !{sideboard || []},
       botDecks: !{JSON.stringify(bot_decks)},
       bots: !{JSON.stringify(bots)},
-      canEdit: !{JSON.stringify(user && user.id === deck.owner)},
+      canEdit: !{JSON.stringify(user && user._id == owner)},
     };
   include ../react
   script(src='/js/cube_deck.bundle.js')

--- a/views/cube/cube_deck.pug
+++ b/views/cube/cube_deck.pug
@@ -15,6 +15,8 @@ block scripts
       drafter: !{JSON.stringify(drafter)},
       cards: !{cards ? JSON.stringify(cards) : '[]'},
       deck: !{deck || []},
+      description: !{JSON.stringify(description)},
+      name: !{JSON.stringify(name)},
       sideboard: !{sideboard || []},
       botDecks: !{JSON.stringify(bot_decks)},
       bots: !{JSON.stringify(bots)},

--- a/views/cube/cube_deck.pug
+++ b/views/cube/cube_deck.pug
@@ -21,6 +21,9 @@ block scripts
       botDecks: !{JSON.stringify(bot_decks)},
       bots: !{JSON.stringify(bots)},
       canEdit: !{JSON.stringify(user && user._id == owner)},
+      comments: !{JSON.stringify(comments)},
+      deckid: !{JSON.stringify(deckid)},
+      userid: !{JSON.stringify(user._id)},
     };
   include ../react
   script(src='/js/cube_deck.bundle.js')

--- a/views/cube/cube_deck.pug
+++ b/views/cube/cube_deck.pug
@@ -15,6 +15,7 @@ block scripts
       drafter: !{JSON.stringify(drafter)},
       cards: !{cards ? JSON.stringify(cards) : '[]'},
       deck: !{deck || []},
+      sideboard: !{sideboard || []},
       botDecks: !{JSON.stringify(bot_decks)},
       bots: !{JSON.stringify(bots)},
       canEdit: !{JSON.stringify(user && user.id === deck.owner)},

--- a/views/cube/cube_deckbuilder.pug
+++ b/views/cube/cube_deckbuilder.pug
@@ -1,6 +1,7 @@
 extends cube_layout
 
 block cube_toolbar
+  link(rel='stylesheet' href='/css/texteditor.css')
   link(rel='stylesheet' href='/css/draft.css')
 
 block cube_content


### PR DESCRIPTION
fixes #696, fixes #88
Adds sideboard to draft deck view. Fixed an issue where draft decks can't be edited. Revised the deck preview. Added commenting + comments section on decks. Allow edits of deck name + description.

Not really related bugfix:
Cube deletion no longer 404s, now goes to dashboard