### PR TITLE
Add support for ctrl click for table view

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ VSCode (with the ESLint extension) is the recommended environment. When using th
 
 ### Initial Setup
 
-Clone the project into a folder of your choice. Copy `.env-EXAMPLE` to `.env` and fill out your personal tokens. **NOTE** `TCG_PLAYER_PUBLIC_KEY` and `TCG_PLAYER_PRIVATE_KEY` can be left blank.
+Clone the project into a folder of your choice. Copy `.env_EXAMPLE` to `.env` and fill out your personal tokens. **NOTE** `TCG_PLAYER_PUBLIC_KEY` and `TCG_PLAYER_PRIVATE_KEY` can be left blank.
 
 Once your `.env` file is filled out, run the following commands in the root of the cloned repository:
 

--- a/__tests__/src/components/CubeListPage.test.js
+++ b/__tests__/src/components/CubeListPage.test.js
@@ -102,3 +102,20 @@ test('CubeListPage has major functionality', async () => {
     expect(getAllByText(card.details.name).length).toBeGreaterThan(0);
   }
 });
+
+test('CubeListPage supports modal and new window card triggers', async () => {
+  const { findByAltText, findByText, getByText } = render(element());
+
+  const cardName = exampleCardsFull[0].details.name;
+  // Show modal card dialog
+  fireEvent.click(getByText(cardName));
+  expect(await findByAltText(cardName));
+  // Close dialog
+  fireEvent.click(global.document.querySelector('.close[aria-label="Close"]'));
+  await findByText(cardName);
+
+  // Open new window if ctrl pressed
+  global.open = jest.fn();
+  fireEvent.click(getByText(cardName), { ctrlKey: true });
+  expect(global.open).toBeCalled();
+});

--- a/src/components/AutocardListItem.js
+++ b/src/components/AutocardListItem.js
@@ -15,21 +15,28 @@ const AutocardListItem = ({ card, noCardModal, inModal, className, children }) =
   const { name } = card.details;
   const { cardColorClass } = useContext(TagContext);
   const openCardModal = useContext(CardModalContext);
+  const openCardToolWindow = useCallback(() => {
+    window.open(`/tool/card/${card.details._id}`);
+  }, [card.details._id]);
   const handleClick = useCallback(
     (event) => {
       event.preventDefault();
-      openCardModal(card);
+      if (event.ctrlKey) {
+        openCardToolWindow();
+      } else {
+        openCardModal(card);
+      }
     },
-    [card, openCardModal],
+    [card, openCardModal, openCardToolWindow],
   );
   const handleAuxClick = useCallback(
     (event) => {
       if (event.button == 1) {
         event.preventDefault();
-        window.open('/tool/card/' + card.details._id);
+        openCardToolWindow();
       }
     },
-    [card.details._id],
+    [openCardToolWindow],
   );
   return (
     <AutocardDiv


### PR DESCRIPTION
Addresses #1562 

Using `event.ctrlKey` we can detect button presses during clicks. 
A variant would also be to support `event.metaKey` since mac users might be more used to using CMD for these interactions, but this would also cause windows key to trigger on win.

I also updated a doc typo I encountered while setting up dev env.