### PR TITLE
Allow tags in the autocard popup to wrap correctly.

### DIFF
--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -290,7 +290,6 @@
 #autocardPopup {
 	position: absolute;
 	pointer-events: none;
-	user-drag: none;
 	user-select: none;
 	-moz-user-select: none;
 	-webkit-user-drag: none;
@@ -302,6 +301,14 @@
 
 #autocardPopup img {
 	width: 15rem;
+}
+
+#autocardPopup {
+	width: 15rem;
+}
+
+#autocardPopup.double-width {
+	width: 30rem;
 }
 
 .autocard-background {

--- a/public/css/tags.css
+++ b/public/css/tags.css
@@ -1,21 +1,11 @@
 .tag {
 	background-color: #E9ECEF;
-}
-
-.autocard-tags .tag, .tag-item {
 	font-size: 85%;
 	padding: 0.5em .75em;
 	margin: .25em .1em;
 	display: inline-block;
 	border: 1px solid #DEE2E6;
 	transition: all .1s linear;
-}
-
-.autocard-tags {
-  width: 100%;
-  padding: 3px;
-  padding-left: 5px;
-  padding-right: 5px;
 }
 
 .tag-sort-placeholder {

--- a/public/js/autocard.js
+++ b/public/js/autocard.js
@@ -96,6 +96,12 @@ function autocard_show_card(card_image, card_flip, show_art_crop, tags, foil, in
   const popupImg = document.getElementById('autocardImageFront');
   const popupImgBack = document.getElementById('autocardImageBack');
 
+  if (card_flip) {
+    popup.classList.add('double-width');
+  } else {
+    popup.classList.remove('double-width');
+  }
+
   const overlays = popup.getElementsByClassName('foilOverlay');
   for (let i = 0; i < overlays.length; i++) {
     if (foil) {
@@ -124,11 +130,10 @@ function autocard_show_card(card_image, card_flip, show_art_crop, tags, foil, in
   popup.style.zIndex = in_modal ? 1500 : 500;
 
   if (tags) {
-    let tagsText = '<div class="autocard-tags">';
+    let tagsText = '';
     tags.forEach(function (tag, index) {
       tagsText += "<span class='tag " + getTagColorClass(tag.trim()) + "'>" + tag.trim() + '</span>';
     });
-    tagsText += '</div>';
     document.getElementById('autocardTags').innerHTML = tagsText;
   }
 
@@ -147,7 +152,6 @@ function autocard_show_card(card_image, card_flip, show_art_crop, tags, foil, in
       if (!popupImg.complete) {
         return;
       }
-      // only fill in tags area once the image is done loading
       if (autocardTimeout) autocardTimeout = clearTimeout(autocardTimeout);
       autocardTimeout = setTimeout(() => document.getElementById('autocardPopup').classList.remove('d-none'), 10);
     };

--- a/src/components/TagColorsModal.js
+++ b/src/components/TagColorsModal.js
@@ -126,7 +126,7 @@ class TagColorsModalRaw extends Component {
     const orderedTags = [...tagColors, ...unknownTagColors];
 
     const editableRows = orderedTags.map(({ tag, color }) => {
-      const tagClass = `tag-item ${getTagColorClass(tagColors, tag)}`;
+      const tagClass = `tag ${getTagColorClass(tagColors, tag)}`;
       return {
         element: <TagColorRow tag={tag} tagClass={tagClass} value={color} onChange={this.handleChangeColor} />,
         key: tag,
@@ -134,7 +134,7 @@ class TagColorsModalRaw extends Component {
     });
 
     const staticRows = orderedTags.map(({ tag, color }) => {
-      const tagClass = `mr-2 tag-item ${getTagColorClass(tagColors, tag)}`;
+      const tagClass = `mr-2 tag ${getTagColorClass(tagColors, tag)}`;
       return (
         <span key={tag} className={tagClass}>
           {tag}


### PR DESCRIPTION
Fixes #1406.