### PR TITLE
fixed totals row in table analysis

### DIFF
--- a/src/analytics/Table.js
+++ b/src/analytics/Table.js
@@ -7,14 +7,14 @@ import AsfanDropdown from 'components/AsfanDropdown';
 import ErrorBoundary from 'components/ErrorBoundary';
 import { sortIntoGroups, getSorts, getLabels, cardCanBeSorted } from 'utils/Sort';
 
-const AnalyticTable = ({ cards, cube, defaultFormatId, setAsfans }) => {
+const AnalyticTable = ({ cards: allCards, cube, defaultFormatId, setAsfans }) => {
   const sorts = getSorts();
 
   const [primary, setPrimary] = useState('Color Identity');
   const [secondary, setSecondary] = useState('Type');
 
   // some criteria cannot be applied to some cards
-  cards = cards.filter((card) => cardCanBeSorted(card, primary) && cardCanBeSorted(card, secondary));
+  const cards = allCards.filter((card) => cardCanBeSorted(card, primary) && cardCanBeSorted(card, secondary));
 
   const sortWithTotal = (pool, sort) => {
     const groups = sortIntoGroups(pool, sort);

--- a/src/utils/Sort.js
+++ b/src/utils/Sort.js
@@ -466,6 +466,10 @@ function typeLine(card) {
   return card.type_line || card.details.type;
 }
 
+export function cardCanBeSorted(card, sort) {
+  return cardGetLabels(card, sort).length != 0;
+}
+
 export function cardGetLabels(card, sort) {
   if (sort == 'Color Category') {
     if (card.colorCategory) return [card.colorCategory];


### PR DESCRIPTION
fixes #1282 

SeedCube02 ColorIdentity/Toughness table:
![Table_ColorCat_Toughness_SeedCube02](https://user-images.githubusercontent.com/9307361/84697687-dbe8d300-af4e-11ea-9388-57fa70fdee1c.png)
The totals are calculated from the amount of cards that were "considered" for the table. The percentages in the last column are also in reference to the `Total.Total`.