### PR TITLE
Markdown centering regression fix

### DIFF
--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -451,11 +451,17 @@ body.busy-cursor {
 }
 
 .centered {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+}
+
+.centered-markdown {
 	width: 100%;
 	text-align: center;
 }
 
-.centered > div {
+.centered-markdown > div {
 	margin: auto;
 }
 

--- a/src/components/MagicMarkdown.js
+++ b/src/components/MagicMarkdown.js
@@ -327,7 +327,7 @@ const OuterMarkdown = ({ markdown, limited }) => {
         if (section.startsWith('>>>')) {
           section = section.replace(/>>>\r?\n?|<<</gm, '');
           return (
-            <div className="centered">
+            <div className="centered-markdown">
               <Markdown markdown={section} />
             </div>
           );


### PR DESCRIPTION
This PR fixes a regression introduced in #1644. The markdown centering was originally done using the `.centered` CSS class. When changing the functionality of `.centered`, I neglected the fact that this class was also used for other purposes. This change broke for example the landing page, which on current master renders like this:
![2020-10-22_16-46](https://user-images.githubusercontent.com/38463785/96888666-28f12e80-1486-11eb-96f3-6be150f8fb71.png)

To mitigate this issue, I moved the reworked behaviour into a separate class, `.centered-markdown` and restored the original definition of `.centered`. That way, any elements created with the original class in mind will continue to work as expected and the centered markdown blocks can use the new correct definition.