### PR TITLE
Ignore tests and private for nodemon

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "prettier-master": "prettier --write $(git diff master --name-only | grep -E '.js$')",
     "prettier-head": "prettier --write $(git diff HEAD --name-only | grep -E '.js$')",
     "lint": "prettier --check {__tests__,fixtures,models,one_shot_scripts,public,routes,serverjs,src,views}'/**/*.js' && eslint app.js models public/js routes serverjs src",
-    "nodemon": "nodemon --ignore src --ignore public",
+    "nodemon": "nodemon --ignore src --ignore public --ignore private --ignore dist/pages --ignore __tests__",
     "webpack-dev-server": "webpack-dev-server --config webpack.dev.js",
     "build": "webpack --mode production --config webpack.prod.js --progress",
-    "start": "nodemon --ignore src --ignore public --ignore dist/pages & webpack-dev-server --config webpack.dev.js & webpack --mode development --config webpack.server.js --watch",
+    "start": "npm run nodemon & webpack-dev-server --config webpack.dev.js & webpack --mode development --config webpack.server.js --watch",
     "test": "jest --silent --detectOpenHandles  --coverage",
     "setup": "webpack --mode development --config webpack.server.js --progress && node --max-old-space-size=4096 force_update.js"
   },


### PR DESCRIPTION
Prevents thrashing when updating carddb and unneeded reloads when modifying tests.