### PR TITLE
Better Compressed View.

### DIFF
--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -168,9 +168,17 @@
 	}
 }
 
-.table-view.compressed .table-col {
-	flex: 0 0 calc(100% / 8);
-	width: calc(100% / 8);
+@media(max-width: 991.98px) {
+	.compressed.table-view.row {
+		transform: scale(0.5) translate(-50%, -50%);
+		padding: 0;
+		margin: 0 -15px;
+		width: 200vw;
+		overflow: visible;
+	}
+	.compressed .card-list-heading {
+		font-size: 10pt !important;
+	}
 }
 
 @media(max-width: 649.98px) {
@@ -178,18 +186,15 @@
 		margin-top: 0.375rem !important;
 	}
 	.compressed .card-list-heading {
-		font-size: 7pt;
 		margin-bottom: 0.375rem !important;
 		overflow: hidden;
 		text-overflow: ellipsis;
 	}
 	.compressed .list-group-heading {
 		padding: 2px 4px;
-		font-size: 5pt;
 	}
 	.compressed .card-list-item {
-		font-size: 5pt;
-		padding: 1px 1px;
+		padding: 2px 0;
 		text-overflow: clip;
 	}
 }
@@ -559,7 +564,7 @@ body.busy-cursor {
 		overflow: hidden;
 		width: 100vw;
 		padding: 0 calc(50vw - 50%);
-		margin: 0 calc(-50vw + 50%);
+		margin: -0.5rem calc(-50vw + 50%) 0rem;
 	}
 
 	.table-view.row {

--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -194,7 +194,7 @@
 		padding: 2px 4px;
 	}
 	.compressed .card-list-item {
-		padding: 2px 0;
+		padding: 0 2px;
 		text-overflow: clip;
 	}
 }

--- a/src/components/TableView.js
+++ b/src/components/TableView.js
@@ -20,9 +20,12 @@ const TableView = ({ cards, rowTag, noGroupModal, className, ...props }) => {
         {sorted.map(([columnLabel, column]) => (
           <Col
             key={columnLabel}
-            md="auto"
+            md={compressedView ? undefined : 'auto'}
             className="table-col"
-            style={{ width: `${100 / Math.min(sorted.length, 8)}%` }}
+            style={{
+              width: `${100 / Math.min(sorted.length, 8)}%`,
+              flexBasis: compressedView ? `${100 / Math.min(sorted.length, 8)}%` : undefined,
+            }}
           >
             <h6 className="text-center card-list-heading">
               {columnLabel}


### PR DESCRIPTION
<img width="292" alt="Screen Shot 2020-01-22 at 5 04 51 PM" src="https://user-images.githubusercontent.com/548999/72939191-67f92480-3d3a-11ea-9535-0b990b54285f.png">
