### PR TITLE
Default to connecting over 127.0.0.1 to force IPv4.

### DIFF
--- a/cubecobrasecrets.example/mongodb.js
+++ b/cubecobrasecrets.example/mongodb.js
@@ -1,5 +1,4 @@
-module.exports =
-{
-  connectionString:'mongodb://localhost:27017/nodecube',
-  dbname:'nodecube'
-}
+module.exports = {
+  connectionString: 'mongodb://127.0.0.1:27017/nodecube',
+  dbname: 'nodecube',
+};


### PR DESCRIPTION
MongoDB by default refuses IPv6 queries which mongoose will use by default on some systems.