### PR TITLE
Fix CubePlaytestPage.js

### DIFF
--- a/src/pages/CubePlaytestPage.js
+++ b/src/pages/CubePlaytestPage.js
@@ -245,7 +245,7 @@ const DEFAULT_FORMAT = {
   packs: [['rarity:Mythic', 'tag:new', 'identity>1']],
 };
 const CubePlaytestPage = ({ cube, cubeID, canEdit, decks, draftFormats }) => {
-  const [alerts, addAlert] = useAlerts();
+  const { alerts, addAlert } = useAlerts();
   const [formats, setFormats] = useState(draftFormats);
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [editFormatIndex, setEditFormatIndex] = useState(-1);
@@ -345,7 +345,7 @@ const CubePlaytestPage = ({ cube, cubeID, canEdit, decks, draftFormats }) => {
 
 CubePlaytestPage.propTypes = {
   cube: PropTypes.shape({
-    cards: PropTypes.arrayOf(PropTypes.object).isRequired,
+    cards: PropTypes.arrayOf(PropTypes.object),
   }).isRequired,
   cubeID: PropTypes.string.isRequired,
   canEdit: PropTypes.bool.isRequired,


### PR DESCRIPTION
Removes a warning from the console of cards being null and fixes the error with useAlerts preventing it from rendering.