### PR TITLE
Fix several parsing issues.

### DIFF
--- a/nearley/cardFilters.ne
+++ b/nearley/cardFilters.ne
@@ -125,7 +125,7 @@ artistCondition -> ("a"i | "art"i | "artist"i) stringOpValue {% ([, valuePred]) 
 eloCondition -> "elo"i integerOpValue {% ([, valuePred]) => genericCondition('elo', cardElo, valuePred) %}
 
 nameCondition -> ("n"i | "name"i) stringOpValue {% ([, valuePred]) => genericCondition('name_lower', cardNameLower, valuePred) %}
-  | noQuoteStringValue {% ([value]) => genericCondition('name_lower', cardNameLower, (fieldValue) => fieldValue.includes(value.toLowerCase())) %}
+  | stringValue {% ([value]) => genericCondition('name_lower', cardNameLower, (fieldValue) => fieldValue.includes(value.toLowerCase())) %}
 
 manaCostCondition -> ("mana"i | "cost"i) manaCostOpValue {% ([, valuePred]) => genericCondition('parsed_cost', cardCost, valuePred) %}
 

--- a/nearley/cubeFilters.ne
+++ b/nearley/cubeFilters.ne
@@ -38,7 +38,7 @@ const genericCondition = (property, valuePred) => ({ query: { [property]: valueP
 ownerNameCondition -> ("owner"i | "owner_name"i | "ownername"i) stringOpValue {% ([, valuePred]) => genericCondition('owner_name', valuePred) %}
 
 nameCondition -> ("n"i | "name"i | "cubename"i | "cube_name"i) stringOpValue {% ([, valuePred]) => genericCondition('name', valuePred) %}
-  | noQuoteStringValue {% ([value]) => genericCondition('name', stringOperation(':', value)) %}
+  | stringValue {% ([value]) => genericCondition('name', stringOperation(':', value)) %}
 
 numDecksCondition -> ("numdecks"i | "num_decks"i | "decks"i | "d"i) integerOpValue {% ([, valuePred]) => genericCondition('numDecks', valuePred) %}
 

--- a/nearley/values.ne
+++ b/nearley/values.ne
@@ -40,9 +40,9 @@ finishValue -> ("Foil"i | "Non-Foil"i) {% ([[finish]]) => finish.toLowerCase() %
 
 statusOpValue -> equalityOperator statusValue {% ([op, value]) => stringOperation(op.toString() === ':' ? '=' : op, value) %}
 
-statusValue -> ("owned"i | "proxied"i) {% ([[status]]) => status.toLowerCase() %} 
-  | "'" ("owned"i | "proxied"i | "not owned"i | "premium owned"i) "'" {% ([, [status]]) => status.toLowerCase() %}
-  | "\"" ("owned"i | "proxied"i | "not owned"i | "premium owned"i) "\"" {% ([, [status]]) => status.toLowerCase() %}
+statusValue -> ("owned"i | "proxied"i | "ordered"i) {% ([[status]]) => status.toLowerCase() %} 
+  | "'" ("owned"i | "proxied"i | "ordered"i | "not owned"i | "premium owned"i) "'" {% ([, [status]]) => status.toLowerCase() %}
+  | "\"" ("owned"i | "proxied"i | "ordered"i | "not owned"i | "premium owned"i) "\"" {% ([, [status]]) => status.toLowerCase() %}
 
 rarityOpValue -> anyOperator rarityValue {% ([op, value]) => rarityOperation(op, value) %}
 
@@ -137,7 +137,7 @@ stringContainOpValue -> equalityOperator stringValue {% ([op, value]) => stringC
 stringValue -> (noQuoteStringValue | dqstring | sqstring) {% ([[value]]) => value.toLowerCase() %}
 
 # anything that isn't a special character and isn't "and" or "or"
-noQuoteStringValue -> ([^aAoO \t\n"'\\=<>:] 
+noQuoteStringValue -> ([^aAoO\- \t\n"'\\=<>:] 
   | "a"i [^nN \t\n"'\\=<>:] 
   | "an"i:+ [^dD \t\n"'\\=<>:] 
   | "and"i:+ [^ \t\n"'\\=<>:] 

--- a/nearley/values.ne
+++ b/nearley/values.ne
@@ -128,7 +128,7 @@ colorCombinationValue ->
 
 @builtin "string.ne"
 
-stringSetElementOpValue -> equalityOperator stringValue {% ([, value]) => setElementOperation(value) %}
+stringSetElementOpValue -> equalityOperator stringValue {% ([op, value]) => setElementOperation(op, value) %}
 
 stringOpValue -> equalityOperator stringValue {% ([op, value]) => stringOperation(op, value) %}
 


### PR DESCRIPTION
Names can now be passed in quotes without a condition needed.
Status now allows ordered as a value.
Names without quotes can be negated and in general strings without quotes
cannot start with a - to make the parse unambiguous.

Fixes #1352.