### PR TITLE
255 Encode search parameters

### DIFF
--- a/routes/root.js
+++ b/routes/root.js
@@ -294,10 +294,12 @@ router.get('/landing', async (req, res) => {
 router.post('/advanced_search', (req, res) => {
   let url = '/search/';
   if (req.body.name && req.body.name.length > 0) {
-    url += `name${req.body.nameType}${req.body.name};`;
+    const encoded = encodeURIComponent(req.body.name);
+    url += `name${req.body.nameType}${encoded};`;
   }
   if (req.body.owner && req.body.owner.length > 0) {
-    url += `owner_name${req.body.ownerType}${req.body.owner};`;
+    const encoded = encodeURIComponent(req.body.owner);
+    url += `owner_name${req.body.ownerType}${encoded};`;
   }
   res.redirect(url);
 });

--- a/routes/root.js
+++ b/routes/root.js
@@ -324,6 +324,10 @@ router.get('/search/:id', (req, res) => {
   let page = parseInt(rawSplit[1], 10);
   let query = {};
   const terms = [];
+
+  function regexEscape(input) {
+    return input.replace(/[-[\]/{}()*+?.\\^$|]/g, "\\$&");
+  }
   rawQueries.forEach((searchExpression) => {
     let field;
     let filter;
@@ -332,11 +336,12 @@ router.get('/search/:id', (req, res) => {
 
     if (searchExpression.includes('=')) {
       [field, filter] = searchExpression.split('=');
-      searchRegex = new RegExp(`^${filter}$`, 'i');
+      const escapedFilter = regexEscape(filter);
+      searchRegex = new RegExp(`^${escapedFilter}$`, 'i');
       expressionTerm = 'is exactly';
     } else if (searchExpression.includes('~')) {
       [field, filter] = searchExpression.split('~');
-      searchRegex = new RegExp(filter, 'i');
+      searchRegex = new RegExp(regexEscape(filter), 'i');
       expressionTerm = 'contains';
     }
 

--- a/routes/root.js
+++ b/routes/root.js
@@ -326,7 +326,7 @@ router.get('/search/:id', (req, res) => {
   const terms = [];
 
   function regexEscape(input) {
-    return input.replace(/[-[\]/{}()*+?.\\^$|]/g, "\\$&");
+    return input.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&');
   }
   rawQueries.forEach((searchExpression) => {
     let field;

--- a/routes/root.js
+++ b/routes/root.js
@@ -325,7 +325,10 @@ router.get('/search/:id', (req, res) => {
   let query = {};
   const terms = [];
 
-  function regexEscape(input) {
+  // input is the search string from a user -- should be treated as a string literal, rather than
+  // a regex with special characters.  This method escapes any characters which could be considered
+  // special characters by the regex, like . and *
+  function escapeRegexLiteral(input) {
     return input.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&');
   }
   rawQueries.forEach((searchExpression) => {
@@ -336,12 +339,12 @@ router.get('/search/:id', (req, res) => {
 
     if (searchExpression.includes('=')) {
       [field, filter] = searchExpression.split('=');
-      const escapedFilter = regexEscape(filter);
+      const escapedFilter = escapeRegexLiteral(filter);
       searchRegex = new RegExp(`^${escapedFilter}$`, 'i');
       expressionTerm = 'is exactly';
     } else if (searchExpression.includes('~')) {
       [field, filter] = searchExpression.split('~');
-      searchRegex = new RegExp(regexEscape(filter), 'i');
+      searchRegex = new RegExp(escapeRegexLiteral(filter), 'i');
       expressionTerm = 'contains';
     }
 


### PR DESCRIPTION
fixes #255 

There seemed to be two separate issues with special characters in search params. 

1 - Search params that were already HTML special character strings (like %20) were not escaped in the search URL.  Note that the server was already decoding these parameters, resulting in some unusual results:

![image](https://user-images.githubusercontent.com/18319107/74624195-608c2780-50fc-11ea-8565-7874ef886ac9.png)


2 - Search params that were special characters for regex were not escaped in the actual search method

![image](https://user-images.githubusercontent.com/18319107/74624258-a0530f00-50fc-11ea-812f-502f976cabbc.png)


This PR resolves both issues, and I've validated locally.  I don't see a great spot to write a unit test but if I've missed the right place for a test, please let me know!