### PR TITLE
Change custom drafts to use id instead of index

### DIFF
--- a/__tests__/serverjs/cubefn.test.js
+++ b/__tests__/serverjs/cubefn.test.js
@@ -204,3 +204,123 @@ test('addAutocard correctly replaces autocard format strings', () => {
     expect(result).toBe(expected);
   });
 });
+
+describe('getDraftFormatIndex', () => {
+  let cube;
+  let existingFormatID = '1ee7';
+
+  beforeEach(() => {
+    cube = JSON.parse(JSON.stringify(cubefixture.exampleCube));
+    cube.draft_formats = [];
+    cube.draft_formats.push({ _id: existingFormatID });
+  });
+
+  test('returns -1 if format not found', () => {
+    expect(cubefn.getDraftFormatIndex(cube, 'notexisting')).toBe(-1);
+  });
+
+  test('returns index of format found', () => {
+    expect(cubefn.getDraftFormatIndex(cube, existingFormatID)).toBe(0);
+    cube.draft_formats.push({ _id: '1' });
+    cube.draft_formats.push({ _id: '2' });
+    cube.draft_formats.push({ _id: '3' });
+    expect(cubefn.getDraftFormatIndex(cube, '2')).toBe(2);
+  });
+
+  test('returns error if cube has no formats', () => {
+    cube.draft_formats = [];
+    expect(() => {
+      cubefn.getDraftFormatIndex(cube, existingFormatID);
+    }).toThrow();
+
+    delete cube.draft_formats;
+    expect(() => {
+      cubefn.getDraftFormatIndex(cube, existingFormatID);
+    }).toThrow();
+  });
+
+  test('returns error if format id invalid', () => {
+    expect(() => {
+      cubefn.getDraftFormatIndex(cube);
+    }).toThrow();
+
+    expect(() => {
+      cubefn.getDraftFormatIndex(cube, '');
+    }).toThrow();
+  });
+});
+
+describe('addDraftFormat', () => {
+  let cube;
+  let existingFormatID = '1ee7';
+
+  beforeEach(() => {
+    cube = JSON.parse(JSON.stringify(cubefixture.exampleCube));
+    cube.draft_formats = [];
+    cube.draft_formats.push({ _id: existingFormatID });
+  });
+
+  test('adds format to existing', () => {
+    const format = { title: 'Title', multiples: false, html: '<h1>Test</h1>', packs: '[[]]' };
+    cubefn.addDraftFormat(cube, format);
+    expect(cube.draft_formats[1]).toEqual(format);
+  });
+
+  test('adds format when none exist', () => {
+    delete cube.draft_formats;
+    const format = { title: 'Title', multiples: false, html: '<h1>Test</h1>', packs: '[[]]' };
+    cubefn.addDraftFormat(cube, format);
+    expect(cube.draft_formats[0]).toEqual(format);
+  });
+});
+
+describe('updateDraftFormat', () => {
+  let cube;
+  let existingFormatID = '1ee7';
+
+  beforeEach(() => {
+    cube = JSON.parse(JSON.stringify(cubefixture.exampleCube));
+    cube.draft_formats = [];
+    cube.draft_formats.push({ _id: existingFormatID });
+  });
+
+  test('update existing format to existing', () => {
+    const new_format = { title: 'Title', multiples: false, html: '<h1>Test</h1>', packs: '[[]]' };
+    cubefn.updateDraftFormat(cube, existingFormatID, new_format);
+    const format = cube.draft_formats[0];
+    expect(format.title).toEqual(new_format.title);
+    expect(format.multiples).toEqual(new_format.multiples);
+    expect(format.html).toEqual(new_format.html);
+    expect(format.packs).toEqual(new_format.packs);
+  });
+
+  test("throws error if format doesn't exist", () => {
+    const new_format = { title: 'Title', multiples: false, html: '<h1>Test</h1>', packs: '[[]]' };
+    expect(() => {
+      cubefn.updateDraftFormat(cube, 'not_exist', format);
+    }).toThrow();
+  });
+});
+
+describe('deleteDraftFormat', () => {
+  let cube;
+  let existingFormatID = '1ee7';
+
+  beforeEach(() => {
+    cube = JSON.parse(JSON.stringify(cubefixture.exampleCube));
+    cube.draft_formats = [];
+    cube.draft_formats.push({ _id: existingFormatID });
+  });
+
+  test('delete existing format', () => {
+    cubefn.deleteDraftFormat(cube, existingFormatID);
+    expect(cube.draft_formats).toHaveLength(0);
+  });
+
+  test('throws error if cube has no formats', () => {
+    delete cube.draft_formats;
+    expect(() => {
+      cubefn.deleteDraftFormat(cube, existingFormatID);
+    }).toThrow();
+  });
+});

