### PR TITLE
Color Category and Rarity Overrides

### DIFF
--- a/models/cube.js
+++ b/models/cube.js
@@ -11,6 +11,7 @@ const Card = {
   addedTmsp: Date,
   imgUrl: String,
   notes: String,
+  colorCategory: String,
   details: {},
 };
 

--- a/models/cube.js
+++ b/models/cube.js
@@ -8,6 +8,7 @@ const Card = {
   cmc: Number,
   cardID: String,
   type_line: String,
+  rarity: String,
   addedTmsp: Date,
   imgUrl: String,
   notes: String,

--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -147,8 +147,8 @@
 		padding: 2px 4px;
 	}
 	.table-col {
-		flex: 0 0 calc(100% / 8);
-		width: calc(100% / 8);
+		flex: 0 0 calc(100% / 9);
+		width: calc(100% / 9);
 	}
 }
 

--- a/src/components/CardModal.js
+++ b/src/components/CardModal.js
@@ -16,7 +16,7 @@ import {
 } from 'reactstrap';
 
 import Affiliate from 'utils/Affiliate';
-import { getLabels } from 'utils/Sort';
+import { getLabels, cardGetLabels } from 'utils/Sort';
 
 import { ColorChecksAddon } from 'components/ColorCheck';
 import LoadingButton from 'components/LoadingButton';
