### PR TITLE
Update and clean up syntax page

### DIFF
--- a/views/info/filters.pug
+++ b/views/info/filters.pug
@@ -12,30 +12,51 @@ block content
           button(class="btn btn-link" type="button")
             h5 General
         #collapseGeneral.collapse.show(aria-labelledby="general-syntax" data-parent="#syntax-accordion")
-          p You can combine any number of filters together, using AND, or OR.
-          p #[code t:instant or t:sorcery] cards that are either #[code instants] or #[code sorceries].
-          p #[code t:instant t:tribal] cards that are both #[code instants] and #[code tribal].
-          p You can also use quotes to ignore spaces.
-          p #[code goblin blood] cards whose names contain both #[code blood] and #[code goblin].
-          p #[code "goblin blood"] cards whose names contain #[code goblin blood].
-          p #[code o:destroy o:target o:creature] cards whose oracle text contains #[code destroy] and #[code target] and #[code creature].
-          p #[code o:"destroy target creature"] cards whose oracle text contains #[code destroy target creature].
-          p You can also use parentheses.
-          p #[code t:instant OR (t:creature o:flash)] cards which are instants, or cards which are creatures with flash.
-          p #[code (t:artifact t:creature) OR (t:instant OR t:sorcery)] cards which are instants or sorceries, or cards which are artifact creatures.
-          p You can put - before anything to negate it.
+          p You can combine any number of filters together using #[code AND] or #[code OR].
+          p #[strong Examples:]
+          table.table
+            tr
+              td(scope="col") #[code t:instant OR t:sorcery]
+              td(scope="col") Cards that are either instants or sorceries.
+            tr
+              td(scope="col") #[code t:instant t:tribal]
+              td(scope="col") Cards that are both instants and tribal.
+          p You can use quotes to ignore spaces.
+          p #[strong Examples:]
+          table.table
+            tr
+              td(scope="col") #[code goblin blood]
+              td(scope="col") Cards whose names contain both "blood" and "goblin".
+            tr
+              td(scope="col") #[code "goblin blood"]
+              td(scope="col") Cards whose names contain exactly "goblin blood".
+            tr
+              td(scope="col") #[code o:destroy o:target o:creature] 
+              td(scope="col") Cards whose oracle text contains each of "destroy", "target", and "creature".
+            tr
+              td(scope="col") #[code o:"destroy target creature"]
+              td(scope="col") Cards whose oracle text contains exactly "destroy target creature".
+          p You can also use parentheses to combine clauses.
+          p #[strong Examples:]
+          table.table
+            tr
+              td(scope="col") #[code t:instant OR (t:creature o:flash)]
+              td(scope="col") Cards which are instants, or cards which are creatures with flash.
+            tr
+              td(scope="col") #[code (t:artifact t:creature) OR (-t:creature o:create)]
+              td(scope="col") Cards which are artifact creatures, or cards that aren't creatures and have "create" in their oracle text.
+          p You can put #[code -] before anything to negate it.
           p #[strong Examples:]
           table.table
             tr
               td(scope="col") #[code -c:w] 
-              td(scope="col") Cards that are not white
+              td(scope="col") Cards that are not white.
             tr
               td(scope="col") #[code -o:draw] 
-              td(scope="col") Cards which do not have draw in their oracle text
+              td(scope="col") Cards which do not have draw in their oracle text.
             tr
               td(scope="col") #[code -bob] 
-              td(scope="col") Cards which do not have bob in their names
-
+              td(scope="col") Cards which do not have bob in their names.
       .card
         #color-syntax.card-header(data-toggle="collapse" data-target="#collapseColor" aria-expanded="true" aria-controls="collapseColor")
           button(class="btn btn-link" type="button")
@@ -46,25 +67,24 @@ block content
           p In addition to #[code w], #[code u], #[code b], #[code r], #[code g] and #[code c], you can use color words like #[code white], #[code blue], #[code green], etc.
           p You can also use all shard, wedge, or guild names, like #[code azorius], #[code bant], #[code dimir], etc.
           p You can also compare by number of colors by using numbers instead of color names.