--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -849,7 +849,7 @@ router.get('/playtest/:id', async (req, res) => {
         .sort((a, b) => a.title.localeCompare(b.title)) // sort titles alphabetically
         .map(({ _id, packs, ...format }, index) => ({
           id: _id,
-          index: index,
+          index,
           ...format,
           packs: JSON.parse(packs),
         }));
@@ -3097,7 +3097,7 @@ router.delete('/:cubeId/format/:formatId', ensureAuth, async (req, res) => {
   } catch (err) {
     return res.status(500).send({
       success: 'false',
-      message: 'Error deleting format: ' + err.message,
+      message: `Error deleting format: ${err.message}`,
     });
   }
 });

--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -32,8 +32,8 @@ const {
   maybeCards,
   getElo,
   addDraftFormat,
-  editDraftFormat,
-  removeDraftFormat,
+  deleteDraftFormat,
+  updateDraftFormat,
 } = require('../serverjs/cubefn.js');
 const analytics = require('../serverjs/analytics.js');
 const draftutil = require('../dist/utils/draftutil.js');
@@ -198,7 +198,7 @@ router.post('/format/add/:id', ensureAuth, async (req, res) => {
       });
       message = 'Custom format successfully added.';
     } else {
-      editDraftFormat(cube, req.body.id, {
+      updateDraftFormat(cube, req.body.id, {
         title: req.body.title,
         multiples: req.body.multiples === 'true',
         html: req.body.html,
@@ -3087,7 +3087,7 @@ router.delete('/:cubeId/format/:formatId', ensureAuth, async (req, res) => {
       return res.sendStatus(401);
     }
 
-    removeDraftFormat(cube, req.params.formatId);
+    deleteDraftFormat(cube, req.params.formatId);
 
     await cube.save();
 

--- a/serverjs/cubefn.js
+++ b/serverjs/cubefn.js
@@ -259,7 +259,6 @@ function removeDraftFormat(cube, id) {
 
 // returns -1 if format id not found
 function getDraftFormatIndex(cube, id) {
-  console.log('getDraftFormatIndex', cube, id);
   if (!cube.draft_formats) {
     throw new Error('Cube has no draft formats');
   }

--- a/serverjs/cubefn.js
+++ b/serverjs/cubefn.js
@@ -235,7 +235,7 @@ function addDraftFormat(cube, { title, multiples, html, packs }) {
   cube.draft_formats.push({ title, multiples, html, packs });
 }
 
-function editDraftFormat(cube, id, { title, multiples, html, packs }) {
+function updateDraftFormat(cube, id, { title, multiples, html, packs }) {
   if (!cube.draft_formats) {
     throw new Error('Cube has no draft formats');
   }
@@ -246,8 +246,8 @@ function editDraftFormat(cube, id, { title, multiples, html, packs }) {
   cube.draft_formats[index] = { title, multiples, html, packs };
 }
 
-function removeDraftFormat(cube, id) {
-  if (!cube.draft_formats) {
+function deleteDraftFormat(cube, id) {
+  if (!cube.draft_formats || cube.draft_formats.length === 0) {
     throw new Error('Cube has no draft formats');
   }
   const index = getDraftFormatIndex(cube, id);
@@ -259,7 +259,7 @@ function removeDraftFormat(cube, id) {
 
 // returns -1 if format id not found
 function getDraftFormatIndex(cube, id) {
-  if (!cube.draft_formats) {
+  if (!cube.draft_formats || cube.draft_formats.length === 0) {
     throw new Error('Cube has no draft formats');
   }
   if (!id || id == '') {
@@ -399,8 +399,9 @@ const methods = {
   maybeCards,
   getElo,
   addDraftFormat,
-  editDraftFormat,
-  removeDraftFormat,
+  deleteDraftFormat,
+  updateDraftFormat,
+  getDraftFormatIndex,
 };
 
 module.exports = methods;

--- a/serverjs/cubefn.js
+++ b/serverjs/cubefn.js
@@ -228,6 +228,49 @@ async function getElo(cardnames, round) {
   return result;
 }
 
+function addDraftFormat(cube, { title, multiples, html, packs }) {
+  if (!cube.draft_formats) {
+    cube.draft_formats = [];
+  }
+  cube.draft_formats.push({ title, multiples, html, packs });
+}
+
+function editDraftFormat(cube, id, { title, multiples, html, packs }) {
+  if (!cube.draft_formats) {
+    throw new Error('Cube has no draft formats');
+  }
+  const index = getDraftFormatIndex(cube, id);
+  if (index < 0) {
+    throw new Error('Format ' + id + ' not found');
+  }
+  cube.draft_formats[index] = { title, multiples, html, packs };
+}
+
+function removeDraftFormat(cube, id) {
+  if (!cube.draft_formats) {
+    throw new Error('Cube has no draft formats');
+  }
+  const index = getDraftFormatIndex(cube, id);
+  if (index < 0) {
+    throw new Error('Format ' + id + ' not found');
+  }
+  cube.draft_formats.splice(index, 1);
+}
+
+// returns -1 if format id not found
+function getDraftFormatIndex(cube, id) {
+  console.log('getDraftFormatIndex', cube, id);
+  if (!cube.draft_formats) {
+    throw new Error('Cube has no draft formats');
+  }
+  if (!id || id == '') {
+    throw new Error('Invalid format id');
+  }
+  return cube.draft_formats.findIndex((format) => {
+    return format._id == id;
+  });
+}
+
 const methods = {
   getBasics: function(carddb) {
     const names = ['Plains', 'Mountain', 'Forest', 'Swamp', 'Island'];
@@ -356,6 +399,9 @@ const methods = {
   build_tag_colors,
   maybeCards,
   getElo,
+  addDraftFormat,
+  editDraftFormat,
+  removeDraftFormat,
 };
 
 module.exports = methods;

--- a/src/components/CustomDraftFormatModal.js
+++ b/src/components/CustomDraftFormatModal.js
@@ -133,12 +133,12 @@ const CustomDraftFormatModal = ({ isOpen, toggle, formatIndex, format, setFormat
             specified <code>tag:yourtagname</code> or simply <code>yourtagname</code>. <code>*</code> can be used to
             match any card.
           </FormText>
-          {packs.map((pack, index) => (
-            <Card key={index} className="mb-3">
+          {packs.map((pack, packIndex) => (
+            <Card key={packIndex} className="mb-3">
               <CardHeader>
                 <CardTitle className="mb-0">
-                  Pack {index + 1} - {pack.length} Cards
-                  <Button close onClick={handleRemovePack} data-index={index} />
+                  Pack {packIndex + 1} - {pack.length} Cards
+                  <Button close onClick={handleRemovePack} data-index={packIndex} />
                 </CardTitle>
               </CardHeader>
               <CardBody>
@@ -151,7 +151,7 @@ const CustomDraftFormatModal = ({ isOpen, toggle, formatIndex, format, setFormat
                       type="text"
                       value={card}
                       onChange={handleChangeCard}
-                      data-pack={index}
+                      data-pack={packIndex}
                       data-index={cardIndex}
                     />
                     <InputGroupAddon addonType="append">
@@ -159,7 +159,7 @@ const CustomDraftFormatModal = ({ isOpen, toggle, formatIndex, format, setFormat
                         color="secondary"
                         outline
                         onClick={handleRemoveCard}
-                        data-pack={index}
+                        data-pack={packIndex}
                         data-index={cardIndex}
                       >
                         Remove
@@ -169,10 +169,10 @@ const CustomDraftFormatModal = ({ isOpen, toggle, formatIndex, format, setFormat
                 ))}
               </CardBody>
               <CardFooter>
-                <Button className="mr-2" color="success" onClick={handleAddCard} data-index={index}>
+                <Button className="mr-2" color="success" onClick={handleAddCard} data-index={packIndex}>
                   Add Card Slot
                 </Button>
-                <Button color="success" onClick={handleDuplicatePack} data-index={index}>
+                <Button color="success" onClick={handleDuplicatePack} data-index={packIndex}>
                   Duplicate Pack
                 </Button>
               </CardFooter>
@@ -184,7 +184,7 @@ const CustomDraftFormatModal = ({ isOpen, toggle, formatIndex, format, setFormat
         </ModalBody>
         <ModalFooter>
           <Input type="hidden" name="format" value={JSON.stringify(packs)} />
-          <Input type="hidden" name="id" value={formatIndex} />
+          <Input type="hidden" name="id" value={format.id} />
           <Button color="success" type="submit">
             Save
           </Button>

--- a/src/components/DeckPreview.js
+++ b/src/components/DeckPreview.js
@@ -33,7 +33,7 @@ DeckPreview.propTypes = {
     name: PropTypes.string.isRequired,
     owner: PropTypes.string,
     username: PropTypes.string,
-    date: PropTypes.number.isRequired,
+    date: PropTypes.instanceOf(Date).isRequired,
   }).isRequired,
 };
 

--- a/src/pages/CubePlaytestPage.js
+++ b/src/pages/CubePlaytestPage.js
@@ -1,4 +1,4 @@
-import React, { useContext, useCallback, useMemo, useState } from 'react';
+import React, { useContext, useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import {
@@ -190,7 +190,7 @@ const StandardDraftCard = () => {
   );
 };
 
-const DecksCard = ({ decks, ...props }) => {
+const DecksCard = ({ decks }) => {
   const { cubeID } = useContext(CubeContext);
   return (
     <Card>
@@ -273,7 +273,6 @@ const CubePlaytestPage = ({ cube, cubeID, canEdit, decks, draftFormats }) => {
 
   const handleDeleteFormat = useCallback(
     async (event) => {
-      const formatIndex = parseInt(event.target.getAttribute('data-index'), 10);
       const formatID = event.target.getAttribute('data-id');
       try {
         const response = await csrfFetch(`/cube/${cubeID}/format/${formatID}`, {
@@ -288,7 +287,7 @@ const CubePlaytestPage = ({ cube, cubeID, canEdit, decks, draftFormats }) => {
         setFormats(formats.filter((format) => format.id !== formatID));
       } catch (err) {
         console.error(err);
-        addAlert('danger', 'Failed to delete format. ' + err.message);
+        addAlert('danger', `Failed to delete format. ${err.message}`);
       }
     },
     [addAlert, cubeID, formats],


### PR DESCRIPTION
Changes custom drafts to use id instead of index.

- Adds draft format helpers to `cubefn.js`.
- 2 other react errors on console for playtest page fixed
- improves format delete route so there aren't weird parameters