@@ -138,6 +138,16 @@ const CardModal = ({
               <InputGroup className="mb-3">
                 <InputGroupText className="square-right">Color</InputGroupText>
                 <ColorChecksAddon addonType="append" prefix="color" values={values} onChange={onChange} />
+              </InputGroup>
+              <InputGroup className="mb-3">
+                <InputGroupAddon addonType="prepend">
+                  <InputGroupText>Color Category</InputGroupText>
+                </InputGroupAddon>
+                <CustomInput type="select" name="colorCategory" id="colorCat" value={values.colorCategory || cardGetLabels(card, 'Color Category' )} onChange={onChange}>
+                  {getLabels(null, 'Color Category').map((colorCat) => (
+                    <option key={colorCat}>{colorCat}</option>
+                  ))}
+                </CustomInput>
               </InputGroup>
 
               <h5>Notes</h5>

--- a/src/components/CardModal.js
+++ b/src/components/CardModal.js
@@ -131,6 +131,16 @@ const CardModal = ({
               </InputGroup>
               <InputGroup className="mb-3">
                 <InputGroupAddon addonType="prepend">
+                  <InputGroupText>Rarity</InputGroupText>
+                </InputGroupAddon>
+                <CustomInput type="select" name="rarity" id="cardModalRarity" value={values.rarity} onChange={onChange}>
+                  {getLabels(null, 'Rarity').map((rarity) => (
+                    <option key={rarity}>{rarity}</option>
+                  ))}
+                </CustomInput>
+              </InputGroup>
+              <InputGroup className="mb-3">
+                <InputGroupAddon addonType="prepend">
                   <InputGroupText>Image URL</InputGroupText>
                 </InputGroupAddon>
                 <Input type="text" name="imgUrl" value={values.imgUrl} onChange={onChange} />

--- a/src/components/CardModal.js
+++ b/src/components/CardModal.js
@@ -143,7 +143,13 @@ const CardModal = ({
                 <InputGroupAddon addonType="prepend">
                   <InputGroupText>Color Category</InputGroupText>
                 </InputGroupAddon>
-                <CustomInput type="select" name="colorCategory" id="colorCat" value={values.colorCategory || cardGetLabels(card, 'Color Category' )} onChange={onChange}>
+                <CustomInput
+                  type="select"
+                  name="colorCategory"
+                  id="colorCat"
+                  value={values.colorCategory || cardGetLabels(card, 'Color Category')}
+                  onChange={onChange}
+                >
                   {getLabels(null, 'Color Category').map((colorCat) => (
                     <option key={colorCat}>{colorCat}</option>
                   ))}

--- a/src/components/CardModalForm.js
+++ b/src/components/CardModalForm.js
@@ -79,6 +79,7 @@ const CardModalForm = ({ children, ...props }) => {
   const saveChanges = useCallback(async () => {
     const colors = [...'WUBRG'].filter((color) => formValues[`color${color}`]);
     const updated = { ...formValues, colors };
+    updated.rarity = updated.rarity.toLowerCase();
     for (const color of [...'WUBRG']) {
       delete updated[`color${color}`];
     }
@@ -87,6 +88,9 @@ const CardModalForm = ({ children, ...props }) => {
     }
     if (updated.notes === '') {
       updated.notes = null;
+    }
+    if (updated.rarity === card.details.rarity) {
+      updated.rarity = null;
     }
     if (updated.colorCategory === cardGetLabels(card, 'Color Category')) {
       updated.colorCategory = null;
@@ -163,6 +167,8 @@ const CardModalForm = ({ children, ...props }) => {
   const openCardModal = useCallback((newCard, newMaybe) => {
     const colors = newCard.colors || newCard.details.colors;
     const typeLine = newCard.type_line || newCard.details.type;
+    let rarity = newCard.rarity || newCard.details.rarity;
+    rarity = rarity[0].toUpperCase() + rarity.slice(1);
     const tags = newCard.tags || [];
     setCard(newCard);
     setMaybe(!!newMaybe);
@@ -172,6 +178,7 @@ const CardModalForm = ({ children, ...props }) => {
       finish: newCard.finish,
       cmc: newCard.cmc,
       type_line: typeLine,
+      rarity: rarity,
       imgUrl: newCard.imgUrl || '',
       notes: newCard.notes || '',
       tags: tags.map((tag) => ({ id: tag, text: tag })),

--- a/src/components/CardModalForm.js
+++ b/src/components/CardModalForm.js
@@ -9,10 +9,11 @@ import CardModalContext from 'components/CardModalContext';
 import ChangelistContext from 'components/ChangelistContext';
 import CubeContext from 'components/CubeContext';
 import MaybeboardContext from 'components/MaybeboardContext';
+import { cardGetLabels } from 'utils/Sort';
 
 const CardModalForm = ({ children, ...props }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [card, setCard] = useState({ colors: [], details: {}, tags: [] });
+  const [card, setCard] = useState({ colors: [], details: { type: '' }, tags: [], type_line: '' });
   const [maybe, setMaybe] = useState(false);
   const [versionDict, setVersionDict] = useState({});
   const [versionsLoading, setVersionsLoading] = useState(true);
@@ -86,6 +87,9 @@ const CardModalForm = ({ children, ...props }) => {
     }
     if (updated.notes === '') {
       updated.notes = null;
+    }
+    if (updated.colorCategory === cardGetLabels(card, 'Color Category')) {
+      updated.colorCategory = null;
     }
     updated.cardID = updated.version;
     delete updated.version;

--- a/src/components/TableView.js
+++ b/src/components/TableView.js
@@ -25,8 +25,8 @@ const TableView = ({ cards, rowTag, noGroupModal, className, ...props }) => {
             md={compressedView ? undefined : 'auto'}
             className="table-col"
             style={{
-              width: `${100 / Math.min(sorted.length, 8)}%`,
-              flexBasis: compressedView ? `${100 / Math.min(sorted.length, 8)}%` : undefined,
+              width: `${100 / Math.min(sorted.length, 9)}%`,
+              flexBasis: compressedView ? `${100 / Math.min(sorted.length, 9)}%` : undefined,
             }}
           >
             <h6 className="text-center card-list-heading">

--- a/src/utils/Card.js
+++ b/src/utils/Card.js
@@ -72,7 +72,8 @@ export function cardsAreEquivalent(a, b) {
     a.finish === b.finish &&
     a.imgUrl === b.imgUrl &&
     a.notes === b.notes &&
-    a.colorCategory === b.colorCategory
+    a.colorCategory === b.colorCategory &&
+    a.rarity === b.rarity
   );
 }
 

--- a/src/utils/Card.js
+++ b/src/utils/Card.js
@@ -71,7 +71,8 @@ export function cardsAreEquivalent(a, b) {
     arraysEqual(a.tags, b.tags) &&
     a.finish === b.finish &&
     a.imgUrl === b.imgUrl &&
-    a.notes === b.notes
+    a.notes === b.notes &&
+    a.colorCategory === b.colorCategory
   );
 }
 

--- a/src/utils/Filter.js
+++ b/src/utils/Filter.js
@@ -635,7 +635,7 @@ function filterApply(card, filter, inCube) {
   }
   if (filter.category == 'rarity') {
     let { rarity } = card.details;
-    if( card.rarity ) rarity = card.rarity;
+    if (card.rarity) rarity = card.rarity;
     const rarityNum = rarity_order.indexOf(rarity);
     const argNum = rarity_order.indexOf(filter.arg);
     res = testNumeric(filter, rarityNum, argNum);

--- a/src/utils/Filter.js
+++ b/src/utils/Filter.js
@@ -634,7 +634,8 @@ function filterApply(card, filter, inCube) {
     }
   }
   if (filter.category == 'rarity') {
-    const { rarity } = card.details;
+    let { rarity } = card.details;
+    if( card.rarity ) rarity = card.rarity;
     const rarityNum = rarity_order.indexOf(rarity);
     const argNum = rarity_order.indexOf(filter.arg);
     res = testNumeric(filter, rarityNum, argNum);

--- a/src/utils/Sort.js
+++ b/src/utils/Sort.js
@@ -444,7 +444,7 @@ function typeLine(card) {
 
 export function cardGetLabels(card, sort) {
   if (sort == 'Color Category') {
-    if (card.colorCategory ) return [card.colorCategory];
+    if (card.colorCategory) return [card.colorCategory];
     return [GetColorCategory(typeLine(card), colorIdentity(card))];
   }
   if (sort == 'Color Identity') {

--- a/src/utils/Sort.js
+++ b/src/utils/Sort.js
@@ -538,7 +538,7 @@ export function cardGetLabels(card, sort) {
     return [card.details.set.toUpperCase()];
   } else if (sort == 'Rarity') {
     let { rarity } = card.details;
-    if( card.rarity ) rarity = card.rarity;
+    if (card.rarity) rarity = card.rarity;
     return [rarity[0].toUpperCase() + rarity.slice(1)];
   } else if (sort == 'Subtype') {
     const split = typeLine(card).split(/[-–—]/);

--- a/src/utils/Sort.js
+++ b/src/utils/Sort.js
@@ -537,7 +537,9 @@ export function cardGetLabels(card, sort) {
   } else if (sort == 'Set') {
     return [card.details.set.toUpperCase()];
   } else if (sort == 'Rarity') {
-    return [card.details.rarity[0].toUpperCase() + card.details.rarity.slice(1)];
+    let { rarity } = card.details;
+    if( card.rarity ) rarity = card.rarity;
+    return [rarity[0].toUpperCase() + rarity.slice(1)];
   } else if (sort == 'Subtype') {
     const split = typeLine(card).split(/[-–—]/);
     if (split.length > 1) {

--- a/src/utils/Sort.js
+++ b/src/utils/Sort.js
@@ -118,7 +118,7 @@ const ALL_CMCS = Array.from(Array(33).keys())
 
 function getLabelsRaw(cube, sort) {
   if (sort == 'Color Category') {
-    return ['White', 'Blue', 'Black', 'Red', 'Green', 'Multicolored', 'Colorless', 'Lands'];
+    return ['White', 'Blue', 'Black', 'Red', 'Green', 'Hybrid', 'Multicolored', 'Colorless', 'Lands'];
   }
   if (sort == 'Color Identity') {
     return ['White', 'Blue', 'Black', 'Red', 'Green', 'Multicolored', 'Colorless'];
@@ -444,6 +444,7 @@ function typeLine(card) {
 
 export function cardGetLabels(card, sort) {
   if (sort == 'Color Category') {
+    if (card.colorCategory ) return [card.colorCategory];
     return [GetColorCategory(typeLine(card), colorIdentity(card))];
   }
   if (sort == 'Color Identity') {


### PR DESCRIPTION
Addresses #1081 

Adds color category and rarity override fields to the card modal.

Adding two drop downs with overrides for every primary sort turned out to be really complicated because some sorts put cards in multiple columns, so this seems like the best way to handle this for now.

Once we have custom sorts those will handle other edge cases, but this will cover the super common case of wanting mono lands to sort with their colors in color category mode.

Also adds hybrid as a possible column in color category mode - cards will need to be overridden to appear in this column.