### PR TITLE
Add custom images to sample pack

### DIFF
--- a/__tests__/serverjs/cards.test.js
+++ b/__tests__/serverjs/cards.test.js
@@ -146,7 +146,7 @@ test('getCardDetails returns a well-formed card object', () => {
     const result = carddb.getCardDetails({
       cardID: _id,
     });
-    expect(result).toEqual(expected);
+    expect(result).toEqual(expected.details);
   });
 });
 
@@ -160,7 +160,7 @@ test('getCardDetails returns a placeholder card object when given a nonexistent 
     const result = carddb.getCardDetails({
       cardID: _id,
     });
-    expect(result).toEqual(expected);
+    expect(result).toEqual(expected.details);
   });
 });
 

--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -4,7 +4,7 @@ const { body, param } = require('express-validator');
 const fetch = require('node-fetch');
 const cheerio = require('cheerio');
 const serialize = require('serialize-javascript');
-const mergeImages = require('merge-images');
+// const mergeImages = require('merge-images');
 const RSS = require('rss');
 const { Canvas, Image } = require('canvas');
 
@@ -14,6 +14,7 @@ const React = require('react');
 const ReactDOMServer = require('react-dom/server');
 // eslint-disable-next-line import/no-unresolved
 const secrets = require('../../cubecobrasecrets/secrets');
+const mergeImages = require('../serverjs/mergeImages');
 
 const {
   addAutocard,
@@ -993,9 +994,11 @@ router.get('/samplepackimage/:id/:seed', async (req, res) => {
 
     const srcArray = pack.pack.map((card, index) => {
       return {
-        src: card.image_normal,
-        x: CARD_WIDTH * (index % 5),
-        y: CARD_HEIGHT * Math.floor(index / 5),
+        src: card.imgUrl || card.details.image_normal,
+        left: CARD_WIDTH * (index % 5),
+        top: CARD_HEIGHT * Math.floor(index / 5),
+        width: CARD_WIDTH,
+        height: CARD_HEIGHT,
       };
     });
 
@@ -1003,12 +1006,15 @@ router.get('/samplepackimage/:id/:seed', async (req, res) => {
       width: CARD_WIDTH * 5,
       height: CARD_HEIGHT * 3,
       Canvas,
-    }).then((image) => {
-      res.writeHead(200, {
-        'Content-Type': 'image/png',
-      });
-      res.end(Buffer.from(image.replace(/^data:image\/png;base64,/, ''), 'base64'));
-    });
+      Image,
+    })
+      .then((image) => {
+        res.writeHead(200, {
+          'Content-Type': 'image/png',
+        });
+        res.end(Buffer.from(image.replace(/^data:image\/png;base64,/, ''), 'base64'));
+      })
+      .catch((err) => util.handleRouteError(req, res, err, '/404'));
   } catch (err) {
     return util.handleRouteError(req, res, err, '/404');
   }

--- a/serverjs/cards.js
+++ b/serverjs/cards.js
@@ -75,10 +75,11 @@ function getCardDetails(card) {
   if (data._carddict[card.cardID]) {
     const details = data._carddict[card.cardID];
     card.details = details;
-    return details;
+    return card;
   }
   winston.error(null, { error: new Error(`Could not find card details: ${card.cardID}`) });
-  return getPlaceholderCard(card.cardID);
+  card.details = getPlaceholderCard(card.cardID);
+  return card;
 }
 
 function loadJSONFile(filename, attribute) {

--- a/serverjs/mergeImages.js
+++ b/serverjs/mergeImages.js
@@ -45,7 +45,7 @@ const mergeImages = (sources = [], options = {}) =>
           // Resolve source and img when loaded
           const img = new Image();
           img.crossOrigin = options.crossOrigin;
-          img.onerror = () => reject(new Error("Couldn't load image"));
+          img.onerror = () => reject(new Error(`Couldn't load image '${source.src}'`));
           img.onload = () => resolve({ ...source, img });
           img.src = source.src;
         }),