-          p Color Identity searches will respect any color identity overrides you have set.
-          p 
-            b Examples:
+          p Color Identity searches will respect any color identity overrides you have set while filtering in your cube.
+          p #[strong Examples:]
           table.table
             tr
-              td(scope="col") #[code c:wubrg] 
-              td(scope="col") Cards that are all 5 colors
+              td(scope="col") #[code c=wubrg] 
+              td(scope="col") Cards that are all 5 colors.
             tr
-              td(scope="col") #[code c < wub] 
-              td(scope="col") Cards that are #[code wu], #[code ub], #[code bw], #[code w], #[code u], or #[code b]
+              td(scope="col") #[code c<esper] 
+              td(scope="col") Cards who colors are a subset of Esper (UB, WB, WU, U, B, or W).
             tr
               td(scope="col") #[code ci:wu] 
-              td(scope="col") Only #[code uw] color identity cards
+              td(scope="col") Cards whose color identities are exactly white blue.
             tr
-              td(scope="col") #[code ci>wu] 
-              td(scope="col") 3+ color cards that contain #[code uw]
+              td(scope="col") #[code ci>azorius]
+              td(scope="col") Cards whose color identities contain white, blue, and at least one other color.
             tr
               td(scope="col") #[code ci>1] 
-              td(scope="col") Cards with more than 1 color in their identity
+              td(scope="col") Cards with more than 1 color in their identity.
       .card
         #card-type-syntax.card-header(data-toggle="collapse" data-target="#collapseCardTypes" aria-expanded="true" aria-controls="collapseCardTypes")
           button(class="btn btn-link" type="button")
@@ -77,7 +97,7 @@ block content
           p #[strong Examples:]
           table.table
             tr
-              td(scope="col") #[code t:legendary] 
+              td(scope="col") #[code type=legendary] 
               td(scope="col") Cards that are legendary.
             tr
               td(scope="col") #[code t:legendary t:creature] 
@@ -97,10 +117,10 @@ block content
           table.table
             tr
               td(scope="col") #[code o:"draw a card"] 
-              td(scope="col") Cards with oracle text draw a card.
+              td(scope="col") Cards whose oracle text contains "draw a card".
             tr
-              td(scope="col") #[code o:"token with Sacrifice"] 
-              td(scope="col") Cards with oracle text #[code token with Sacrifice].
+              td(scope="col") #[code o:":"] 
+              td(scope="col") Cards whose oracle text contains ":" (cards with activated abilities).
             tr
               td(scope="col") #[code s:war]
               td(scope="col") Cards from War of the Spark.
@@ -201,13 +221,36 @@ block content
                 td(scope="col") #[code a:reb]
                 td(scope="col") All cards illustrated by artists with "reb" in their name.
       .card
+        #collapsePrice-syntax.card-header(data-toggle="collapse" data-target="#collapsePrice" aria-expanded="true" aria-controls="collapsePrice")
+          button(class="btn btn-link" type="button")
+            h5 Price
+        #collapsePrice.collapse(aria-labelledby="collapsePrice-syntax" data-parent="#syntax-accordion")
+          p You can use #[code price:] or #[code priceFoil:] to filter cards by price.
+          p #[strong Examples:]
+            table.table
+              tr
+                td(scope="col") #[code price>10.5]
+                td(scope="col") All non-foil cards with a price over $10.50.
+              tr
+                td(scope="col") #[code foilPrice<10 OR price<10]
+                td(scope="col") All cards with a price under $10.
+      .card
         #collapseMiscellaneous-syntax.card-header(data-toggle="collapse" data-target="#collapseMiscellaneous" aria-expanded="true" aria-controls="collapseMiscellaneous")
           button(class="btn btn-link" type="button")
             h5 Miscellaneous
         #collapseMiscellaneous.collapse(aria-labelledby="collapseMiscellaneous-syntax" data-parent="#syntax-accordion")
           p You can use #[code elo:] to filter cards by their ELO rating.
+          p #[strong Filters for individual cubes:]
+          p You can use #[code finish:] to filter by cards with the given finish. Available options are "Non-foil" and "Foil".
+          p You can use #[code status:] to filter by cards with the given status. Available options are "Not Owned", "Ordered", "Owned", "Premium Owned", and "Proxied".
           p #[strong Examples:]
             table.table
               tr
