### PR TITLE
Get test files to sync paths with the files they're testing.

### DIFF
--- a/__tests__/src/utils/draftutil.test.js
+++ b/__tests__/src/utils/draftutil.test.js
@@ -1,13 +1,17 @@
-const carddb = require('../../serverjs/cards');
-const fixturesPath = 'fixtures';
-const cubefixture = require('../../fixtures/examplecube');
 const sinon = require('sinon');
-const methods = require('../../dist/utils/draftutil');
-let CardRating = require('../../models/cardrating');
-let Draft = require('../../models/draft');
 
-import Filter from '../../src/utils/Filter';
-import { expectOperator } from '../helpers';
+const fixturesPath = 'fixtures';
+const cubefixture = require('../../../fixtures/examplecube');
+
+let CardRating = require('../../../models/cardrating');
+let Draft = require('../../../models/draft');
+
+const carddb = require('../../../serverjs/cards');
+
+import Filter from '../../../src/utils/Filter';
+import methods from '../../../src/utils/draftutil';
+
+import { expectOperator } from '../../helpers';
 
 describe('getDraftBots', () => {
   it('can get the correct number of draft bots', () => {

--- a/__tests__/src/utils/filter.test.js
+++ b/__tests__/src/utils/filter.test.js
@@ -1,9 +1,11 @@
-const carddb = require('../../serverjs/cards');
 const fixturesPath = 'fixtures';
-const cubefixture = require('../../fixtures/examplecube');
+const cubefixture = require('../../../fixtures/examplecube');
 
-import Filter from '../../src/utils/Filter';
-import { expectOperator } from '../helpers';
+const carddb = require('../../../serverjs/cards');
+
+import Filter from '../../../src/utils/Filter';
+
+import { expectOperator } from '../../helpers';
 
 const setCounts = (cards, propertyName) => {
   let greenCardCount = 0;


### PR DESCRIPTION
draftutils moved from serverjs to src/utils but we didn't move the test file.
filter is in src/utils but tests were in src.