### PR TITLE
Add a mention of using docker to run mongo for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ MongoDB: https://docs.mongodb.com/manual/installation/
 
 You will need to either start MongoDB background process, or manually start and stop the process in a separate console. Refer to the official documentation for directions on how to set this up for your OS.
 
+Optionally, you can also run MongoDB using docker
+
+```sh
+docker run --name cubecobra -p 27017:27017 -d mongo:4.2
+```
+
 VSCode (strongly recommended, but not required): https://code.visualstudio.com/
 ESLint Extension for VSCode: https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint
 


### PR DESCRIPTION
I personally find using docker to run external dependencies nicer than having to installed them on local machine, and in past this has worked great in other projects. Docker could also be used to guide the exact versions of external dependencies we aim for.

This PR adds a README mention of the possibility of using docker to run mongo instead of installing it on local machine. Eventually this project could also have an optional `docker-compose.yml` file to install the whole stack with a single command for development, which could make this repository slightly easier to approach.