### PR TITLE
More room for diff on blog post

### DIFF
--- a/src/components/BlogPost.js
+++ b/src/components/BlogPost.js
@@ -98,12 +98,12 @@ class BlogPost extends React.Component {
         <div style={{ overflow: 'auto', maxHeight: '50vh' }}>
           {post.changelist && post.html ? (
             <Row className="no-gutters">
-              <Col className="col-12 col-l-3 col-md-3 col-sm-12" style={{ borderRight: '1px solid #DFDFDF' }}>
+              <Col className="col-12 col-l-5 col-md-4 col-sm-12" style={{ borderRight: '1px solid #DFDFDF' }}>
                 <CardBody className="py-2">
                   <CardText dangerouslySetInnerHTML={{ __html: post.changelist }} />
                 </CardBody>
               </Col>
-              <Col className="col-9">
+              <Col className="col-l-7 col-m-6">
                 <CardBody className="py-2">
                   <CardText dangerouslySetInnerHTML={{ __html: post.html }} />
                 </CardBody>


### PR DESCRIPTION
Right now most diff lines (like "Strandwalker -> Darksteel Sentinel") wrap onto another line, sometimes two. This adds a little more space.

Before, large:
![before large](https://user-images.githubusercontent.com/1253274/74991794-e0b3d500-53fb-11ea-9bc5-87430d4cfb29.png)

Before, medium:
![before medium](https://user-images.githubusercontent.com/1253274/74991809-e7424c80-53fb-11ea-9c8f-697e238a55b6.png)

After, large:
<img width="1129" alt="after large" src="https://user-images.githubusercontent.com/1253274/74991817-ec070080-53fb-11ea-8cd2-1a751d505c9e.png">

After, medium:
<img width="952" alt="after medium" src="https://user-images.githubusercontent.com/1253274/74991824-f1644b00-53fb-11ea-9f43-d8ccf43578ed.png">

(small is unaffected)