--- a/serverjs/mergeImages.js
+++ b/serverjs/mergeImages.js
@@ -1,0 +1,105 @@
+// Copy of https://github.com/lukechilds/merge-images
+// With the following pull request:
+// #87 Add top/bottom/left/right/width/height options. Created by RedSparr0w
+// When this pull request is merged this file can be deleted.
+
+// Defaults
+const defaultOptions = {
+  format: 'image/png',
+  quality: 0.92,
+  width: undefined,
+  height: undefined,
+  Canvas: undefined,
+  crossOrigin: undefined,
+};
+
+function getX(image, width) {
+  if (image.right !== undefined) return width - (image.right + (image.width || image.img.width));
+  return image.left || image.x || 0;
+}
+
+function getY(image, height) {
+  if (image.bottom !== undefined) return height - (image.bottom + (image.height || image.img.height));
+  return image.top || image.y || 0;
+}
+
+// Return Promise
+const mergeImages = (sources = [], options = {}) =>
+  new Promise((resolve) => {
+    options = { ...defaultOptions, ...options };
+
+    // Setup browser/Node.js specific variables
+    const canvas = options.Canvas ? new options.Canvas() : window.document.createElement('canvas');
+    const Image = options.Image || window.Image;
+
+    // Load sources
+    const images = sources.map(
+      (source) =>
+        // eslint-disable-next-line no-shadow
+        new Promise((resolve, reject) => {
+          // Convert sources to objects
+          if (source.constructor.name !== 'Object') {
+            source = { src: source };
+          }
+
+          // Resolve source and img when loaded
+          const img = new Image();
+          img.crossOrigin = options.crossOrigin;
+          img.onerror = () => reject(new Error("Couldn't load image"));
+          img.onload = () => resolve({ ...source, img });
+          img.src = source.src;
+        }),
+    );
+
+    // Get canvas context
+    const ctx = canvas.getContext('2d');
+
+    // When sources have loaded
+    resolve(
+      // eslint-disable-next-line no-shadow
+      Promise.all(images).then((images) => {
+        // Set canvas dimensions
+        const getSize = (dim) => options[dim] || Math.max(...images.map((image) => image.img[dim]));
+        canvas.width = getSize('width');
+        canvas.height = getSize('height');
+
+        // Draw images to canvas
+        images.forEach((image) => {
+          ctx.globalAlpha = image.opacity ? image.opacity : 1;
+          return ctx.drawImage(
+            image.img,
+            getX(image, canvas.width),
+            getY(image, canvas.height),
+            image.width || image.img.width,
+            image.height || image.img.height,
+          );
+        });
+
+        if (options.Canvas && options.format === 'image/jpeg') {
+          // Resolve data URI for node-canvas jpeg async
+          // eslint-disable-next-line no-shadow
+          return new Promise((resolve, reject) => {
+            canvas.toDataURL(
+              options.format,
+              {
+                quality: options.quality,
+                progressive: false,
+              },
+              (err, jpeg) => {
+                if (err) {
+                  reject(err);
+                  return;
+                }
+                resolve(jpeg);
+              },
+            );
+          });
+        }
+
+        // Resolve all other data URIs sync
+        return canvas.toDataURL(options.format, options.quality);
+      }),
+    );
+  });
+
+module.exports = mergeImages;

--- a/views/cube/cube_samplepack.pug
+++ b/views/cube/cube_samplepack.pug
@@ -18,9 +18,17 @@ block cube_content
             each card, i in pack
               if i % 5 === 0
                 .col-md-2.offset-md-1(style='padding-top:10px;')
-                  a.autocard(card=card.image_normal)
-                    img.defaultCardImage( src=card.image_normal, width='150', height='210')
+                  if card.imgUrl
+                    a.autocard(card=card.imgUrl)
+                      img.defaultCardImage( src=card.imgUrl, width='150', height='210')
+                  else
+                    a.autocard(card=card.details.image_normal)
+                      img.defaultCardImage( src=card.details.image_normal, width='150', height='210')
               else
                 .col-md-2(style='padding-top:10px;')
-                  a.autocard(card=card.image_normal)
-                    img.defaultCardImage( src=card.image_normal, width='150', height='210')
+                  if card.imgUrl
+                    a.autocard(card=card.imgUrl)
+                      img.defaultCardImage( src=card.imgUrl, width='150', height='210')
+                  else
+                    a.autocard(card=card.details.image_normal)
+                      img.defaultCardImage( src=card.details.image_normal, width='150', height='210')


### PR DESCRIPTION
Issue #684 "Get Image" of sample pack doesn't use custom images

Custom images can have different sizes, so the merge images function needs to set the size of each image. The merge-images package doesn't support that yet. However, someone made a pull request with this functionality. For now I have made a copy of it. When the pull request is merged, we can go back to the reference the package.