### PR TITLE
Fixed cube descriptions

### DIFF
--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -34,6 +34,7 @@ const draftutil = require('../dist/utils/draftutil.js');
 const cardutil = require('../dist/utils/Card.js');
 const sortutil = require('../dist/utils/Sort.js');
 const filterutil = require('../dist/filtering/FilterCards.js');
+const miscutil = require('../dist/utils/Util.js');
 const carddb = require('../serverjs/cards.js');
 
 const util = require('../serverjs/util.js');
@@ -461,7 +462,7 @@ router.get('/overview/:id', async (req, res) => {
         title: `${abbreviate(cube.name)} - Overview`,
         metadata: generateMeta(
           `Cube Cobra Overview: ${cube.name}`,
-          cube.type ? `${cube.card_count} Card ${cube.type} Cube` : `${cube.card_count} Card Cube`,
+          miscutil.getCubeDescription(cube),
           cube.image_uri,
           `https://cubecobra.com/cube/overview/${req.params.id}`,
         ),
@@ -524,7 +525,7 @@ router.get('/blog/:id/:page', async (req, res) => {
         title: `${abbreviate(cube.name)} - Blog`,
         metadata: generateMeta(
           `Cube Cobra Blog: ${cube.name}`,
-          cube.type ? `${cube.card_count} Card ${cube.type} Cube` : `${cube.card_count} Card Cube`,
+          miscutil.getCubeDescription(cube),
           cube.image_uri,
           `https://cubecobra.com/cube/blog/${req.params.id}`,
         ),
@@ -698,7 +699,7 @@ router.get('/list/:id', async (req, res) => {
         title: `${abbreviate(cube.name)} - List`,
         metadata: generateMeta(
           `Cube Cobra List: ${cube.name}`,
-          cube.type ? `${cube.card_count} Card ${cube.type} Cube` : `${cube.card_count} Card Cube`,
+          miscutil.getCubeDescription(cube),
           cube.image_uri,
           `https://cubecobra.com/cube/list/${req.params.id}`,
         ),
@@ -752,7 +753,7 @@ router.get('/playtest/:id', async (req, res) => {
         title: `${abbreviate(cube.name)} - Playtest`,
         metadata: generateMeta(
           `Cube Cobra Playtest: ${cube.name}`,
-          cube.type ? `${cube.card_count} Card ${cube.type} Cube` : `${cube.card_count} Card Cube`,
+          miscutil.getCubeDescription(cube),
           cube.image_uri,
           `https://cubecobra.com/cube/playtest/${req.params.id}`,
         ),
@@ -826,7 +827,7 @@ router.get('/analysis/:id', async (req, res) => {
       {
         metadata: generateMeta(
           `Cube Cobra Analysis: ${cube.name}`,
-          cube.type ? `${cube.card_count} Card ${cube.type} Cube` : `${cube.card_count} Card Cube`,
+          miscutil.getCubeDescription(cube),
           cube.image_uri,
           `https://cubecobra.com/cube/analysis/${req.params.id}`,
         ),
@@ -2165,7 +2166,7 @@ router.get('/griddraft/:id', async (req, res) => {
         title: `${abbreviate(cube.name)} - Grift Draft`,
         metadata: generateMeta(
           `Cube Cobra Grid Draft: ${cube.name}`,
-          cube.type ? `${cube.card_count} Card ${cube.type} Cube` : `${cube.card_count} Card Cube`,
+          miscutil.getCubeDescription(cube),
           cube.image_uri,
           `https://cubecobra.com/cube/griddraft/${req.params.id}`,
         ),
@@ -2239,7 +2240,7 @@ router.get('/draft/:id', async (req, res) => {
         title: `${abbreviate(cube.name)} - Draft`,
         metadata: generateMeta(
           `Cube Cobra Draft: ${cube.name}`,
-          cube.type ? `${cube.card_count} Card ${cube.type} Cube` : `${cube.card_count} Card Cube`,
+          miscutil.getCubeDescription(cube),
           cube.image_uri,
           `https://cubecobra.com/cube/draft/${req.params.id}`,
         ),
@@ -2913,7 +2914,7 @@ router.get('/decks/:cubeid/:page', async (req, res) => {
         title: `${abbreviate(cube.name)} - Draft Decks`,
         metadata: generateMeta(
           `Cube Cobra Decks: ${cube.name}`,
-          cube.type ? `${cube.card_count} Card ${cube.type} Cube` : `${cube.card_count} Card Cube`,
+          miscutil.getCubeDescription(cube),
           cube.image_uri,
           `https://cubecobra.com/user/decks/${req.params.cubeid}`,
         ),
@@ -3270,7 +3271,7 @@ router.get('/deckbuilder/:id', async (req, res) => {
         title: `${abbreviate(cube.name)} - Deckbuilder`,
         metadata: generateMeta(
           `Cube Cobra Draft: ${cube.name}`,
-          cube.type ? `${cube.card_count} Card ${cube.type} Cube` : `${cube.card_count} Card Cube`,
+          miscutil.getCubeDescription(cube),
           cube.image_uri,
           `https://cubecobra.com/cube/draft/${req.params.id}`,
         ),
@@ -3359,7 +3360,7 @@ router.get('/deck/:id', async (req, res) => {
         title: `${abbreviate(cube.name)} - ${drafter}'s deck`,
         metadata: generateMeta(
           `Cube Cobra Deck: ${cube.name}`,
-          cube.type ? `${cube.card_count} Card ${cube.type} Cube` : `${cube.card_count} Card Cube`,
+          miscutil.getCubeDescription(cube),
           cube.image_uri,
           `https://cubecobra.com/cube/deck/${req.params.id}`,
         ),

--- a/src/components/CubeOverviewModal.js
+++ b/src/components/CubeOverviewModal.js
@@ -18,6 +18,7 @@ import {
 } from 'reactstrap';
 
 import { csrfFetch } from 'utils/CSRF';
+import { getCubeDescription } from 'utils/Util';
 
 import AutocompleteInput from 'components/AutocompleteInput';
 import LoadingButton from 'components/LoadingButton';
@@ -239,15 +240,7 @@ class CubeOverviewModal extends Component {
                   name="name"
                   type="text"
                   disabled
-                  value={
-                    cube.overrideCategory
-                      ? cube.card_count +
-                        ' Card ' +
-                        (cube.categoryPrefixes.length > 0 ? cube.categoryPrefixes.join(' ') + ' ' : '') +
-                        cube.categoryOverride +
-                        ' Cube'
-                      : cube.card_count + ' Card ' + cube.type + ' Cube'
-                  }
+                  value={getCubeDescription(cube)}
                 />
 
                 <Row>

--- a/src/components/CubePreview.js
+++ b/src/components/CubePreview.js
@@ -5,7 +5,7 @@ import { Card } from 'reactstrap';
 
 import AspectRatioBox from 'components/AspectRatioBox';
 
-const getCubeId = (cube) => cube.urlAlias || cube.shortId || cube._id;
+import { getCubeDescription, getCubeId } from 'utils/Util';
 
 const CubePreview = ({ cube }) => {
   const [hover, setHover] = useState(false);
@@ -19,10 +19,7 @@ const CubePreview = ({ cube }) => {
     },
     [cube],
   );
-  const defaultSubtitle = `${cube.card_count} Card ${cube.type} Cube`;
-  const overridePrefixes =
-    cube.categoryPrefixes && cube.categoryPrefixes.length > 0 ? `${cube.categoryPrefixes.join(' ')} ` : '';
-  const overrideSubtitle = `${cube.card_count} Card ${overridePrefixes}${cube.categoryOverride} Cube`;
+
   return (
     <Card
       className={hover ? 'cube-preview-card hover' : 'cube-preview-card'}
@@ -38,7 +35,7 @@ const CubePreview = ({ cube }) => {
       </AspectRatioBox>
       <div className="w-100 py-1 px-2">
         <h5 className="text-muted text-ellipsis my-0">{cube.name}</h5>
-        <div className="text-muted text-ellipsis">{cube.overrideCategory ? overrideSubtitle : defaultSubtitle}</div>
+        <div className="text-muted text-ellipsis">{getCubeDescription(cube)}</div>
         <em className="text-muted text-ellipsis">
           Designed by{' '}
           <a data-sublink href={`/user/view/${cube.owner}`}>

--- a/src/layouts/CubeLayout.js
+++ b/src/layouts/CubeLayout.js
@@ -5,6 +5,7 @@ import { NavItem, NavLink } from 'reactstrap';
 
 import CubeContext, { CubeContextProvider } from 'components/CubeContext';
 import ErrorBoundary from 'components/ErrorBoundary';
+import { getCubeDescription } from 'utils/Util';
 
 const CubeNavItem = ({ link, activeLink, children }) => {
   const { cubeID } = useContext(CubeContext);
@@ -28,11 +29,7 @@ CubeNavItem.defaultProps = {
 };
 
 const CubeLayout = ({ cube, cubeID, canEdit, activeLink, children }) => {
-  const categories =
-    cube.categoryPrefixes && cube.categoryPrefixes.length > 0 ? `${cube.categoryPrefixes.join(' ')} ` : '';
-  const subtitle = cube.overrideCategory
-    ? `${cube.card_count} Card ${categories}${cube.categoryOverride} Cube`
-    : `${cube.card_count} Card ${cube.type} Cube`;
+  const subtitle = getCubeDescription(cube);
   return (
     <CubeContextProvider initialCube={cube} cubeID={cubeID} canEdit={canEdit}>
       <div className="mb-3">

--- a/src/pages/CubeOverviewPage.js
+++ b/src/pages/CubeOverviewPage.js
@@ -19,7 +19,7 @@ import {
 } from 'reactstrap';
 
 import { csrfFetch } from 'utils/CSRF';
-import { getCubeId } from 'utils/Util';
+import { getCubeId, getCubeDescription } from 'utils/Util';
 
 import BlogPost from 'components/BlogPost';
 import CSRFForm from 'components/CSRFForm';
@@ -207,15 +207,7 @@ class CubeOverview extends Component {
                   <em className="cube-preview-artist">Art by {cube.image_artist}</em>
                 </div>
                 <CardBody className="pt-2 px-3 pb-3">
-                  {cube.type && (
-                    <p className="mb-1">
-                      {cube.overrideCategory
-                        ? `${cube.card_count} Card ${
-                            cube.categoryPrefixes.length > 0 ? `${cube.categoryPrefixes.join(' ')} ` : ''
-                          }${cube.categoryOverride} Cube`
-                        : `${cube.card_count} Card ${cube.type} Cube`}
-                    </p>
-                  )}
+                  {cube.type && <p className="mb-1">{getCubeDescription(cube)}</p>}
                   <h6 className="mb-2">
                     <i>
                       Designed by

--- a/src/utils/Util.js
+++ b/src/utils/Util.js
@@ -171,6 +171,16 @@ export function getCubeId(cube) {
   return cube.urlAlias || cube.shortID || cube._id;
 }
 
+export function getCubeDescription(cube) {
+  if (cube.overrideCategory) {
+    const overridePrefixes =
+      cube.categoryPrefixes && cube.categoryPrefixes.length > 0 ? `${cube.categoryPrefixes.join(' ')} ` : '';
+    return `${cube.card_count} Card ${overridePrefixes}${cube.categoryOverride} Cube`;
+  }
+
+  return `${cube.card_count} Card ${cube.type} Cube`;
+}
+
 export default {
   arraysEqual,
   arrayRotate,
@@ -185,4 +195,6 @@ export default {
   cmcColumn,
   sortDeck,
   COLORS,
+  getCubeId,
+  getCubeDescription,
 };


### PR DESCRIPTION
Fixes #1436 .

**Cause of issue:** The way cube descriptions were formatted was duplicated across the codebase, and in some places - specifically when generating metadata - the `cube.overrideCategory` and related fields were completely ignored and the autogenerated `cube.type` default was used instead, which led to inconsistencies.

**Fix:** Introduced a new utility function for formatting cube descriptions, then used it everywhere a description is needed.