### PR TITLE
Improve custom draft titles and order alphabetically

### DIFF
--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -878,6 +878,9 @@ router.get('/playtest/:id', async (req, res) => {
 
     const [user, decks] = await Promise.all([userq, decksq]);
 
+    // sort titles alphabetically
+    cube.draft_formats.sort((a, b) => a.title.localeCompare(b.title));
+
     const reactProps = {
       canEdit: user._id.equals(cube.owner),
       decks,

--- a/src/components/CubePlaytestPage.js
+++ b/src/components/CubePlaytestPage.js
@@ -91,7 +91,7 @@ const CustomDraftCard = ({ format, formatIndex, onEditFormat, onDeleteFormat, ..
     <Card {...props}>
       <CSRFForm method="POST" action={`/cube/startdraft/${cubeID}`}>
         <CardHeader>
-          <CardTitleH5>Draft Custom Format: {format.title}</CardTitleH5>
+          <CardTitleH5>{format.title} (custom draft)</CardTitleH5>
         </CardHeader>
         <CardBody>
           <div className="description-area" dangerouslySetInnerHTML={{ __html: format.html }} />
@@ -132,7 +132,7 @@ const StandardDraftCard = ({ cubeID }) => (
   <Card className="mt-3">
     <CSRFForm method="POST" action={`/cube/startdraft/${cubeID}`}>
       <CardHeader>
-        <CardTitleH5>Start a new draft</CardTitleH5>
+        <CardTitleH5>Standard draft</CardTitleH5>
       </CardHeader>
       <CardBody>
         <LabelRow htmlFor="packs" label="Number of Packs">


### PR DESCRIPTION
Small UI improvements to custom drafts:
 - Put custom draft title first
 - Rename standard draft (to "Standard draft" from "Start a draft")
 - Order custom drafts alphabetically