-                td(scope="col") #[code elo>=1500]
+                td(scope="col") #[code elo>1500]
                 td(scope="col") All cards with an ELO rating above 1500.
+              tr
+                td(scope="col") #[code finish:non-foil]
+                td(scope="col") All cards with the non-foil finish selected.
+              tr
+                td(scope="col") #[code status:"Premium Owned"]
+                td(scope="col") All cards marked with the "Premium Owned" status.

--- a/views/info/filters.pug
+++ b/views/info/filters.pug
@@ -21,7 +21,7 @@ block content
             tr
               td(scope="col") #[code t:instant t:tribal]
               td(scope="col") Cards that are both instants and tribal.
-          p You can use quotes to ignore spaces.
+          p You can use quotes to require an exact match. To match names in quotes, you must use the #[code name:] operator.
           p #[strong Examples:]
           table.table
             tr
@@ -55,8 +55,8 @@ block content
               td(scope="col") #[code -o:draw] 
               td(scope="col") Cards which do not have draw in their oracle text.
             tr
-              td(scope="col") #[code -bob] 
-              td(scope="col") Cards which do not have bob in their names.
+              td(scope="col") #[code -t:creature] 
+              td(scope="col") Cards which are not creatures.
       .card
         #color-syntax.card-header(data-toggle="collapse" data-target="#collapseColor" aria-expanded="true" aria-controls="collapseColor")
           button(class="btn btn-link" type="button")
@@ -225,14 +225,14 @@ block content
           button(class="btn btn-link" type="button")
             h5 Price
         #collapsePrice.collapse(aria-labelledby="collapsePrice-syntax" data-parent="#syntax-accordion")
-          p You can use #[code price:], #[code priceNormal:], or #[code priceFoil:] to filter cards by price.
+          p You can use #[code price:], #[code priceNormal:], or #[code priceFoil:] to filter cards by price. When filtering in individual cubes, #[code price:] uses the printing specified for the cube.
           p #[strong Examples:]
             table.table
               tr
                 td(scope="col") #[code price>10.5]
                 td(scope="col") All cards in a cube whose specified printing has a price over $10.50.
               tr
-                td(scope="col") #[code priceFoil<10 OR price<10]
+                td(scope="col") #[code priceFoil<10 OR priceNormal<10]
                 td(scope="col") All cards with a price under $10.
       .card
         #collapseMiscellaneous-syntax.card-header(data-toggle="collapse" data-target="#collapseMiscellaneous" aria-expanded="true" aria-controls="collapseMiscellaneous")

--- a/views/info/filters.pug
+++ b/views/info/filters.pug
@@ -8,10 +8,10 @@ block content
   dl.row
     .accordion#syntax-accordion
       .card
-        #general-syntax.card-header(data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne")
-          button(class="btn btn-link" type="button" )
+        #general-syntax.card-header(data-toggle="collapse" data-target="#collapseGeneral" aria-expanded="true" aria-controls="collapseGeneral")
+          button(class="btn btn-link" type="button")
             h5 General
-        #collapseOne.collapse.show(aria-labelledby="general-syntax" data-parent="#syntax-accordion")
+        #collapseGeneral.collapse.show(aria-labelledby="general-syntax" data-parent="#syntax-accordion")
           p You can combine any number of filters together, using AND, or OR.
           p #[code t:instant or t:sorcery] cards that are either #[code instants] or #[code sorceries].
           p #[code t:instant t:tribal] cards that are both #[code instants] and #[code tribal].
@@ -37,10 +37,10 @@ block content
               td(scope="col") Cards which do not have bob in their names
 
       .card
-        #color-syntax.card-header(data-toggle="collapse" data-target="#collapseTwo" aria-expanded="true" aria-controls="collapseTwo")
-          button(class="btn btn-link" type="button" )
+        #color-syntax.card-header(data-toggle="collapse" data-target="#collapseColor" aria-expanded="true" aria-controls="collapseColor")
+          button(class="btn btn-link" type="button")
             h5 Color and Color Identity
