### PR TITLE
Fix moving multiple cards from maybeboard to cube to always remove moved cards

### DIFF
--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -2207,18 +2207,10 @@ router.post('/edit/:id', ensureAuth, async (req, res) => {
       }
     }
 
-    const newMaybe = [...cube.maybe];
-    const newCards = [];
-    for (const add of adds) {
-      newCards.push(util.newCard(add, [], cube.defaultStatus));
-      const maybeIndex = cube.maybe.findIndex((card) => card.cardID === add._id);
-      if (maybeIndex !== -1) {
-        newMaybe.splice(maybeIndex, 1);
-      }
-    }
-    // Remove all invalid cards.
-    cube.cards = [...cube.cards.filter((card, index) => card.cardID && !removes.has(index)), ...newCards];
-    cube.maybe = newMaybe;
+    // Filter out removed and invalid cards, and add new cards.
+    const newCards = adds.map((add) => util.newCard(add, [], cube.defaultStatus));
+    cube.cards = cube.cards.filter((card, index) => card.cardID && !removes.has(index)).concat(newCards);
+    cube.maybe = cube.maybe.filter((maybeCard) => !adds.some((addedCard) => addedCard._id === maybeCard.cardID));
 
     const blogpost = new Blog();
     blogpost.title = req.body.title;


### PR DESCRIPTION
This PR addresses issue #1490, which caused cards added from maybeboard to cube to not always be removed from maybeboard as the edit was saved.

This bug was caused by us mutating `newMaybe` size with `.splice`, and then later comparing `cube.maybe` indices to `newMaybe` indices. The fix was to refactor this code to a more functional approach, and while at it I touched the newCards handling a little bit too.

This is my first contribution to this project, and I decided to start with this small issue that has annoyed me as an end-user.