### PR TITLE
Added null-ish check to markdown parser

### DIFF
--- a/src/components/MagicMarkdown.js
+++ b/src/components/MagicMarkdown.js
@@ -299,7 +299,7 @@ const OuterMarkdown = ({ markdown, limited }) => {
     return <Markdown markdown={markdown} />;
   }
 
-  const markdownStr = markdown.toString();
+  const markdownStr = markdown?.toString() ?? '';
   const split = markdownStr.split(/(<<.+>>|(?:^>(?: .*)?\r?\n)+|^>>>[^<>]+<<<)/gm);
   return (
     <>


### PR DESCRIPTION
Fixes #1633.

## Cause of issue
Auto-generated blog posts created on cube changes didn't define any markdown value when no text was added. This broke the parser, which tried to call `toString()` on the undefined value when opening the editor for that blog post.

## Fix
Added a check to `OuterMarkdown` so that null-ish values are silently converted to an empty string instead of throwing an exception. (This seemed both easier and more future-proof than trying to change the post creation process.)