-        #collapseTwo.collapse(aria-labelledby="color-syntax" data-parent="#syntax-accordion")
+        #collapseColor.collapse(aria-labelledby="color-syntax" data-parent="#syntax-accordion")
           p You can find cards that are a certain color by using #[code c:] or #[code color:], and cards with a certain color identity by using #[code ci:], #[code id:] or #[code identity:].
           p Operators supported: #[code :], #[code =], #[code <], #[code >], #[code <=], #[code >=].
           p In addition to #[code w], #[code u], #[code b], #[code r], #[code g] and #[code c], you can use color words like #[code white], #[code blue], #[code green], etc.
@@ -66,10 +66,10 @@ block content
               td(scope="col") #[code ci>1] 
               td(scope="col") Cards with more than 1 color in their identity
       .card
-        #card-type-syntax.card-header(data-toggle="collapse" data-target="#collapseThree" aria-expanded="true" aria-controls="collapseThree")
-          button(class="btn btn-link" type="button" )
+        #card-type-syntax.card-header(data-toggle="collapse" data-target="#collapseCardTypes" aria-expanded="true" aria-controls="collapseCardTypes")
+          button(class="btn btn-link" type="button")
             h5 Card Types
-        #collapseThree.collapse(aria-labelledby="card-type-syntax" data-parent="#syntax-accordion")
+        #collapseCardTypes.collapse(aria-labelledby="card-type-syntax" data-parent="#syntax-accordion")
           p You can search for card types with #[code t:] or #[code type:].
           p Operators supported: #[code :], #[code =].
           p Search for any part of the typeline, i.e. #[code legendary], or #[code human].
@@ -86,10 +86,10 @@ block content
               td(scope="col") #[code t:sha] 
               td(scope="col") Cards that are shamans, or shapeshifters, spellshapers.
       .card
-        #card-text-syntax.card-header(data-toggle="collapse" data-target="#collapseFour" aria-expanded="true" aria-controls="collapseFour")
-          button(class="btn btn-link" type="button" )
+        #card-text-syntax.card-header(data-toggle="collapse" data-target="#collapseCardTextAndSet" aria-expanded="true" aria-controls="collapseCardTextAndSet")
+          button(class="btn btn-link" type="button")
             h5 Card Text and Set
-        #collapseFour.collapse(aria-labelledby="card-text-syntax" data-parent="#syntax-accordion")
+        #collapseCardTextAndSet.collapse(aria-labelledby="card-text-syntax" data-parent="#syntax-accordion")
           p You can use #[code o:] or #[code oracle:] to search oracle text, and #[code s:] or #[code set:] to search for a specific set code.
           p Operators Supported: #[code :], #[code =].
           p This searches the full oracle text, including reminder text. The set code can be either upper or lower case.
@@ -105,10 +105,10 @@ block content
               td(scope="col") #[code s:war]
               td(scope="col") Cards from War of the Spark.
       .card
-        #mana-cost-syntax.card-header(data-toggle="collapse" data-target="#collapseFive" aria-expanded="true" aria-controls="collapseFive")
-          button(class="btn btn-link" type="button" )
+        #mana-cost-syntax.card-header(data-toggle="collapse" data-target="#collapseManaCosts" aria-expanded="true" aria-controls="collapseManaCosts")
+          button(class="btn btn-link" type="button")
             h5 Mana Costs
-        #collapseFive.collapse(aria-labelledby="mana-cost-syntax" data-parent="#syntax-accordion")
+        #collapseManaCosts.collapse(aria-labelledby="mana-cost-syntax" data-parent="#syntax-accordion")
           p You can use #[code m:] or #[code mana:] to search for cards with specific mana costs.
           p Operators Supported: #[code :], #[code =].
           p You can use plain numbers and letters for the 5 basic colors, snow, colorless, and x, y, and z costs.
@@ -134,10 +134,10 @@ block content
               td(scope="col") #[code is:phyrexian]
               td(scope="col") Cards with one or more Phyrexian mana symbols.
       .card
