### PR TITLE
adds Prismatic Vista and Fabled Passage to fetchland list [#1135]

### DIFF
--- a/src/utils/Draft.js
+++ b/src/utils/Draft.js
@@ -50,6 +50,8 @@ const fetchLands = {
   'Verdant Catacombs': ['B', 'G'],
   'Windswept Heath': ['W', 'G'],
   'Wooded Foothills': ['R', 'G'],
+  'Prismatic Vista': ['W', 'U', 'B', 'R', 'G'],
+  'Fabled Passage': ['W', 'U', 'B', 'R', 'G'],
 };
 
 function botRating(botColors, card) {


### PR DESCRIPTION
Adds the two new 5c basic fetches to the fetchland list that boosts ELO ratings for bots drafting.