### PR TITLE
1083 Add card meta for use in social media

### DIFF
--- a/routes/tools_routes.js
+++ b/routes/tools_routes.js
@@ -271,7 +271,7 @@ router.get('/card/:id', async (req, res) => {
       metadata: generateMeta(
         `${card.name} - Cube Cobra`,
         `Analytics for ${card.name} on CubeCobra`,
-        card.art_crop,
+        card.image_normal,
         `https://cubecobra.com/card/${req.params.id}`,
       ),
     });

--- a/routes/tools_routes.js
+++ b/routes/tools_routes.js
@@ -7,6 +7,7 @@ const cardutil = require('../dist/utils/Card.js');
 const { addPrices, GetPrices } = require('../serverjs/prices');
 const Filter = require('../dist/utils/Filter');
 const { getElo } = require('../serverjs/cubefn.js');
+const generateMeta = require('../serverjs/meta.js');
 
 const CardRating = require('../models/cardrating');
 const Card = require('../models/card');
@@ -258,12 +259,22 @@ router.get('/card/:id', async (req, res) => {
     const pids = carddb.nameToId[card.name_lower].map((id) => carddb.cardFromId(id).tcgplayer_id);
     const prices = await GetPrices(pids);
     card.elo = (await getElo([card.name], true))[card.name];
-    return res.render('tool/cardpage', {
+    const reactProps = {
       card,
       data,
       prices,
       cubes,
       related: data.cubedWith.map((name) => carddb.getMostReasonable(name[0])),
+    };
+    return res.render('tool/cardpage', {
+      reactProps: serialize(reactProps),
+      title: `${card.name}`,
+      metadata: generateMeta(
+        `${card.name} - Cube Cobra`,
+        `Analytics for ${card.name} on CubeCobra`,
+        card.art_crop,
+        `https://cubecobra.com/card/${req.params.id}`,
+      ),
     });
   } catch (err) {
     console.error(err);

--- a/src/cardpage.js
+++ b/src/cardpage.js
@@ -72,9 +72,9 @@ class CardPage extends Component {
             </Col>
             <Col className="breakdown" xs="12" sm="8">
               <p>
-                Played in
+                Played in &nbsp;
                 {Math.round(data.total[1] * 1000.0) / 10}%<span className="percent">{data.total[0]}</span>
-                Cubes total.
+                &nbsp;Cubes total.
               </p>
               <Row>
                 <Col xs="12" sm="6" md="6" lg="6">
@@ -201,13 +201,8 @@ CardPage.propTypes = {
   cubes: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
 };
 
-const data = JSON.parse(document.getElementById('data').value);
-const card = JSON.parse(document.getElementById('card').value);
-const prices = JSON.parse(document.getElementById('prices').value);
-const cubes = JSON.parse(document.getElementById('cubes').value);
-const related = JSON.parse(document.getElementById('related').value);
 const wrapper = document.getElementById('react-root');
-const element = <CardPage data={data} card={card} prices={prices} related={related} cubes={cubes} />;
+const element = <CardPage {...window.reactProps} />;
 if (wrapper) {
   ReactDOM.render(element, wrapper);
 }

--- a/src/cardpage.js
+++ b/src/cardpage.js
@@ -70,9 +70,8 @@ class CardPage extends Component {
             </Col>
             <Col className="breakdown" xs="12" sm="8">
               <p>
-                Played in &nbsp;
-                {Math.round(data.total[1] * 1000.0) / 10}%<span className="percent">{data.total[0]}</span>
-                &nbsp;Cubes total.
+                Played in {Math.round(data.total[1] * 1000.0) / 10}%<span className="percent">{data.total[0]}</span>{' '}
+                Cubes total.
               </p>
               <Row>
                 <Col xs="12" sm="6" md="6" lg="6">

--- a/views/tool/cardpage.pug
+++ b/views/tool/cardpage.pug
@@ -2,12 +2,12 @@ extends ../layout
 
 block content
   include ../flash
-  input(type='hidden', id='data', value=JSON.stringify(data))
-  input(type='hidden', id='card', value=JSON.stringify(card))
-  input(type='hidden', id='prices', value=JSON.stringify(prices))
-  input(type='hidden', id='related', value=JSON.stringify(related))
-  input(type='hidden', id='cubes', value=JSON.stringify(cubes))
+
   #react-root
+
+block scripts
   include ../react
+  script(type='text/javascript').
+    window.reactProps = !{reactProps};
   script(src='/js/autocard.js')
   script(src='/js/cardpage.bundle.js')


### PR DESCRIPTION
fixes #1083 

Social media (like Discord) requires a set of meta tags in the head to be able to show the contextual card. However these meta tags were missing for the single-card analysis pages.

Luckily we had already written a method to generate meta for other pages, so I only had to pull it in for the card analytics page. 

Along the way, I had to refactor this page to use window.reactProps.

I can see the meta tags in my local browser, and I'll also retest with Discord after it's pushed to Dev.