### PR TITLE
add coverage report to test running script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "webpack-dev-server": "webpack-dev-server --config webpack.dev.js",
     "build": "webpack --mode production --config webpack.prod.js && rollup -c",
     "start": "nodemon --ignore src --ignore public & webpack-dev-server --config webpack.dev.js & rollup -c --watch",
-    "test": "jest --silent --detectOpenHandles",
+    "test": "jest --silent --detectOpenHandles --coverage",
     "setup": "rollup -c & node force_update.js"
   },
   "author": "Gwen Dekker",


### PR DESCRIPTION
This could help reduce the number of bugs we're getting going forward. It will print out a test coverage report after running the tests.
```
------------------|----------|----------|----------|----------|-------------------|
File              |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
------------------|----------|----------|----------|----------|-------------------|
All files         |    40.26 |    33.12 |    40.75 |    41.31 |                   |
 __tests__        |      100 |      100 |      100 |      100 |                   |
  helpers.js      |      100 |      100 |      100 |      100 |                   |
 dist/util        |     25.5 |    17.12 |     24.3 |     25.8 |                   |
  Card.js         |    77.78 |      100 |    33.33 |    77.78 |             14,18 |
  Filter.js       |    20.02 |    14.39 |    25.37 |    20.03 |... 1401,1409,1410 |
  Util.js         |    18.89 |        0 |        0 |    20.73 |... 31,132,137,138 |
  draftutil.js    |       50 |    48.19 |    36.36 |    51.46 |... 95,296,298,300 |
 fixtures         |      100 |      100 |      100 |      100 |                   |
  examplecards.js |      100 |      100 |      100 |      100 |                   |
  examplecube.js  |      100 |      100 |      100 |      100 |                   |
  examplelands.js |      100 |      100 |      100 |      100 |                   |
 models           |      100 |      100 |      100 |      100 |                   |
  cardrating.js   |      100 |      100 |      100 |      100 |                   |
  cube.js         |      100 |      100 |      100 |      100 |                   |
  draft.js        |      100 |      100 |      100 |      100 |                   |
 serverjs         |    69.73 |    64.55 |    79.13 |    70.15 |                   |
  analytics.js    |    53.31 |    51.78 |    73.33 |    53.49 |... 87,490,534,535 |
  cards.js        |    73.17 |    55.17 |    68.42 |    73.08 |... 58,159,160,162 |
  cubefn.js       |    84.82 |    77.63 |    90.48 |    85.58 |... 86,193,213,216 |
  meta.js         |      100 |       50 |      100 |      100 |             21,25 |
  updatecards.js  |     75.9 |       70 |       80 |    76.31 |... 93,694,696,697 |
  util.js         |    77.88 |    75.86 |    78.95 |    81.44 |... 54,200,201,220 |
 src/util         |    26.37 |     25.3 |     12.5 |    27.63 |                   |
  Card.js         |    33.33 |      100 |    33.33 |    33.33 |             10,14 |
  Filter.js       |    50.97 |    48.45 |       40 |     53.6 |... 21,822,823,827 |
  Sort.js         |     1.55 |        0 |     1.89 |     1.64 |... 69,670,671,673 |
  Util.js         |     1.35 |        0 |        0 |     1.52 |... 27,128,133,134 |
------------------|----------|----------|----------|----------|-------------------|
```