### PR TITLE
Move card page buttons up

### DIFF
--- a/src/cardpage.js
+++ b/src/cardpage.js
@@ -2,19 +2,7 @@ import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 
-import {
-  Card,
-  CardHeader,
-  Row,
-  Col,
-  CardBody,
-  Table,
-  Nav,
-  NavItem,
-  NavLink,
-  TabContent,
-  TabPane,
-} from 'reactstrap';
+import { Card, CardHeader, Row, Col, CardBody, Table, Nav, NavItem, NavLink, TabContent, TabPane } from 'reactstrap';
 
 import ImageFallback from 'components/ImageFallback';
 import ButtonLink from 'components/ButtonLink';

--- a/src/cardpage.js
+++ b/src/cardpage.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import {
   Card,
   CardHeader,
-  CardFooter,
   Row,
   Col,
   CardBody,

--- a/src/cardpage.js
+++ b/src/cardpage.js
@@ -47,7 +47,18 @@ class CardPage extends Component {
     return (
       <Card>
         <CardHeader>
-          <h4>{card.name}</h4>
+          <h4>
+            {card.name}
+            <div className="float-right">
+              <ButtonLink className="mx-2" color="success" href={card.scryfall_uri}>
+                <span className="d-none d-sm-inline">View on Scryfall</span>
+                <span className="d-sm-none">Scryfall</span>
+              </ButtonLink>
+              <ButtonLink className="mx-2" color="secondary" href={getTCGLink({ details: card })}>
+                Buy
+              </ButtonLink>
+            </div>
+          </h4>
         </CardHeader>
         <CardBody>
           <Row>
@@ -156,15 +167,6 @@ class CardPage extends Component {
             </Row>
           </TabPane>
         </TabContent>
-        <CardFooter>
-          <ButtonLink className="mx-2" color="success" href={card.scryfall_uri}>
-            <span className="d-none d-sm-inline">View on Scryfall</span>
-            <span className="d-sm-none">Scryfall</span>
-          </ButtonLink>
-          <ButtonLink className="mx-2" color="secondary" href={getTCGLink({ details: card })}>
-            Buy
-          </ButtonLink>
-        </CardFooter>
       </Card>
     );
   }


### PR DESCRIPTION
Removes header and moves the buttons up.

Before:
![image](https://user-images.githubusercontent.com/28238025/74610352-a925ef80-50c0-11ea-8a3d-6f7f2dc15820.png)

After:
![image](https://user-images.githubusercontent.com/28238025/74610353-adeaa380-50c0-11ea-954f-2f6fb730f6ec.png)

