### PR TITLE
Fix deck builder displaying wrong card counts by card type.

### DIFF
--- a/src/pages/CubeDraftPage.js
+++ b/src/pages/CubeDraftPage.js
@@ -35,9 +35,9 @@ import { Internal } from 'components/DraftbotBreakdown';
 
 export const subtitle = (cards) => {
   const numCards = cards.length;
-  const numLands = cards.filter((card) => cardType(card).includes('land')).length;
-  const numNonlands = cards.filter((card) => !cardType(card).includes('land') && !cardIsSpecialZoneType(card)).length;
-  const numCreatures = cards.filter((card) => cardType(card).includes('creature')).length;
+  const numLands = cards.filter((card) => /land/i.test(cardType(card))).length;
+  const numNonlands = cards.filter((card) => !/land/i.test(cardType(card)) && !cardIsSpecialZoneType(card)).length;
+  const numCreatures = cards.filter((card) => /creature/i.test(cardType(card))).length;
   const numNonCreatures = numNonlands - numCreatures;
   return (
     `${numCards} card${numCards === 1 ? '' : 's'}: ` +


### PR DESCRIPTION
Fixes #1518. 

Looks my earlier refactoring was a bit sloppy, and the code was checking the card type line without converting it to lowercase. I don't know how I didn't notice that then...

Use case insensitive regex tests here (like in cardIsSpecialZoneType).