### PR TITLE
autocomplete tag filter in advanced filter modal

### DIFF
--- a/public/css/autocomplete.css
+++ b/public/css/autocomplete.css
@@ -33,3 +33,12 @@
 	background-color: #28A745 !important;
 	color: #ffffff;
 }
+
+.tag-autocomplete-wrapper {
+  flex: 1 1 0%;
+}
+
+.tag-autocomplete-input {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}

--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -27,6 +27,7 @@ const {
   replaceCardHtml,
   abbreviate,
   buildTagColors,
+  cubeCardTags,
   maybeCards,
   getElo,
   CSVtoCards,
@@ -2629,6 +2630,19 @@ router.get(
     return res.status(200).send({
       success: 'true',
       cardnames: result,
+    });
+  }),
+);
+
+router.get(
+  '/api/cubecardtags/:id',
+  util.wrapAsyncApi(async (req, res) => {
+    const cube = await Cube.findOne(buildIdQuery(req.params.id)).lean();
+    const tags = cubeCardTags(cube);
+
+    return res.status(200).send({
+      success: 'true',
+      tags: util.turnToTree(tags),
     });
   }),
 );

--- a/serverjs/cubefn.js
+++ b/serverjs/cubefn.js
@@ -197,6 +197,19 @@ function buildTagColors(cube) {
   return tagColor;
 }
 
+function cubeCardTags(cube) {
+  const tags = [];
+  for (const card of cube.cards) {
+    for (let tag of card.tags) {
+      tag = tag.trim();
+      if (!tags.includes(tag)) {
+        tags.push(tag);
+      }
+    }
+  }
+  return tags;
+}
+
 function maybeCards(cube, carddb) {
   const maybe = (cube.maybe || []).filter((card) => card.cardID);
   return maybe.map((card) => ({ ...card, details: carddb.cardFromId(card.cardID) }));
@@ -546,6 +559,7 @@ const methods = {
   replaceCardHtml,
   abbreviate,
   buildTagColors,
+  cubeCardTags,
   maybeCards,
   getCardElo,
   getElo,

--- a/src/components/AutocompleteInput.js
+++ b/src/components/AutocompleteInput.js
@@ -184,7 +184,7 @@ const fetchTree = async (treeUrl, treePath) => {
 };
 
 const AutocompleteInput = forwardRef(
-  ({ treeUrl, treePath, defaultValue, value, onChange, onSubmit, ...props }, ref) => {
+  ({ treeUrl, treePath, defaultValue, value, onChange, onSubmit, wrapperClassName, ...props }, ref) => {
     const [tree, setTree] = useState({});
     const [position, setPosition] = useState(-1);
     const [visible, setVisible] = useState(false);
@@ -278,7 +278,7 @@ const AutocompleteInput = forwardRef(
     );
 
     return (
-      <div>
+      <div className={wrapperClassName}>
         <Input ref={ref} value={inputValue} onKeyDown={handleKeyDown} onChange={handleChange} {...props} />
         {showMatches && (
           <ul className="autocomplete-list">

--- a/src/components/FilterCollapse.js
+++ b/src/components/FilterCollapse.js
@@ -26,6 +26,8 @@ import LoadingButton from 'components/LoadingButton';
 
 import TextField from 'components/TextField';
 import NumericField from 'components/NumericField';
+import AutocompleteInput from 'components/AutocompleteInput';
+import CubeContext from 'components/CubeContext';
 
 const allFields = [
   'name',
@@ -149,13 +151,30 @@ const AdvancedFilterModal = ({ isOpen, toggle, apply, values, onChange, ...props
           value={values.set}
           onChange={onChange}
         />
-        <TextField
-          name="tag"
-          humanName="Tag"
-          placeholder={'Any text, e.g. "Zombie Testing"'}
-          value={values.tag}
-          onChange={onChange}
-        />
+        <CubeContext.Consumer>
+          {({ cubeID }) =>
+            cubeID && (
+              <InputGroup className="mb-3" {...props}>
+                <InputGroupAddon addonType="prepend">
+                  <InputGroupText>Tag</InputGroupText>
+                </InputGroupAddon>
+                <AutocompleteInput
+                  treeUrl={`/cube/api/cubecardtags/${cubeID}`}
+                  treePath="tags"
+                  type="text"
+                  name="tag"
+                  value={values.tag}
+                  onChange={onChange}
+                  placeholder={'Any text, e.g. "Zombie Testing"'}
+                  autoComplete="off"
+                  data-lpignore
+                  className="tag-autocomplete-input"
+                  wrapperClassName="tag-autocomplete-wrapper"
+                />
+              </InputGroup>
+            )
+          }
+        </CubeContext.Consumer>
         <Row className="row-mid-padding">
           <Col md={6}>
             <InputGroup className="mb-3">


### PR DESCRIPTION
Also removed tags filter from advanced filter modal where no tags are present (for example "Search Cards")
fixes #370

![Tag autocomplete screenshot](https://user-images.githubusercontent.com/9307361/91195530-60976080-e6f9-11ea-95a1-221b3e36f9e7.png)