-        #cmc-syntax.card-header(data-toggle="collapse" data-target="#collapseSix" aria-expanded="true" aria-controls="collapseSix")
-          button(class="btn btn-link" type="button" )
+        #cmc-syntax.card-header(data-toggle="collapse" data-target="#collapseCmc" aria-expanded="true" aria-controls="collapseCmc")
+          button(class="btn btn-link" type="button")
             h5 Converted Mana Cost
-        #collapseSix.collapse(aria-labelledby="cmc-syntax" data-parent="#syntax-accordion")
+        #collapseCmc.collapse(aria-labelledby="cmc-syntax" data-parent="#syntax-accordion")
           p You can use #[code cmc:] to search for specific converted mana costs.
           p Operators supported: #[code :], #[code =], #[code <], #[code >], #[code <=], #[code >=].
           p #[strong Examples:]
@@ -149,10 +149,10 @@ block content
               td(scope="col") #[code cmc=3] 
               td(scope="col") Cards with converted mana cost of exactly 3.
       .card
-        #power-toughness-syntax.card-header(data-toggle="collapse" data-target="#collapseSeven" aria-expanded="true" aria-controls="collapseSeven")
-          button(class="btn btn-link" type="button" )
+        #power-toughness-syntax.card-header(data-toggle="collapse" data-target="#collapsePower" aria-expanded="true" aria-controls="collapsePower")
+          button(class="btn btn-link" type="button")
             h5 Power, Toughness, and Loyalty
-        #collapseSeven.collapse(aria-labelledby="power-toughness-syntax" data-parent="#syntax-accordion")
+        #collapsePower.collapse(aria-labelledby="power-toughness-syntax" data-parent="#syntax-accordion")
           p You can use #[code pow:] or #[code power:] to search for cards with certain powers.
           p You can use #[code tou:] or #[code toughness:] to search for cards with certain toughness.
           p You can use #[code loy:] or #[coode loyalty:] to search for cards with certain starting loyalty.
@@ -169,10 +169,10 @@ block content
               td(scope="col") #[code loy:3 or loy:4]
                 td(scope="col") Cards with a starting loyalty of 3 or 4.
       .card
-        #rarity-syntax.card-header(data-toggle="collapse" data-target="#collapseEight" aria-expanded="true" aria-controls="collapseEight")
-          button(class="btn btn-link" type="button" )
+        #rarity-syntax.card-header(data-toggle="collapse" data-target="#collapseRarity" aria-expanded="true" aria-controls="collapseRarity")
+          button(class="btn btn-link" type="button")
             h5 Rarity
-        #collapseEight.collapse(aria-labelledby="rarity-syntax" data-parent="#syntax-accordion")
+        #collapseRarity.collapse(aria-labelledby="rarity-syntax" data-parent="#syntax-accordion")
           p You can use #[code r:] or #[code rarity:] to search for cards with a specific rarity.
           p Operators supported: #[code :], #[code =], #[code <], #[code >], #[code <=], #[code >=].
           p #[strong Examples:]
@@ -188,7 +188,7 @@ block content
               td(scope="col") Common or rare cards.
       .card
         #collapseArtist-syntax.card-header(data-toggle="collapse" data-target="#collapseArtist" aria-expanded="true" aria-controls="collapseArtist")
-          button(class="btn btn-link" type="button" )
+          button(class="btn btn-link" type="button")
             h5 Artist
         #collapseArtist.collapse(aria-labelledby="collapseArtist-syntax" data-parent="#syntax-accordion")
           p You can use #[code a:], #[code art:], or #[code artist:] to search for cards illustrated by a specific artist.
@@ -200,3 +200,14 @@ block content
               tr
                 td(scope="col") #[code a:reb]
                 td(scope="col") All cards illustrated by artists with "reb" in their name.
+      .card
+        #collapseMiscellaneous-syntax.card-header(data-toggle="collapse" data-target="#collapseMiscellaneous" aria-expanded="true" aria-controls="collapseMiscellaneous")
+          button(class="btn btn-link" type="button")
+            h5 Miscellaneous
+        #collapseMiscellaneous.collapse(aria-labelledby="collapseMiscellaneous-syntax" data-parent="#syntax-accordion")
+          p You can use #[code elo:] to filter cards by their ELO rating.
+          p #[strong Examples:]
+            table.table
+              tr
+                td(scope="col") #[code elo>=1500]
+                td(scope="col") All cards with an ELO rating above 1500.

