### PR TITLE
Markdown: No link modal for internal links

### DIFF
--- a/src/components/MagicMarkdown.js
+++ b/src/components/MagicMarkdown.js
@@ -160,7 +160,24 @@ const InnerMarkdown = ({ markdown }) => {
           }
           if (section.startsWith('[')) {
             const parts = section.split('](');
+            const link = parts[1].substring(0, parts[1].length - 1);
+            const text = parts[0].substring(1);
 
+            const isInternalURL = (to) => {
+              try {
+                const url = new URL(to, window.location.origin);
+                return url.hostname === window.location.hostname;
+              } catch {
+                return false;
+              }
+            };
+            if (isInternalURL(link)) {
+              return (
+                <a target="_blank" rel="noopener noreferrer" href={link}>
+                  {text}
+                </a>
+              );
+            }
             return (
               /* eslint-disable-next-line jsx-a11y/anchor-is-valid */
               <Link href="#" modalProps={{ link: parts[1].substring(0, parts[1].length - 1) }}>


### PR DESCRIPTION
Implements #1605 

Previous behaviour: Markdown links with cubecobra destination display the external link modal

New behaviour: For markdown links that match the hostname or begin with "/", no modal is displayed.

As far as I have tested, no XSS shenanigans should be possible, as parentheses are needed for that and links with parentheses in them break the markdown link, causing it not to work.