### PR TITLE
Only shuffle cards once for standard draft

### DIFF
--- a/src/util/draftutil.js
+++ b/src/util/draftutil.js
@@ -58,13 +58,13 @@ function standardDraft(cards, probabilistic = false) {
   if (cards.length === 0) {
     throw new Error('Unable to create draft: not enough cards.');
   }
+  cards = arrayShuffle(cards);
   return function(cardFilters) {
     // ignore cardFilters, just take any card in cube
     if (cards.length === 0) {
       throw new Error('Unable to create draft: not enough cards.');
     }
     // remove a random card
-    cards = arrayShuffle(cards);
     return { card: cards.pop(), messages: '' };
   };
 }


### PR DESCRIPTION
We only need to shuffle once and this way we can more easily add a seed if needed in the future. 