### PR TITLE
Enable source maps on production build.

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -7,7 +7,7 @@ const common = require('./webpack.common.js');
 
 const config = {
   mode: 'production',
-  devtool: false,
+  devtool: 'source-map',
   plugins: [
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production'),
@@ -24,6 +24,7 @@ const config = {
     minimizer: [
       new TerserPlugin({
         parallel: true,
+        sourceMap: true,
       }),
     ],
     usedExports: true,


### PR DESCRIPTION
This should make debugging on the dev + production server much, much easier at no performance cost. I don't know why I turned this off. I haven't been able to reproduce a couple reported bugs and this should help.