### PR TITLE
Markdown centering fix

### DIFF
--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -451,9 +451,12 @@ body.busy-cursor {
 }
 
 .centered {
-	display: flex;
-	justify-content: center;
-	align-items: center;
+	width: 100%;
+	text-align: center;
+}
+
+.centered > div {
+	margin: auto;
 }
 
 .centered-max400 {

--- a/src/components/BlogPost.js
+++ b/src/components/BlogPost.js
@@ -84,7 +84,7 @@ class BlogPost extends React.Component {
         <div style={{ overflow: 'auto', maxHeight: '50vh' }}>
           {post.changelist && (post.html || post.markdown) ? (
             <Row className="no-gutters">
-              <Col className="col-12 col-l-5 col-md-4 col-sm-12 blog-post-border" >
+              <Col className="col-12 col-l-5 col-md-4 col-sm-12 blog-post-border">
                 <CardBody className="py-2">
                   <CardText dangerouslySetInnerHTML={{ __html: post.changelist }} />
                 </CardBody>

--- a/src/components/MagicMarkdown.js
+++ b/src/components/MagicMarkdown.js
@@ -15,11 +15,15 @@ const Link = withModal('a', LinkModal);
 const InnerMarkdown = ({ markdown }) => {
   const markdownStr = markdown.toString();
   const split = markdownStr.split(
-    /(\[.+?\]\(.+?\)|@[a-zA-Z0-9_]+|\*\*\*[^*]+?\*\*\*|\*\*[^*]+?\*\*|\*[^*]+?\*|_[^_]+?_|__[^_]+?__|___[^_]+?___|~~[^~]+?~~|{[wubrgcmtsqepxyzWUBRGCMTSQEPXYZ\d/-]+?}|\[\[!?[/]?[a-zA-Z ',-|]+?\]\]|%%\d+%%|\$\$[^$]+?\$\$|\$\$\$[^$]+?\$\$\$|\n)/gm,
+    /(\[.+?\]\(.+?\)|@[a-zA-Z0-9_]+|\*\*\*[^*]+?\*\*\*|\*\*[^*]+?\*\*|\*[^*]+?\*|_[^_]+?_|__[^_]+?__|___[^_]+?___|~~[^~]+?~~|{[wubrgcmtqepxyzWUBRGCMTQEPXYZ\d/-]+?}|\[\[!?[/]?[a-zA-Z ',-|]+?\]\]|%%\d+%%|\$\$[^$]+?\$\$|\$\$\$[^$]+?\$\$\$|\n)/gm,
   );
+  console.log('!!!!!!!!!!!!!!!!!\nInner Markdown split:');
+  console.log(split);
   return (
     <>
       {split.map((section, position) => {
+        console.log('Inner Markdown section:');
+        console.log(section);
         try {
           if (section.startsWith('$$$')) {
             const sub = section.substring(1, section.length - 1);
@@ -211,6 +215,8 @@ InnerMarkdown.propTypes = {
 const Markdown = ({ markdown }) => {
   const markdownStr = markdown.toString();
   const split = markdownStr.split(/(#{1,6} .+\r?\n|(?:^1\. .+(?:\r?\n|$))+|(?:^- .+(?:\r?\n|$))+)/gm);
+  console.log('/////////////////\nMarkdown split:');
+  console.log(split);
   return (
     <>
       {split.map((section) => {
@@ -284,6 +290,8 @@ const Markdown = ({ markdown }) => {
         } catch (err) {
           console.error(err);
         }
+        console.log('Markdown section:');
+        console.log(section);
         return <InnerMarkdown markdown={section} />;
       })}
     </>
@@ -301,9 +309,13 @@ const OuterMarkdown = ({ markdown, limited }) => {
 
   const markdownStr = markdown.toString();
   const split = markdownStr.split(/(<<.+>>|(?:^> .{0,}\r?\n)+|^>>>[^<>]+<<<)/gm);
+  console.log('####################\nOuter Markdown split:');
+  console.log(split);
   return (
     <>
       {split.map((section) => {
+        console.log(`Outer Markdown Section:`);
+        console.log(section);
         if (section.startsWith('<<')) {
           const sub = section.substring(2, section.length - 2);
           return (
@@ -325,13 +337,21 @@ const OuterMarkdown = ({ markdown, limited }) => {
           );
         }
         if (section.startsWith('>>>')) {
-          const lines = section.split(/(> .+\r?\n)/gm).filter((line) => line.length > 0);
+          section = section.replace(/>>>\r?\n?|<<</gm, '');
+          const lines = section.split('\n');
+          console.log(`Lines:`);
+          console.log(lines);
+          lines.map((line) => {
+            console.log('Line:');
+            console.log(line);
+            console.log('Replaced');
+            console.log(line.replace(/(>>>)|(<<<)/g, ''));
+            return line;
+          });
           return (
-            <span className="centered">
-              {lines.map((line) => (
-                <Markdown markdown={line.replace(/(>>>)|(<<<)/g, '')} />
-              ))}
-            </span>
+            <div className="centered">
+              <Markdown markdown={section} />
+            </div>
           );
         }
         return <Markdown markdown={section} />;

--- a/src/components/MagicMarkdown.js
+++ b/src/components/MagicMarkdown.js
@@ -17,13 +17,9 @@ const InnerMarkdown = ({ markdown }) => {
   const split = markdownStr.split(
     /(\[.+?\]\(.+?\)|@[a-zA-Z0-9_]+|\*\*\*[^*]+?\*\*\*|\*\*[^*]+?\*\*|\*[^*]+?\*|_[^_]+?_|__[^_]+?__|___[^_]+?___|~~[^~]+?~~|{[wubrgcmtqepxyzWUBRGCMTQEPXYZ\d/-]+?}|\[\[!?[/]?[a-zA-Z ',-|]+?\]\]|%%\d+%%|\$\$[^$]+?\$\$|\$\$\$[^$]+?\$\$\$|\n)/gm,
   );
-  console.log('!!!!!!!!!!!!!!!!!\nInner Markdown split:');
-  console.log(split);
   return (
     <>
       {split.map((section, position) => {
-        console.log('Inner Markdown section:');
-        console.log(section);
         try {
           if (section.startsWith('$$$')) {
             const sub = section.substring(1, section.length - 1);
@@ -215,8 +211,6 @@ InnerMarkdown.propTypes = {
 const Markdown = ({ markdown }) => {
   const markdownStr = markdown.toString();
   const split = markdownStr.split(/(#{1,6} .+\r?\n|(?:^1\. .+(?:\r?\n|$))+|(?:^- .+(?:\r?\n|$))+)/gm);
-  console.log('/////////////////\nMarkdown split:');
-  console.log(split);
   return (
     <>
       {split.map((section) => {
@@ -290,8 +284,6 @@ const Markdown = ({ markdown }) => {
         } catch (err) {
           console.error(err);
         }
-        console.log('Markdown section:');
-        console.log(section);
         return <InnerMarkdown markdown={section} />;
       })}
     </>
@@ -309,13 +301,9 @@ const OuterMarkdown = ({ markdown, limited }) => {
 
   const markdownStr = markdown.toString();
   const split = markdownStr.split(/(<<.+>>|(?:^>(?: .*)?\r?\n)+|^>>>[^<>]+<<<)/gm);
-  console.log('####################\nOuter Markdown split:');
-  console.log(split);
   return (
     <>
       {split.map((section) => {
-        console.log(`Outer Markdown Section:`);
-        console.log(section);
         if (section.startsWith('<<')) {
           const sub = section.substring(2, section.length - 2);
           return (
@@ -338,16 +326,6 @@ const OuterMarkdown = ({ markdown, limited }) => {
         }
         if (section.startsWith('>>>')) {
           section = section.replace(/>>>\r?\n?|<<</gm, '');
-          const lines = section.split('\n');
-          console.log(`Lines:`);
-          console.log(lines);
-          lines.map((line) => {
-            console.log('Line:');
-            console.log(line);
-            console.log('Replaced');
-            console.log(line.replace(/(>>>)|(<<<)/g, ''));
-            return line;
-          });
           return (
             <div className="centered">
               <Markdown markdown={section} />

--- a/src/components/MagicMarkdown.js
+++ b/src/components/MagicMarkdown.js
@@ -15,7 +15,7 @@ const Link = withModal('a', LinkModal);
 const InnerMarkdown = ({ markdown }) => {
   const markdownStr = markdown.toString();
   const split = markdownStr.split(
-    /(\[.+?\]\(.+?\)|@[a-zA-Z0-9_]+|\*\*\*[^*]+?\*\*\*|\*\*[^*]+?\*\*|\*[^*]+?\*|_[^_]+?_|__[^_]+?__|___[^_]+?___|~~[^~]+?~~|{[wubrgcmtqepxyzWUBRGCMTQEPXYZ\d/-]+?}|\[\[!?[/]?[a-zA-Z ',-|]+?\]\]|%%\d+%%|\$\$[^$]+?\$\$|\$\$\$[^$]+?\$\$\$|\n)/gm,
+    /(\[.+?\]\(.+?\)|@[a-zA-Z0-9_]+|\*\*\*[^*]+?\*\*\*|\*\*[^*]+?\*\*|\*[^*]+?\*|_[^_]+?_|__[^_]+?__|___[^_]+?___|~~[^~]+?~~|{[wubrgcmtsqepxyzWUBRGCMTSQEPXYZ\d/-]+?}|\[\[!?[/]?[a-zA-Z ',-|]+?\]\]|%%\d+%%|\$\$[^$]+?\$\$|\$\$\$[^$]+?\$\$\$|\n)/gm,
   );
   return (
     <>

--- a/src/components/MagicMarkdown.js
+++ b/src/components/MagicMarkdown.js
@@ -308,7 +308,7 @@ const OuterMarkdown = ({ markdown, limited }) => {
   }
 
   const markdownStr = markdown.toString();
-  const split = markdownStr.split(/(<<.+>>|(?:^> .{0,}\r?\n)+|^>>>[^<>]+<<<)/gm);
+  const split = markdownStr.split(/(<<.+>>|(?:^>(?: .*)?\r?\n)+|^>>>[^<>]+<<<)/gm);
   console.log('####################\nOuter Markdown split:');
   console.log(split);
   return (

--- a/src/pages/MarkdownPage.js
+++ b/src/pages/MarkdownPage.js
@@ -741,7 +741,7 @@ const MarkdownPage = ({ user, loginCallback }) => (
             <Card>
               <CardHeader>Result</CardHeader>
               <CardBody>
-                <MagicMarkdown markdown={`>>> Centered Image: [[!Hexdrinker]] <<<`} />
+                <MagicMarkdown markdown={`>>> Centered Card: [[!Hexdrinker]] <<<`} />
               </CardBody>
             </Card>
           </Col>
@@ -764,7 +764,7 @@ const MarkdownPage = ({ user, loginCallback }) => (
               <CardHeader>Result</CardHeader>
               <CardBody>
                 <MagicMarkdown
-                  markdown={`>>> 
+                  markdown={`>>>
                 #### Centered heading
                 <<<`}
                 />
@@ -793,7 +793,7 @@ const MarkdownPage = ({ user, loginCallback }) => (
               <CardHeader>Result</CardHeader>
               <CardBody>
                 <MagicMarkdown
-                  markdown={`>>> 
+                  markdown={`>>>
                 Centered paragraph 
                 spanning 
                 multiple


### PR DESCRIPTION
Fixes #1612 
Fixes #1638 
Addresses issues introduced in #1625 .

*Warning*: This is a long comment. It may not need to be, but I just spent four hours on what amounts to changing six lines, so I'm going to write about this damn it. If you aren't interested and just want to see how it works, there are pictures at the end.

The current way centering is written in the markdown parser is flawed in several ways. Firstly, there are some code issues this PR fixes:
- The '>>>' parser includes the `lines = section.split().filter()` line followed by `lines.map` in the actual results. I assume this was copied from the '> ' parser. This isn't necessarily a bug, because the regex on which we're splitting cannot ever match anything, meaning `lines` will always contain just one element with the whole section, but it doesn't really make any sense (also, the centered section doesn't need to be split into lines at all).
- The centered section is wrapped in a `span` element. I believe that the centered section is a block-level element, not an inline one (supported by the fact that it's parsed in OuterMarkdown), which makes `div` a more appropriate choice.

Secondly, and rather more importantly, however, the current solution has some functional issues, mostly on the CSS side.

## How it works currently.
The `span` is displayed as horizontal flexbox container, which centers all the containers horizontally and justifies them to the center vertically.

### The problems with this approach:
1. **It doesn't work with other markdown.** Any InnerMarkdown element (such as piece of bold text, an image, or a link) will create its own flexbox container, splitting the line into multiple separated fragments. That means this source:
![bad_boxes_src](https://user-images.githubusercontent.com/38463785/96027344-47807580-0e47-11eb-930d-f223af908184.png)  
Turns into this result:
![bad_boxes_res](https://user-images.githubusercontent.com/38463785/96027368-4fd8b080-0e47-11eb-99aa-691c93b2188f.png) 
which I'd argue isn't the desired outcome.
2. **It doesn't work with other markdown.** The behaviour explained in the previous point is also the root cause of #1638 , because the bounding boxes by themselves have no padding/margin and whitespace is trimmed by default.
3. **It doesn't actually centre text.** This issue is best seen in a multiline centred block. Here's the source:
![not_centred_src](https://user-images.githubusercontent.com/38463785/96029113-b4950a80-0e49-11eb-8cc7-d4c03c69bdc4.png)
and here's the result:
![2020-10-14_20-14](https://user-images.githubusercontent.com/38463785/96029133-bd85dc00-0e49-11eb-8887-6304adcd4bc2.png)
This is clearly not a centre-justified paragraph of text. The reason for this is simple - the flexbox layout doesn't actually centre text. Instead, it centres the containers inside it across the row (but doesn't affect the layout inside those containers themselves). This works when all we have is a single line of simple text - a single container is created in the middle with the width of the text inside it. But it breaks down when introducing multiple lines (or indeed multiple children, as seen above).

## What this PR does
We can realize that centring content isn't as difficult as it may seem. With the exception of card images and block LaTeX, everything is displayed inline by default, so just setting `text-align: center;` on the surrounding div gets us most of the way there. Block LaTeX also centers itself by default, so we don't need to do anything about it either. The only issue left to resolve is centering card images.

Those also turned out surprisingly simple to solve. Since card images are generated as a link inside their own div, we just have to set `margin: auto;` on the div encompassing that link and it will happily move its contents to the center for us. Problem solved.

Oh, and as a side note, the PR also fixes an issue I found where lines containing only ">\n" without a trailing space broke quotation blocks.

## The new centering in action
#### Source:
![2020-10-14_20-42](https://user-images.githubusercontent.com/38463785/96031617-1efb7a00-0e4d-11eb-8b08-0941dd4237fc.png)
#### Result:
![2020-10-14_20-41](https://user-images.githubusercontent.com/38463785/96031638-26228800-0e4d-11eb-8528-8abd74def315.png)
(You can even center lists if you're into that, it works fine, they just didn't fit on the screen.)
I confirmed this to be working locally in cube overviews and blog posts. I didn't look at content articles, and it doesn't work on comments, which don't allow any formatting with `>` or `<`.