### PR TITLE
Add centering to markdown

### DIFF
--- a/src/components/MagicMarkdown.js
+++ b/src/components/MagicMarkdown.js
@@ -296,9 +296,7 @@ const OuterMarkdown = ({ markdown, limited }) => {
           );
         }
         if (section.startsWith('> ')) {
-          console.log(section);
           const lines = section.split(/(> .+\r?\n)/gm).filter((line) => line.length > 0);
-          console.log(lines);
           return (
             <Card className="bg-light">
               <CardBody>
@@ -310,7 +308,6 @@ const OuterMarkdown = ({ markdown, limited }) => {
           );
         }
         if (section.startsWith('>>>')) {
-          console.log(section);
           const lines = section.split(/(> .+\r?\n)/gm).filter((line) => line.length > 0);
           return (
             <span className="centered">

--- a/src/components/MagicMarkdown.js
+++ b/src/components/MagicMarkdown.js
@@ -283,7 +283,7 @@ const OuterMarkdown = ({ markdown, limited }) => {
   }
 
   const markdownStr = markdown.toString();
-  const split = markdownStr.split(/(<<.+>>|(?:^> .{0,}\r?\n)+)/gm);
+  const split = markdownStr.split(/(<<.+>>|(?:^> .{0,}\r?\n)+|^>>>[^<>]+<<<)/gm);
   return (
     <>
       {split.map((section) => {
@@ -307,6 +307,17 @@ const OuterMarkdown = ({ markdown, limited }) => {
                 ))}
               </CardBody>
             </Card>
+          );
+        }
+        if (section.startsWith('>>>')) {
+          console.log(section);
+          const lines = section.split(/(> .+\r?\n)/gm).filter((line) => line.length > 0);
+          return (
+            <span className="centered">
+              {lines.map((line) => (
+                <Markdown markdown={line.replace(/(>>>)|(<<<)/g, '')} />
+              ))}
+            </span>
           );
         }
         return <Markdown markdown={section} />;

--- a/src/pages/MarkdownPage.js
+++ b/src/pages/MarkdownPage.js
@@ -751,9 +751,11 @@ const MarkdownPage = ({ user, loginCallback }) => (
             <Card>
               <CardHeader>Source</CardHeader>
               <CardBody>
-                <code>{`>>>`}</code> <br />
-                <code>### Centered heading</code> <br />
-                <code>{`<<<`}</code>
+                <code>
+                  {`>>>`} <br />
+                  ### Centered heading <br />
+                  {`<<<`}
+                </code>
               </CardBody>
             </Card>
           </Col>
@@ -761,7 +763,8 @@ const MarkdownPage = ({ user, loginCallback }) => (
             <Card>
               <CardHeader>Result</CardHeader>
               <CardBody>
-                <MagicMarkdown markdown={`>>> 
+                <MagicMarkdown
+                  markdown={`>>> 
                 #### Centered heading
                 <<<`}
                 />
@@ -775,12 +778,12 @@ const MarkdownPage = ({ user, loginCallback }) => (
               <CardHeader>Source</CardHeader>
               <CardBody>
                 <code>
-                  <code>{`>>>`}</code> <br />
-                  <code>Centered paragraph</code> <br />
-                  <code>spanning</code> <br />
-                  <code>multiple</code> <br />
-                  <code>lines</code> <br />
-                  <code>{`<<<`}</code> <br />
+                  {`>>>`} <br />
+                  Centered paragraph <br />
+                  spanning <br />
+                  multiple <br />
+                  lines <br />
+                  {`<<<`} <br />
                 </code>
               </CardBody>
             </Card>
@@ -789,7 +792,8 @@ const MarkdownPage = ({ user, loginCallback }) => (
             <Card>
               <CardHeader>Result</CardHeader>
               <CardBody>
-                <MagicMarkdown markdown={`>>> 
+                <MagicMarkdown
+                  markdown={`>>> 
                 Centered paragraph 
                 spanning 
                 multiple

--- a/src/pages/MarkdownPage.js
+++ b/src/pages/MarkdownPage.js
@@ -49,6 +49,9 @@ const MarkdownPage = ({ user, loginCallback }) => (
           <li>
             <a href="#latex">LaTeX</a>
           </li>
+          <li>
+            <a href="#centering">Centering</a>
+          </li>
         </ol>
       </CardBody>
       <CardBody className="border-top">
@@ -697,6 +700,102 @@ const MarkdownPage = ({ user, loginCallback }) => (
                 <MagicMarkdown markdown={`> $$$\\frac{\\sum_{i=1}^N x_i}{N}$$$ `} />
                 <br />
                 <MagicMarkdown markdown={`### $$$\\frac{\\sum_{i=1}^N x_i}{N}$$$ `} />
+              </CardBody>
+            </Card>
+          </Col>
+        </Row>
+      </CardBody>
+      <CardBody className="border-top">
+        <h5 id="centering">Centering</h5>
+        <p>You can center elements by wrapping them in triple angle brackets.</p>
+        <Row>
+          <Col xs="12" sm="6">
+            <Card>
+              <CardHeader>Source</CardHeader>
+              <CardBody>
+                <code>{`>>> This text is centered <<<`}</code>
+              </CardBody>
+            </Card>
+          </Col>
+          <Col xs="12" sm="6">
+            <Card>
+              <CardHeader>Result</CardHeader>
+              <CardBody>
+                <MagicMarkdown markdown={`>>> This text is centered <<<`} />
+              </CardBody>
+            </Card>
+          </Col>
+        </Row>
+        <br />
+        <p>You can center card images, titles and multi-line paragraphs as well.</p>
+        <Row>
+          <Col xs="12" sm="6">
+            <Card>
+              <CardHeader>Source</CardHeader>
+              <CardBody>
+                <code>{`>>> Centered Card: [[!Hexdrinker]] <<<`}</code>
+              </CardBody>
+            </Card>
+          </Col>
+          <Col xs="12" sm="6">
+            <Card>
+              <CardHeader>Result</CardHeader>
+              <CardBody>
+                <MagicMarkdown markdown={`>>> Centered Image: [[!Hexdrinker]] <<<`} />
+              </CardBody>
+            </Card>
+          </Col>
+        </Row>
+        <Row>
+          <Col xs="12" sm="6">
+            <Card>
+              <CardHeader>Source</CardHeader>
+              <CardBody>
+                <code>{`>>>`}</code> <br />
+                <code>### Centered heading</code> <br />
+                <code>{`<<<`}</code>
+              </CardBody>
+            </Card>
+          </Col>
+          <Col xs="12" sm="6">
+            <Card>
+              <CardHeader>Result</CardHeader>
+              <CardBody>
+                <MagicMarkdown markdown={`>>> 
+                #### Centered heading
+                <<<`}
+                />
+              </CardBody>
+            </Card>
+          </Col>
+        </Row>
+        <Row>
+          <Col xs="12" sm="6">
+            <Card>
+              <CardHeader>Source</CardHeader>
+              <CardBody>
+                <code>
+                  <code>{`>>>`}</code> <br />
+                  <code>Centered paragraph</code> <br />
+                  <code>spanning</code> <br />
+                  <code>multiple</code> <br />
+                  <code>lines</code> <br />
+                  <code>{`<<<`}</code> <br />
+                </code>
+              </CardBody>
+            </Card>
+          </Col>
+          <Col xs="12" sm="6">
+            <Card>
+              <CardHeader>Result</CardHeader>
+              <CardBody>
+                <MagicMarkdown markdown={`>>> 
+                Centered paragraph 
+                spanning 
+                multiple
+                lines
+                <<<`}
+                />
               </CardBody>
             </Card>
           </Col>


### PR DESCRIPTION
Implements #1612 

This PR adds the possibility to center elements using markdown.

To center a text, just wrap it in angular brackets >>>  <<<

The markdown wraps the centered text in <span> tags with the "centered" class.