--- a/views/info/filters.pug
+++ b/views/info/filters.pug
@@ -12,7 +12,7 @@ block content
           button(class="btn btn-link" type="button")
             h5 General
         #collapseGeneral.collapse.show(aria-labelledby="general-syntax" data-parent="#syntax-accordion")
-          p You can combine any number of filters together using #[code AND] or #[code OR].
+          p You can combine any number of filters together using #[code AND] or #[code OR]. Operators are case-insensitive, as are all filtering conditions. So #[code TYPE:instant and o:DESTROY] will work just as well.
           p #[strong Examples:]
           table.table
             tr
@@ -28,7 +28,7 @@ block content
               td(scope="col") #[code goblin blood]
               td(scope="col") Cards whose names contain both "blood" and "goblin".
             tr
-              td(scope="col") #[code "goblin blood"]
+              td(scope="col") #[code name:"goblin blood"]
               td(scope="col") Cards whose names contain exactly "goblin blood".
             tr
               td(scope="col") #[code o:destroy o:target o:creature] 
@@ -75,7 +75,7 @@ block content
               td(scope="col") Cards that are all 5 colors.
             tr
               td(scope="col") #[code c<esper] 
-              td(scope="col") Cards who colors are a subset of Esper (UB, WB, WU, U, B, or W).
+              td(scope="col") Cards who colors are a subset of Esper (UB, WB, WU, U, B, W, or colorless).
             tr
               td(scope="col") #[code ci:wu] 
               td(scope="col") Cards whose color identities are exactly white blue.
@@ -225,12 +225,12 @@ block content
           button(class="btn btn-link" type="button")
             h5 Price
         #collapsePrice.collapse(aria-labelledby="collapsePrice-syntax" data-parent="#syntax-accordion")
-          p You can use #[code price:] or #[code priceFoil:] to filter cards by price.
+          p You can use #[code price:], #[code priceNormal:], or #[code priceFoil:] to filter cards by price.
           p #[strong Examples:]
             table.table
               tr
                 td(scope="col") #[code price>10.5]
-                td(scope="col") All non-foil cards with a price over $10.50.
+                td(scope="col") All cards in a cube whose specified printing has a price over $10.50.
               tr
                 td(scope="col") #[code priceFoil<10 OR price<10]
                 td(scope="col") All cards with a price under $10.

--- a/views/info/filters.pug
+++ b/views/info/filters.pug
@@ -232,7 +232,7 @@ block content
                 td(scope="col") #[code price>10.5]
                 td(scope="col") All non-foil cards with a price over $10.50.
               tr
-                td(scope="col") #[code foilPrice<10 OR price<10]
+                td(scope="col") #[code priceFoil<10 OR price<10]
                 td(scope="col") All cards with a price under $10.
       .card
         #collapseMiscellaneous-syntax.card-header(data-toggle="collapse" data-target="#collapseMiscellaneous" aria-expanded="true" aria-controls="collapseMiscellaneous")


### PR DESCRIPTION
Fixes #1348 and normalizes the formatting for each section of the syntax guide.  Adds the Price section and Miscellaneous section with descriptions for `price`, `priceFoil`, `elo`, `finish`, and `status`.  Improves some of the example to give a more thorough overview of the features and more useful queries.

<img width="1161" alt="Screen Shot 2020-05-06 at 5 11 20 PM" src="https://user-images.githubusercontent.com/13154238/81240616-b7e3ba80-8fbc-11ea-92d5-dbc6fd43f7e7.png">

<img width="1142" alt="Screen Shot 2020-05-06 at 5 11 35 PM" src="https://user-images.githubusercontent.com/13154238/81240625-be723200-8fbc-11ea-9041-51165eb531f0.png">

<img width="1132" alt="Screen Shot 2020-05-06 at 5 11 44 PM" src="https://user-images.githubusercontent.com/13154238/81240629-c3cf7c80-8fbc-11ea-9e06-5a6887dfdb06.png">
