### PR TITLE
Minor Sort.js touch-up

### DIFF
--- a/src/utils/Sort.js
+++ b/src/utils/Sort.js
@@ -58,6 +58,13 @@ function removeAdjacentDuplicates(arr) {
   return arr.filter((x, i) => i === 0 || x !== arr[i - 1]);
 }
 
+function defaultSort(x, y) {
+  if (!/^\d+$/.test(x) || !/^\d+$/.test(y)) {
+    return x < y ? -1 : 1;
+  }
+  return parseInt(x, 10) < parseInt(y, 10) ? -1 : 1;
+}
+
 export function GetColorIdentity(colors) {
   if (colors.length === 0) {
     return 'Colorless';
@@ -255,7 +262,7 @@ function getLabelsRaw(cube, sort) {
     return tags.sort();
   }
   if (sort === 'Date Added') {
-    const dates = cube.map((card) => card.addedTmsp).sort();
+    const dates = cube.map((card) => card.addedTmsp).sort((a, b) => a - b);
     const days = dates.map((date) => ISODateToYYYYMMDD(date));
     return removeAdjacentDuplicates(days);
   }
@@ -368,24 +375,7 @@ function getLabelsRaw(cube, sort) {
         }
       }
     }
-    return items.sort((x, y) => {
-      if (!/^\d+$/.test(x) || !/^\d+$/.test(y)) {
-        if (x > y) {
-          return 1;
-        }
-        if (y > x) {
-          return -1;
-        }
-        return 1;
-      }
-      if (parseInt(x, 10) > parseInt(y, 10)) {
-        return 1;
-      }
-      if (parseInt(y, 10) > parseInt(x, 10)) {
-        return -1;
-      }
-      return 1;
-    });
+    return items.sort(defaultSort);
   }
   if (sort === 'Toughness') {
     const items = [];
@@ -396,24 +386,7 @@ function getLabelsRaw(cube, sort) {
         }
       }
     }
-    return items.sort((x, y) => {
-      if (!/^\d+$/.test(x) || !/^\d+$/.test(y)) {
-        if (x > y) {
-          return 1;
-        }
-        if (y > x) {
-          return -1;
-        }
-        return 1;
-      }
-      if (parseInt(x, 10) > parseInt(y, 10)) {
-        return 1;
-      }
-      if (parseInt(y, 10) > parseInt(x, 10)) {
-        return -1;
-      }
-      return 1;
-    });
+    return items.sort(defaultSort);
   }
   if (sort === 'Loyalty') {
     const items = [];
@@ -424,24 +397,7 @@ function getLabelsRaw(cube, sort) {
         }
       }
     }
-    return items.sort((x, y) => {
-      if (!/^\d+$/.test(x) || !/^\d+$/.test(y)) {
-        if (x > y) {
-          return 1;
-        }
-        if (y > x) {
-          return -1;
-        }
-        return 1;
-      }
-      if (parseInt(x, 10) > parseInt(y, 10)) {
-        return 1;
-      }
-      if (parseInt(y, 10) > parseInt(x, 10)) {
-        return -1;
-      }
-      return 1;
-    });
+    return items.sort(defaultSort);
   }
   if (sort === 'Manacost Type') {
     return ['Gold', 'Hybrid', 'Phyrexian'];
@@ -500,15 +456,7 @@ function getLabelsRaw(cube, sort) {
         }
       }
     }
-    elos = elos.sort((x, y) => {
-      if (x - y > 0) {
-        return 1;
-      }
-      if (y - x > 0) {
-        return -1;
-      }
-      return 1;
-    });
+    elos = elos.sort((x, y) => (x < y ? -1 : 1));
     const buckets = elos.map(getEloBucket);
     const res = [];
     for (const bucket of buckets) {


### PR DESCRIPTION
This PR fixes an aesthetic issue with sorting by date. Currently, when sorting by Date Added, the columns aren't arranged chronologically, but lexicografically by Javascript's string representation of Date objects. Here's an example of the current behaviour:
![2020-10-23_18-54](https://user-images.githubusercontent.com/38463785/97032427-57880b80-1551-11eb-956d-08353d062427.png)

This is due to the fact that the `.sort()` function wasn't given a comparison function when sorting by Date Added, and `.sort()` by default converts the objects to strings which and compares them character by character. The `toString()` override on Dates doesn't just print the numeric values, but converts them to some human readable form (which is inherently not chronological).

To fix this, this PR adds a comparison function to the sort. Also, while I was looking through the file, I noticed a comparison function that was duplicated in a couple of places and unnecessarily verbose, so I cleaned it up a bit. The sort after this change:
![2020-10-23_18-58](https://user-images.githubusercontent.com/38463785/97032954-1cd2a300-1552-11eb-88e8-ffc2810ef9c0.png)

(all other sorts were left functionally identical with only some syntax changes made)
