### PR TITLE
Adds card count update to /api/addtocube

### DIFF
--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -3789,6 +3789,7 @@ router.post(
     }
 
     cube.cards.push(util.newCard(req.body.add.details));
+    setCubeType(cube, carddb);
     await cube.save();
 
     return res.status(200).send({

--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -3784,7 +3784,7 @@ router.post(
     if (!req.user._id.equals(cube.owner)) {
       return res.status(403).send({
         success: 'false',
-        message: 'Maybeboard can only be updated by cube owner.',
+        message: 'Cube can only be updated by cube owner.',
       });
     }
 
@@ -3813,7 +3813,7 @@ router.post(
     if (!req.user._id.equals(cube.owner)) {
       return res.status(403).send({
         success: 'false',
-        message: 'Cube can only be updated by owner.',
+        message: 'Maybeboard can only be updated by owner.',
       });
     }
 

--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -3772,7 +3772,7 @@ router.post(
   '/api/addtocube/:id',
   ensureAuth,
   util.wrapAsyncApi(async (req, res) => {
-    const cube = await Cube.findOne(buildIdQuery(req.params.id));
+    let cube = await Cube.findOne(buildIdQuery(req.params.id));
 
     if (!cube) {
       return res.status(400).send({
@@ -3789,7 +3789,7 @@ router.post(
     }
 
     cube.cards.push(util.newCard(req.body.add.details));
-    setCubeType(cube, carddb);
+    cube = setCubeType(cube, carddb);
     await cube.save();
 
     return res.status(200).send({


### PR DESCRIPTION
Fixes #1649 .

## Cause of issue
The card count metadata is read from the `Cube.card_count` database field. During most edits, this field is updated in the `setCubeType` method. When handling the route `/cube/api/addtocube` (used when adding cards from Card Pages), this method wasn't called, so the field was never updated.

## Fix
Added a call to `setCubeType` to the route handler. *(Also fixed a typo I found as a bonus.)*

## Additional comments
Personally I'm not too hot on `setCubeType` being where we update **size** information of a cube - it feels out of place there. This fix took me maybe 20 minutes more than it should because I kept skipping this call when tracing the execution, dismissing a possibility that this method of all places is where the card count is set. Before this PR is merged, we should maybe consider changing the way this is handled. My suggestion would probably be to create a utility function for adding cards to the cube that updates both fields and use that consistently for all cube list edits.

I also noticed that the `date_updated` field isn't changed either when using the API route. Should it? This feels like something that could also be abstracted by a nicer interface.

Finally, I think that `setCubeType` isn't actually working correctly at the moment, which I'll create a separate issue for.