### PR TITLE
1123 draft should allow cmc null

### DIFF
--- a/src/utils/Draft.js
+++ b/src/utils/Draft.js
@@ -79,7 +79,7 @@ function botPicks() {
     const ratedPicks = [];
     const unratedPicks = [];
     for (let cardIndex = 0; cardIndex < botPack.length; cardIndex++) {
-      if (draft.ratings[botPack[cardIndex].details.name]) {
+      if (draft.ratings && draft.ratings[botPack[cardIndex].details.name]) {
         ratedPicks.push(cardIndex);
       } else {
         unratedPicks.push(cardIndex);

--- a/src/utils/Util.js
+++ b/src/utils/Util.js
@@ -79,6 +79,10 @@ export function alphaCompare(a, b) {
 
 export function cmcColumn(card) {
   let cmc = Object.prototype.hasOwnProperty.call(card, 'cmc') ? card.cmc : card.details.cmc;
+  // double equals also handles undefined
+  if (cmc == null) {
+    cmc = 0;
+  }
   if (!Number.isFinite(cmc)) {
     cmc = cmc.indexOf('.') > -1 ? parseFloat(cmc) : parseInt(cmc, 10);
   }


### PR DESCRIPTION
fixes #1123 but we might want some follow up work, i opened https://github.com/dekkerglen/CubeCobra/issues/1133 for later discussion.

In the reported issue, both cards that were undraftable had CMC `null` instead of 0 as expected.

On my local database, the cards initially had CMC zero, but I could reproduce this issue using bulk edit:

![image](https://user-images.githubusercontent.com/18319107/74996454-76edf800-5408-11ea-946e-456cf7807d4e.png)

This quick-fix allows CMC `null` cards to be drafted, and places them in the 0 CMC column.

