### PR TITLE
Fix issue with Android Chrome context search.

### DIFF
--- a/src/components/AutocardListItem.js
+++ b/src/components/AutocardListItem.js
@@ -38,6 +38,7 @@ const AutocardListItem = ({ card, noCardModal, inModal, className, children }) =
       onAuxClick={noCardModal ? undefined : handleAuxClick}
       onClick={noCardModal ? undefined : handleClick}
       inModal={inModal}
+      role="button"
     >
       {name}
       {children}

--- a/src/components/Maybeboard.js
+++ b/src/components/Maybeboard.js
@@ -85,6 +85,7 @@ const MaybeboardListItem = ({ card, className }) => {
       card={card}
       data-index={card.index}
       onClick={handleEdit}
+      role="button"
     >
       <div className="name">{card.details.name}</div>
       {canEdit &&


### PR DESCRIPTION
Android Chrome was doing a definition search instead of opening the card modal.