### PR TITLE
Add rating lookup that was removed earlier back #1492

### DIFF
--- a/jobs/populate_analytics.js
+++ b/jobs/populate_analytics.js
@@ -175,6 +175,8 @@ async function processCard(card) {
   const versions = carddb.getVersionsByOracleId(card.oracle_id);
   const { name, oracle_id } = card;
 
+  const rating = await CardRating.findOne({ name });;
+
   const currentDatapoint = {};
   currentDatapoint.rating = rating ? rating.rating : null;
   currentDatapoint.elo = rating ? rating.elo : null;


### PR DESCRIPTION
This PR adds an apparent fix to #1492 `npm run populate-analytics` script, which is currently not working at master as it tries to use variable `rating` which no longer exists.

I added back the CardRating database query and at least for me locally the script seems to work with it.

This seems to be have been caused by a possibly destructive merge, so someone who knows more about this script should probably take a look at what has happened here.