### PR TITLE
Filter grammar fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,6 @@ private/
 /.vscode/
 src/generated/
 
-src/generated/
-
 .python-version
 
 # Created by https://www.gitignore.io/api/node,komodoedit,webstorm+all,visualstudio,visualstudiocode

--- a/nearley/values.ne
+++ b/nearley/values.ne
@@ -150,13 +150,15 @@ stringContainOpValue -> equalityOperator stringValue {% ([op, value]) => stringC
 stringValue -> (noQuoteStringValue | dqstring | sqstring) {% ([[value]]) => value.toLowerCase() %}
 
 # anything that isn't a special character and isn't "and" or "or"
-noQuoteStringValue -> ([^aAoO\- \t\n"'\\=<>:] 
-  | "a"i [^nN \t\n"'\\=<>:] 
-  | "an"i:+ [^dD \t\n"'\\=<>:] 
-  | "and"i:+ [^ \t\n"'\\=<>:] 
-  | "o"i:+ [^rR \t\n"'\\=<>:]
-  | "or"i:+ [^ \t\n"'\\=<>:]
-) [^ \t\n"'\\=<>:]:* {% ([startChars, chars]) => startChars.concat(chars).join('').toLowerCase() %}
+noQuoteStringValue -> 
+  ("a"i | "an"i | "o"i) {% ([[value]]) => value.toLowerCase() %}
+  | ([^aAoO\- \t\n"'\\=<>:] 
+    | "a"i [^nN \t\n"'\\=<>:] 
+    | "an"i [^dD \t\n"'\\=<>:] 
+    | "and"i [^ \t\n"'\\=<>:] 
+    | "o"i [^rR \t\n"'\\=<>:]
+    | "or"i [^ \t\n"'\\=<>:]
+    ) [^ \t\n"'\\=<>:]:* {% ([startChars, chars]) => startChars.concat(chars).join('').toLowerCase() %}
 # "
 
 manaCostOpValue -> equalityOperator manaCostValue {% ([op, value]) => manaCostOperation(op, value) %}

--- a/src/components/CubeOverviewModal.js
+++ b/src/components/CubeOverviewModal.js
@@ -235,13 +235,7 @@ class CubeOverviewModal extends Component {
 
                 <h6>Category</h6>
 
-                <input
-                  className="form-control"
-                  name="name"
-                  type="text"
-                  disabled
-                  value={getCubeDescription(cube)}
-                />
+                <input className="form-control" name="name" type="text" disabled value={getCubeDescription(cube)} />
 
                 <Row>
                   <Col>


### PR DESCRIPTION
Fixes #1634 .

## Issue
Any string argument matching `/^oo.+/` fails to parse in the filter. This applies to options (`t:ooze`, `name:oon`) as well as plain strings (`oodseeker`). For reasons explained below, arguments matching `/^oror.+/`, `/^anan.+/` or `/^andand.+/` are affected in the same way. When enclosed in quotes, the arguments are parsed correctly. 

## Bug
The parsing grammar is ambiguous. This can be clearly seen by debugging the parser, which returns two possible filters when ran on the strings described above. We interpret this as an error and filtering is disabled on that input.

## Root cause
The ambiguity arises from the following rule, located in `nearley/values.ne`:
```
stringValue -> (noQuoteStringValue | dqstring | sqstring) {% ([[value]]) => value.toLowerCase() %}

# anything that isn't a special character and isn't "and" or "or"
noQuoteStringValue -> ([^aAoO\- \t\n"'\\=<>:] 
  | "a"i [^nN \t\n"'\\=<>:] 
  | "an"i:+ [^dD \t\n"'\\=<>:] 
  | "and"i:+ [^ \t\n"'\\=<>:] 
  | "o"i:+ [^rR \t\n"'\\=<>:]
  | "or"i:+ [^ \t\n"'\\=<>:]
) [^ \t\n"'\\=<>:]:* {% ([startChars, chars]) => startChars.concat(chars).join('').toLowerCase() %}
# "
```
Here's a diagram describing the same rule for clarity:
![broken_rules](https://user-images.githubusercontent.com/38463785/96250426-5af22480-0f9e-11eb-813a-dd66284b5f51.png)

The `noQuoteStringValue` non-terminal is trying to match a sequence of non-special characters that aren't the string "and" or "or". We can see from this rule that there are two ways to parse the string "oox" - either both 'o' characters are matched as part of the `"o"i:+` token and the 'x' matches the following `[^ \t\n"'\\=<>:]`, or only the first 'o' is matched to `"o"i:+`, the second 'o' is matched to `[^ \t\n"'\\=<>:]`, and everything following is matched to the catch-all `[^ \t\n"'\\=<>:]:*` token after the parentheses. The other patterns mentioned above become ambiguous for the same reason. When quoted, the `noQuoteStringValue` token isn't used at all, avoiding this issue completely.

## Fix
First, it's important to see that we don't need the ambiguity. The postprocessor for this rule just concatenates the two parts anyway, so we don't care whether the 'o' was matched inside the parentheses or outside of them.

That means we can make the rule non-ambiguous by simply removing all extraneous possible paths. In this case, the simplest way to do that is to remove the repetition while matching the 'o' - we don't need it. When the 'o' is repeated, the second one will be matched by the following "non-R" terminal and everything works correctly. We can also see that the strings "or" and "and" will still fail to parse to this token, because the rule starting with them requires another token following this sequence. We preserved the intended functionality of the token while making it unambiguous.

## Related issue
Due to how this rule was written, the strings "a", "an", and "o" also failed to parse as operands. I included a rule matching these special cases so that these edge cases are now also handled correctly.


