### PR TITLE
Add jsconfig.json to help with implementation lookup

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "module": "es6",
+        "target": "es6",
+        "baseUrl": "./",
+        "paths": {
+            "serverjs/*": ["./serverjs/*"],
+            "routes/*": ["./routes/*"],
+            "analytics/*": ["./src/analytics/*"],
+            "components/*": ["./src/components/*"],
+            "hooks/*": ["./src/hooks/*"],
+            "layouts/*": ["./src/layouts/*"],
+            "pages/*": ["./src/pages/*"],
+            "utils/*": ["./src/utils/*"]
+        }
+    },
+    "include": ["src/**/*", "app.js", "serverjs/*", "routes/*"]
+}


### PR DESCRIPTION
Helps visual studio code find implementations that it wasn't finding for me because of the absolute imports.