### PR TITLE
#971 cube clone notification

### DIFF
--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -166,6 +166,17 @@ router.get('/clone/:id', async (req, res) => {
     cube = setCubeType(cube, carddb);
     await cube.save();
 
+    const newOwnerq = User.findById(req.user);
+    const sourceOwnerq = User.findById(source.owner);
+    const [newOwner, sourceOwner] = await Promise.all([newOwnerq, sourceOwnerq]);
+
+    await util.addNotification(
+      sourceOwner,
+      newOwner,
+      `/cube/view/${cube._id}`,
+      `${user.username} made a cube by cloning yours: ${cube.name}`,
+    );
+
     req.flash('success', 'Cube Cloned');
     return res.redirect(`/cube/overview/${cube.shortID}`);
   } catch (err) {


### PR DESCRIPTION
fixes #971 Fire a notification when cube is cloned.

From errors I hit, it seemed like I needed a findById for both the original owner and the new owner, but some of that might be redundant.