### PR TITLE
1092 upload page state

### DIFF
--- a/app.js
+++ b/app.js
@@ -212,6 +212,11 @@ app.get('*', (req, res, next) => {
   next();
 });
 
+app.post('*', (req, res, next) => {
+  res.locals.user = req.user || null;
+  next();
+});
+
 // Route files; they manage their own CSRF protection
 const cubes = require('./routes/cube_routes');
 const users = require('./routes/users_routes');

--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -1051,10 +1051,9 @@ router.post('/importcubetutor/:id', ensureAuth, body('cubeid').toInt(), flashVal
         blogpost: blogpost.toObject(),
       };
       return res.render('cube/bulk_upload', {
-        reactHTML:
-          NODE_ENV === 'production'
-            ? await ReactDOMServer.renderToString(React.createElement(BulkUploadPage, reactProps))
-            : undefined,
+        reactHTML: BulkUploadPage
+          ? await ReactDOMServer.renderToString(React.createElement(BulkUploadPage, reactProps))
+          : undefined,
         reactProps: serialize(reactProps),
         cube,
         cubeID: req.params.id,
@@ -1236,10 +1235,9 @@ async function bulkUploadCSV(req, res, cards, cube) {
       blogpost: blogpost.toObject(),
     };
     return res.render('cube/bulk_upload', {
-      reactHTML:
-        NODE_ENV === 'production'
-          ? await ReactDOMServer.renderToString(React.createElement(BulkUploadPage, reactProps))
-          : undefined,
+      reactHTML: BulkUploadPage
+        ? await ReactDOMServer.renderToString(React.createElement(BulkUploadPage, reactProps))
+        : undefined,
       reactProps: serialize(reactProps),
       cube,
       cubeID: req.params.id,

--- a/views/cube/cube_layout.pug
+++ b/views/cube/cube_layout.pug
@@ -11,14 +11,14 @@ block content
             |  (#{cube.card_count} Card #{cube.type} Cube)
       .d-flex.flex-row.flex-wrap
         li.nav-item
-          a.nav-link(href='/cube/overview/'+cube_id, class=activeLink === 'overview' && 'active') Overview
+          a.nav-link(href='/cube/overview/'+get_cube_id(cube), class=activeLink === 'overview' && 'active') Overview
         li.nav-item
-          a.nav-link(href='/cube/list/'+cube_id, class=activeLink === 'list' && 'active') List
+          a.nav-link(href='/cube/list/'+get_cube_id(cube), class=activeLink === 'list' && 'active') List
         li.nav-item
-          a.nav-link(href='/cube/playtest/'+cube_id, class=activeLink === 'playtest' && 'active') Playtest
+          a.nav-link(href='/cube/playtest/'+get_cube_id(cube), class=activeLink === 'playtest' && 'active') Playtest
         li.nav-item
-          a.nav-link(href='/cube/analysis/'+cube_id, class=activeLink === 'analysis' && 'active') Analysis
+          a.nav-link(href='/cube/analysis/'+get_cube_id(cube), class=activeLink === 'analysis' && 'active') Analysis
         li.nav-item
-          a.nav-link(href='/cube/blog/'+cube_id, class=activeLink === 'blog' && 'active') Blog
+          a.nav-link(href='/cube/blog/'+get_cube_id(cube), class=activeLink === 'blog' && 'active') Blog
   block cube_toolbar
   block cube_content


### PR DESCRIPTION
fixes #1092 

This work is related to the page that appears when you attempt to import card names into a cube, but a few card names are not found.

In the reported bug, there are two issues which I initially thought were related:

![image](https://user-images.githubusercontent.com/18319107/74987543-4306d880-53f0-11ea-9fd4-f783f4c51700.png)

1: The user appears to be logged out on this page.  The user was logged in before and after this page
2: The various tabs on the cube navigation page went to /undefined instead of the actual cube ID.

Here are the fixes:

Issue 1: 
In most pages on CC, POSTS are immediately redirected to a GET.  This is not the case for the import error page -- the HTML returned to the user is actually the response to the POST.

In app.js, we already had code to make the user's login info "sticky" across GET requests.  I added the similar block below, to make the login sticky for POST as well.

Issue 2:
The cube_layout.pug layout controls the cube navigation, and the layout was not receiving cube_id as part of the react props.  I initially passed in cube_id as a sibling of the cube object, but I noticed that other pages actually used get_cube_id(cube) instead of passing both, so I updated the layout and tested the other cube pages.
