### PR TITLE
Add default Elo value to card objects

### DIFF
--- a/serverjs/updatecards.js
+++ b/serverjs/updatecards.js
@@ -606,7 +606,7 @@ function convertCard(card, isExtra) {
     eur: card.prices.eur ? parseFloat(card.prices.eur, 10) : null,
     tix: card.prices.tix ? parseFloat(card.prices.tix, 10) : null,
   };
-  newcard.elo = catalog.elodict[name];
+  newcard.elo = catalog.elodict[name] ? catalog.elodict[name] : 1200;
   newcard.embedding = catalog.embeddingdict[name];
   newcard.digital = card.digital;
   newcard.isToken = card.layout === 'token';

--- a/serverjs/updatecards.js
+++ b/serverjs/updatecards.js
@@ -606,7 +606,7 @@ function convertCard(card, isExtra) {
     eur: card.prices.eur ? parseFloat(card.prices.eur, 10) : null,
     tix: card.prices.tix ? parseFloat(card.prices.tix, 10) : null,
   };
-  newcard.elo = catalog.elodict[name] ? catalog.elodict[name] : 1200;
+  newcard.elo = catalog.elodict[name] || 1200;
   newcard.embedding = catalog.embeddingdict[name];
   newcard.digital = card.digital;
   newcard.isToken = card.layout === 'token';

--- a/src/utils/Sort.js
+++ b/src/utils/Sort.js
@@ -44,6 +44,8 @@ const GUILDS = ['Azorius', 'Dimir', 'Rakdos', 'Gruul', 'Selesnya', 'Orzhov', 'Iz
 const SHARDS = ['Bant', 'Esper', 'Grixis', 'Jund', 'Naya', 'Abzan', 'Jeskai', 'Sultai', 'Mardu', 'Temur'];
 const FOUR_AND_FIVE_COLOR = ['4c', '5c'];
 
+const ELO_DEFAULT = 1200;
+
 function ISODateToYYYYMMDD(dateString) {
   const locale = 'en-US';
 
@@ -450,10 +452,9 @@ function getLabelsRaw(cube, sort) {
   if (sort === 'Elo') {
     let elos = [];
     for (const card of cube) {
-      if (card.details.elo) {
-        if (!elos.includes(card.details.elo)) {
-          elos.push(card.details.elo);
-        }
+      const elo = card.details.elo ?? ELO_DEFAULT;
+      if (!elos.includes(elo)) {
+        elos.push(elo);
       }
     }
     elos = elos.sort((x, y) => (x < y ? -1 : 1));
@@ -732,10 +733,7 @@ export function cardGetLabels(card, sort) {
     return ['All'];
   }
   if (sort === 'Elo') {
-    if (card.details.elo) {
-      return [getEloBucket(card.details.elo)];
-    }
-    return [];
+    return [getEloBucket(card.details.elo ?? ELO_DEFAULT)];
   }
   // Unrecognized sort
   return [];


### PR DESCRIPTION
Fixes #1655.

The card update script now adds a default elo of 1200 to cards that don't have any computed elo yet. Sort by elo now also provides a fallback value of 1200 for cards with undefined elo. (Which should only be needed until the next card update is run).