### PR TITLE
Fix touch device detection to work again #1049

### DIFF
--- a/src/components/DndProvider.js
+++ b/src/components/DndProvider.js
@@ -8,8 +8,6 @@ import { isTouchDevice } from '../utils/Util';
 
 const backend = isTouchDevice() ? TouchBackend : HTML5Backend;
 
-const DndProviderWithBackend = (props) => (
-  <DndProvider backend={backend} {...props} />
-);
+const DndProviderWithBackend = (props) => <DndProvider backend={backend} {...props} />;
 
 export default DndProviderWithBackend;

--- a/src/components/DndProvider.js
+++ b/src/components/DndProvider.js
@@ -6,8 +6,10 @@ import TouchBackend from 'react-dnd-touch-backend';
 
 import { isTouchDevice } from '../utils/Util';
 
+const backend = isTouchDevice() ? TouchBackend : HTML5Backend;
+
 const DndProviderWithBackend = (props) => (
-  <DndProvider backend={isTouchDevice() ? TouchBackend : HTML5Backend} {...props} />
+  <DndProvider backend={backend} {...props} />
 );
 
 export default DndProviderWithBackend;

--- a/src/utils/Draft.js
+++ b/src/utils/Draft.js
@@ -40,7 +40,7 @@ export const addSeen = (seen, cards, synergies) => {
         const combStr = comb.join('');
         if (COLOR_INCLUSION_MAP[combStr][colorsStr]) {
           for (const { index } of seen.cards[combStr]) {
-            if (synergyMatrix[index][card.index] === null) {
+            if (synergyMatrix[index][card.index] === null && synergies) {
               const similarityValue = similarity(synergies[card.index], synergies[index]);
               if (Number.isFinite(similarityValue)) {
                 synergyMatrix[card.index][index] = -Math.log(1 - scaleSimilarity(similarityValue)) / SYNERGY_SCALE;

--- a/src/utils/Draft.js
+++ b/src/utils/Draft.js
@@ -40,7 +40,7 @@ export const addSeen = (seen, cards, synergies) => {
         const combStr = comb.join('');
         if (COLOR_INCLUSION_MAP[combStr][colorsStr]) {
           for (const { index } of seen.cards[combStr]) {
-            if (synergyMatrix[index][card.index] === null && synergies) {
+            if (synergyMatrix[index][card.index] === null) {
               const similarityValue = similarity(synergies[card.index], synergies[index]);
               if (Number.isFinite(similarityValue)) {
                 synergyMatrix[card.index][index] = -Math.log(1 - scaleSimilarity(similarityValue)) / SYNERGY_SCALE;

--- a/src/utils/Util.js
+++ b/src/utils/Util.js
@@ -154,7 +154,7 @@ export function isTouchDevice() {
   const mq = (query) => window.matchMedia(query).matches;
 
   // eslint-disable-next-line no-undef
-  if (window.ontouchstart || (window.DocumentTouch && document instanceof DocumentTouch)) {
+  if (window.hasOwnProperty('ontouchstart') || (window.DocumentTouch && document instanceof DocumentTouch)) {
     return true;
   }
 

--- a/src/utils/Util.js
+++ b/src/utils/Util.js
@@ -153,8 +153,11 @@ export function isTouchDevice() {
 
   const mq = (query) => window.matchMedia(query).matches;
 
-  // eslint-disable-next-line no-undef
-  if (window.hasOwnProperty('ontouchstart') || (window.DocumentTouch && document instanceof DocumentTouch)) {
+  if (
+    Object.prototype.hasOwnProperty.call(window, 'ontouchstart') ||
+    // eslint-disable-next-line no-undef
+    (window.DocumentTouch && document instanceof DocumentTouch)
+  ) {
     return true;
   }
 


### PR DESCRIPTION
Touch device detection was broken (at least on the devices I tested this with and as per issue #1049), which broke dragging cards at deckbuilder on mobile.

This PR fixes the touch device detection, and uses the correct backend for react-dnd on touch devices.

Also change how often the detection is executed to only happen once per DndProvider initialization. As I was debugging this I noticed that the check was being made constantly while cards were being dragged, and as real devices should never change from being touch devices to not being them doing the check only once seems sane and performant.

Tested the change on both emulator & real android phone / desktop browsers.