### PR TITLE
Make bots place cards that belong to special zones to sideboard #1452

### DIFF
--- a/src/pages/CubeDraftPage.js
+++ b/src/pages/CubeDraftPage.js
@@ -19,6 +19,7 @@ import {
 import Draft, { init, createSeen, addSeen, getPicked, getSeen } from 'utils/Draft';
 import Location from 'utils/DraftLocation';
 import { cmcColumn } from 'utils/Util';
+import { cardType, cardIsSpecialZoneType } from 'utils/Card';
 
 import CSRFForm from 'components/CSRFForm';
 import CustomImageToggler from 'components/CustomImageToggler';
@@ -34,12 +35,9 @@ import { Internal } from 'components/DraftbotBreakdown';
 
 export const subtitle = (cards) => {
   const numCards = cards.length;
-  const allTypes = cards.map((card) => (card.type_line || card.details.type).toLowerCase());
-  const numLands = allTypes.filter((type) => type.includes('land')).length;
-  const numNonlands = allTypes.filter(
-    (type) => !type.includes('land') && !/^(plane|phenomenon|vanguard|scheme|conspiracy)$/.test(type),
-  ).length;
-  const numCreatures = allTypes.filter((type) => type.includes('creature')).length;
+  const numLands = cards.filter(card => cardType(card).includes('land')).length;
+  const numNonlands = cards.filter(card => !cardType(card).includes('land') && !cardIsSpecialZoneType(card)).length;
+  const numCreatures = cards.filter((card) => cardType(card).includes('creature')).length;
   const numNonCreatures = numNonlands - numCreatures;
   return (
     `${numCards} card${numCards === 1 ? '' : 's'}: ` +

--- a/src/pages/CubeDraftPage.js
+++ b/src/pages/CubeDraftPage.js
@@ -35,8 +35,8 @@ import { Internal } from 'components/DraftbotBreakdown';
 
 export const subtitle = (cards) => {
   const numCards = cards.length;
-  const numLands = cards.filter(card => cardType(card).includes('land')).length;
-  const numNonlands = cards.filter(card => !cardType(card).includes('land') && !cardIsSpecialZoneType(card)).length;
+  const numLands = cards.filter((card) => cardType(card).includes('land')).length;
+  const numNonlands = cards.filter((card) => !cardType(card).includes('land') && !cardIsSpecialZoneType(card)).length;
   const numCreatures = cards.filter((card) => cardType(card).includes('creature')).length;
   const numNonCreatures = numNonlands - numCreatures;
   return (

--- a/src/utils/Card.js
+++ b/src/utils/Card.js
@@ -209,7 +209,7 @@ export const cardDevotion = (card, color) =>
   cardCost(card)?.reduce((count, symbol) => count + (symbol.includes(color.toLowerCase()) ? 1 : 0), 0) ?? 0;
 
 export const cardIsSpecialZoneType = (card) => {
-  return /(plane|phenomenon|vanguard|scheme|conspiracy|contraption)/i.test(cardType(card))
+  return /(plane|phenomenon|vanguard|scheme|conspiracy|contraption)/i.test(cardType(card));
 };
 
 export default {

--- a/src/utils/Card.js
+++ b/src/utils/Card.js
@@ -208,6 +208,10 @@ export const cardElo = (card) => card.details.elo;
 export const cardDevotion = (card, color) =>
   cardCost(card)?.reduce((count, symbol) => count + (symbol.includes(color.toLowerCase()) ? 1 : 0), 0) ?? 0;
 
+export const cardIsSpecialZoneType = (card) => {
+  return /(plane|phenomenon|vanguard|scheme|conspiracy|contraption)/i.test(cardType(card))
+};
+
 export default {
   cardTags,
   cardFinish,
@@ -253,6 +257,7 @@ export default {
   cardImageFlip,
   cardTokens,
   cardDevotion,
+  cardIsSpecialZoneType,
   cardElo,
   COLOR_COMBINATIONS,
   normalizeName,

--- a/src/utils/Draft.js
+++ b/src/utils/Draft.js
@@ -316,7 +316,7 @@ const findShortestKSpanningTree = (nodes, distanceFunc, k) => {
 export async function buildDeck(cards, picked, synergies, initialState, basics) {
   let nonlands = cards.filter((card) => !cardType(card).includes('land') && !cardIsSpecialZoneType(card));
   const lands = cards.filter((card) => cardType(card).includes('land'));
-  const specialZoneCards = cards.filter(cardIsSpecialZoneType)
+  const specialZoneCards = cards.filter(cardIsSpecialZoneType);
 
   const colors = botColors(null, picked, null, null, synergies, initialState, 1, initialState[0].length);
   const sortFn = getSortFn(colors);

--- a/src/utils/Draft.js
+++ b/src/utils/Draft.js
@@ -1,6 +1,13 @@
 import similarity from 'compute-cosine-similarity';
 
-import { COLOR_COMBINATIONS, cardColorIdentity, cardDevotion, cardType, COLOR_INCLUSION_MAP } from 'utils/Card';
+import {
+  COLOR_COMBINATIONS,
+  cardColorIdentity,
+  cardDevotion,
+  cardType,
+  cardIsSpecialZoneType,
+  COLOR_INCLUSION_MAP,
+} from 'utils/Card';
 import { csrfFetch } from 'utils/CSRF';
 import {
   getRating,
@@ -307,8 +314,9 @@ const findShortestKSpanningTree = (nodes, distanceFunc, k) => {
 };
 
 export async function buildDeck(cards, picked, synergies, initialState, basics) {
-  let nonlands = cards.filter((card) => !card.details.type.toLowerCase().includes('land'));
-  const lands = cards.filter((card) => card.details.type.toLowerCase().includes('land'));
+  let nonlands = cards.filter((card) => !cardType(card).includes('land') && !cardIsSpecialZoneType(card));
+  const lands = cards.filter((card) => cardType(card).includes('land'));
+  const specialZoneCards = cards.filter(cardIsSpecialZoneType)
 
   const colors = botColors(null, picked, null, null, synergies, initialState, 1, initialState[0].length);
   const sortFn = getSortFn(colors);
@@ -320,8 +328,6 @@ export async function buildDeck(cards, picked, synergies, initialState, basics) 
 
   const playableLands = lands.filter((land) => isPlayableLand(colors, land));
   const unplayableLands = lands.filter((land) => !isPlayableLand(colors, land));
-
-  // console.log(colors, inColor.length / nonlands.length, inColor.length);
 
   nonlands = inColor;
   let side = outOfColor;
@@ -386,6 +392,7 @@ export async function buildDeck(cards, picked, synergies, initialState, basics) 
   side.push(...playableLands.slice(17));
   side.push(...unplayableLands);
   side.push(...nonlands);
+  side.push(...specialZoneCards);
 
   if (basics) {
     const basicsToAdd = calculateBasicCounts(main, colors);


### PR DESCRIPTION
This PR addresses issue #1452, which points out that bots were drafting special cards like conspiracies and contraptions and using them as 0 cmc cards on their mainboard. Now bots always place the cards to sideboard 0 CMC slot. Later on if command zone slot is implemented (for companions etc) we might want to change the logic to place these cards there.

![2020-06-27-213526_1920x1080_scrot](https://user-images.githubusercontent.com/6438345/85929703-a2ee1e00-b8bf-11ea-8dce-aa1e6087e2dd.png)

Added a new Cards util helper to check if card type is of a type that is never put to main deck. Unified the code of CubeDraftPage to also use these helpers for future if new types are added.

By MTG rules these cards are usually at the command zone, but naming this category of cards to "cardIsOnlyCommandZone" or something felt off.