### PR TITLE
Use faster queries on landing page

### DIFF
--- a/routes/root.js
+++ b/routes/root.js
@@ -266,9 +266,9 @@ router.get('/dashboard/decks/:page', async (req, res) => {
 });
 
 router.get('/landing', async (req, res) => {
-  const cubeq = Cube.countDocuments().exec();
-  const deckq = Deck.countDocuments().exec();
-  const userq = User.countDocuments().exec();
+  const cubeq = Cube.estimatedDocumentCount().exec();
+  const deckq = Deck.estimatedDocumentCount().exec();
+  const userq = User.estimatedDocumentCount().exec();
 
   const [cube, deck, user] = await Promise.all([cubeq, deckq, userq]);
 


### PR DESCRIPTION
The prod front page takes 8 sec to load.  phulin discovered this new method that is faster than countDocuments if you don't need precision. 

https://jira.mongodb.org/browse/NODE-1638

https://stackoverflow.com/a/54607751/470808