### PR TITLE
Fixed issue that causes newly revealed cards to not load card page

### DIFF
--- a/routes/tools_routes.js
+++ b/routes/tools_routes.js
@@ -298,15 +298,69 @@ router.get('/card/:id', async (req, res) => {
     }
 
     // otherwise just go to this ID.
-    const data = await CardHistory.findOne({ oracleId: card.oracle_id });
+    let data = await CardHistory.findOne({ oracleId: card.oracle_id });
+    // id is valid but has no matching history
     if (!data) {
-      req.flash(
-        'danger',
-        `Card with identifier ${req.params.id} not found. Acceptable identifiers are card name (english only), scryfall ID, or oracle ID.`,
-      );
-      return res.redirect('404');
-    }
+      const cardVersions = carddb.getVersionsByOracleId(card.oracle_id);
 
+      data = {
+        current: {
+          rating: null,
+          elo: card.elo,
+          picks: 0,
+          total: [0, 0],
+          size180: [0, 0],
+          size360: [0, 0],
+          size450: [0, 0],
+          size540: [0, 0],
+          size720: [0, 0],
+          pauper: [0, 0],
+          legacy: [0, 0],
+          modern: [0, 0],
+          standard: [0, 0],
+          vintage: [0, 0],
+          cubes: 0,
+          prices: cardVersions.map((cardId) => {
+            return { ...carddb.cardFromId(cardId), version: carddb.cardFromId(cardId)._id };
+          }),
+        },
+        cubedWith: {
+          synergistic: [],
+          top: [],
+          creatures: [],
+          spells: [],
+          other: [],
+        },
+        versions: cardVersions,
+        cubes: [],
+        history: [
+          {
+            data: {
+              size180: [0, 0],
+              size360: [0, 0],
+              size450: [0, 0],
+              size540: [0, 0],
+              size720: [0, 0],
+              pauper: [0, 0],
+              legacy: [0, 0],
+              modern: [0, 0],
+              standard: [0, 0],
+              vintage: [0, 0],
+              total: [0, 0],
+              rating: null,
+              elo: null,
+              picks: 0,
+              cubes: 0,
+              prices: [],
+            },
+            date: '',
+          },
+        ],
+        cardName: card.name,
+        oracleId: card.oracle_id,
+        __v: 0,
+      };
+    }
     const related = {};
 
     for (const category of ['top', 'synergistic', 'spells', 'creatures', 'other']) {

--- a/routes/tools_routes.js
+++ b/routes/tools_routes.js
@@ -5,6 +5,7 @@ const express = require('express');
 
 const carddb = require('../serverjs/cards');
 const cardutil = require('../dist/utils/Card.js');
+const getBlankCardHistory = require('../src/utils/BlankCardHistory.js');
 const { filterUses, makeFilter, filterCardsDetails } = require('../dist/filtering/FilterCards');
 const generateMeta = require('../serverjs/meta.js');
 const util = require('../serverjs/util.js');
@@ -301,65 +302,7 @@ router.get('/card/:id', async (req, res) => {
     let data = await CardHistory.findOne({ oracleId: card.oracle_id });
     // id is valid but has no matching history
     if (!data) {
-      const cardVersions = carddb.getVersionsByOracleId(card.oracle_id);
-
-      data = {
-        current: {
-          rating: null,
-          elo: card.elo,
-          picks: 0,
-          total: [0, 0],
-          size180: [0, 0],
-          size360: [0, 0],
-          size450: [0, 0],
-          size540: [0, 0],
-          size720: [0, 0],
-          pauper: [0, 0],
-          legacy: [0, 0],
-          modern: [0, 0],
-          standard: [0, 0],
-          vintage: [0, 0],
-          cubes: 0,
-          prices: cardVersions.map((cardId) => {
-            return { ...carddb.cardFromId(cardId), version: carddb.cardFromId(cardId)._id };
-          }),
-        },
-        cubedWith: {
-          synergistic: [],
-          top: [],
-          creatures: [],
-          spells: [],
-          other: [],
-        },
-        versions: cardVersions,
-        cubes: [],
-        history: [
-          {
-            data: {
-              size180: [0, 0],
-              size360: [0, 0],
-              size450: [0, 0],
-              size540: [0, 0],
-              size720: [0, 0],
-              pauper: [0, 0],
-              legacy: [0, 0],
-              modern: [0, 0],
-              standard: [0, 0],
-              vintage: [0, 0],
-              total: [0, 0],
-              rating: null,
-              elo: null,
-              picks: 0,
-              cubes: 0,
-              prices: [],
-            },
-            date: '',
-          },
-        ],
-        cardName: card.name,
-        oracleId: card.oracle_id,
-        __v: 0,
-      };
+      data = getBlankCardHistory(id);
     }
     const related = {};
 

--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -30,12 +30,14 @@ class ErrorBoundary extends Component {
                 <code>{this.state.error}</code>
               </p>
               <p>
-                <code>{this.state.stack.split('\n').map((text) => (
-                  <>
-                  {text}
-                  <br/>
-                  </>
-                ))}</code>
+                <code>
+                  {this.state.stack.split('\n').map((text) => (
+                    <>
+                      {text}
+                      <br />
+                    </>
+                  ))}
+                </code>
               </p>
             </Card>
           </Container>

--- a/src/utils/BlankCardHistory.js
+++ b/src/utils/BlankCardHistory.js
@@ -1,0 +1,68 @@
+const carddb = require('../../serverjs/cards');
+
+function getBlankCardHistory(id) {
+  const card = carddb.cardFromId(id);
+  const cardVersions = carddb.getVersionsByOracleId(card.oracle_id);
+
+  const data = {
+    current: {
+      rating: null,
+      elo: card.elo,
+      picks: 0,
+      total: [0, 0],
+      size180: [0, 0],
+      size360: [0, 0],
+      size450: [0, 0],
+      size540: [0, 0],
+      size720: [0, 0],
+      pauper: [0, 0],
+      legacy: [0, 0],
+      modern: [0, 0],
+      standard: [0, 0],
+      vintage: [0, 0],
+      cubes: 0,
+      prices: cardVersions.map((cardId) => {
+        return { ...carddb.cardFromId(cardId), version: carddb.cardFromId(cardId)._id };
+      }),
+    },
+    cubedWith: {
+      synergistic: [],
+      top: [],
+      creatures: [],
+      spells: [],
+      other: [],
+    },
+    versions: cardVersions,
+    cubes: [],
+    history: [
+      {
+        data: {
+          size180: [0, 0],
+          size360: [0, 0],
+          size450: [0, 0],
+          size540: [0, 0],
+          size720: [0, 0],
+          pauper: [0, 0],
+          legacy: [0, 0],
+          modern: [0, 0],
+          standard: [0, 0],
+          vintage: [0, 0],
+          total: [0, 0],
+          rating: null,
+          elo: null,
+          picks: 0,
+          cubes: 0,
+          prices: [],
+        },
+        date: '',
+      },
+    ],
+    cardName: card.name,
+    oracleId: card.oracle_id,
+    __v: 0,
+  };
+
+  return data;
+}
+
+module.exports = getBlankCardHistory;


### PR DESCRIPTION
Bug fix for issue #1567 

Previous behavior: Cards that had scryfall data but no cardHistory data would not generate a card page, but instead redirect to 404. This is primarily an issue with newly revealed cards.

New behavior: Cards that have scryfall data but no cardHistory are now given a default empty data object, which gives enough information to generate and view the scryfall data on the page before cardHistory is added.

I am pretty new to this type of work flow, and I've never worked on a project this large, so I'm pretty open to feedback. Particularly, the big data object in the middle of the route feels a bit out of place to me. Is there a better location/format for this object, or is this fine organization?