### PR TITLE
Fixed issue which caused peasant cube count to not display in card play rate analytics

### DIFF
--- a/models/cardHistory.js
+++ b/models/cardHistory.js
@@ -20,6 +20,7 @@ const Datapoint = {
   size540: [Number],
   size720: [Number],
   pauper: [Number],
+  peasant: [Number],
   legacy: [Number],
   modern: [Number],
   standard: [Number],

--- a/serverjs/cubefn.js
+++ b/serverjs/cubefn.js
@@ -122,10 +122,18 @@ function cardIsLegal(card, legality) {
 
 function setCubeType(cube, carddb) {
   let pauper = true;
+  let peasant = false;
   let type = legalityToInt('Standard');
   for (const card of cube.cards) {
     if (pauper && !['legal', 'banned'].includes(carddb.cardFromId(card.cardID).legalities.Pauper)) {
       pauper = false;
+      peasant = true;
+    }
+    if (!pauper && peasant /* && card only at rare or mythic */) {
+      const rarities = carddb.allVersions(carddb.cardFromId(card.cardID)).map((id) => carddb.cardFromId(id).rarity);
+      if (!rarities.includes('common') && !rarities.includes('uncommon')) {
+        peasant = false;
+      }
     }
     while (type > 0 && !cardIsLegal(carddb.cardFromId(card.cardID), intToLegality(type).toLowerCase())) {
       type -= 1;
@@ -135,6 +143,9 @@ function setCubeType(cube, carddb) {
   cube.type = intToLegality(type);
   if (pauper) {
     cube.type += ' Pauper';
+  }
+  if (peasant) {
+    cube.type += ' Peasant';
   }
   cube.card_count = cube.cards.length;
   return cube;

--- a/serverjs/cubefn.js
+++ b/serverjs/cubefn.js
@@ -129,7 +129,8 @@ function setCubeType(cube, carddb) {
       pauper = false;
       peasant = true;
     }
-    if (!pauper && peasant /* && card only at rare or mythic */) {
+    if (!pauper && peasant) {
+      // check rarities of all card versions
       const rarities = carddb.allVersions(carddb.cardFromId(card.cardID)).map((id) => carddb.cardFromId(id).rarity);
       if (!rarities.includes('common') && !rarities.includes('uncommon')) {
         peasant = false;


### PR DESCRIPTION
Bug fix for #1598 

Previous behavior: Under the Play Rate tab of a card page, the peasant cube count always displays 0, even for cards that are in peasant cubes.

New behavior: Peasant category added in the cardhistories model. On the next card history update, the database will now populate with information about how many peasant cubes that card is in.

I also added behavior that will autodetect peasant cubes as cubes that are not pauper legal, but only contain common or uncommon cards and adds peasant to the type line. This is similar to logic that already exists for pauper cubes.