### PR TITLE
Adds Historic cube category override

### DIFF
--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -2363,7 +2363,7 @@ router.post(
 
     // cube category override
     if (cube.overrideCategory) {
-      const categories = ['Vintage', 'Legacy+', 'Legacy', 'Modern', 'Pioneer', 'Standard', 'Set'];
+      const categories = ['Vintage', 'Legacy+', 'Legacy', 'Modern', 'Pioneer', 'Historic', 'Standard', 'Set'];
       const prefixes = [
         'Powered',
         'Unpowered',

--- a/src/components/CubeOverviewModal.js
+++ b/src/components/CubeOverviewModal.js
@@ -247,7 +247,7 @@ class CubeOverviewModal extends Component {
                 <Row>
                   <Col>
                     <FormGroup tag="fieldset">
-                      {['Vintage', 'Legacy+', 'Legacy', 'Modern', 'Pioneer', 'Standard', 'Set'].map((label) => (
+                      {['Vintage', 'Legacy+', 'Legacy', 'Modern', 'Pioneer', 'Historic', 'Standard', 'Set'].map((label) => (
                         <FormGroup check key={label}>
                           <Label check>
                             <Input

--- a/src/components/CubeOverviewModal.js
+++ b/src/components/CubeOverviewModal.js
@@ -247,21 +247,23 @@ class CubeOverviewModal extends Component {
                 <Row>
                   <Col>
                     <FormGroup tag="fieldset">
-                      {['Vintage', 'Legacy+', 'Legacy', 'Modern', 'Pioneer', 'Historic', 'Standard', 'Set'].map((label) => (
-                        <FormGroup check key={label}>
-                          <Label check>
-                            <Input
-                              type="radio"
-                              name="categoryOverride"
-                              value={label}
-                              disabled={cube.overrideCategory ? false : true}
-                              checked={cube.categoryOverride == label}
-                              onChange={this.handleChange}
-                            />{' '}
-                            {label}
-                          </Label>
-                        </FormGroup>
-                      ))}
+                      {['Vintage', 'Legacy+', 'Legacy', 'Modern', 'Pioneer', 'Historic', 'Standard', 'Set'].map(
+                        (label) => (
+                          <FormGroup check key={label}>
+                            <Label check>
+                              <Input
+                                type="radio"
+                                name="categoryOverride"
+                                value={label}
+                                disabled={cube.overrideCategory ? false : true}
+                                checked={cube.categoryOverride == label}
+                                onChange={this.handleChange}
+                              />{' '}
+                              {label}
+                            </Label>
+                          </FormGroup>
+                        ),
+                      )}
                     </FormGroup>
                   </Col>
                   <Col>

--- a/src/components/CubeSearchNavBar.js
+++ b/src/components/CubeSearchNavBar.js
@@ -25,6 +25,7 @@ const AdvancedSearchModal = ({ isOpen, toggle }) => {
     'Legacy',
     'Modern',
     'Pioneer',
+    'Historic',
     'Standard',
     'Set',
     'Powered',


### PR DESCRIPTION
Users can override the cube category as Historic. Does not implement any legality or analytics related functionality for Historic.