### PR TITLE
🐛 Fixed flash errors on cube creation

### DIFF
--- a/views/user/user_view.pug
+++ b/views/user/user_view.pug
@@ -1,7 +1,7 @@
 extends ../layout
 
 block content
-  include ../dynamic_flash
+  include ../flash
 
   #react-root
 


### PR DESCRIPTION
Flash errors now display when you try to create a cube with an invalid name

Changed the pug file for user_view to use flash instead of dynamic_flash