### PR TITLE
Fixed 404 redirects

### DIFF
--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -498,7 +498,7 @@ router.get('/blog/:id/:page', async (req, res) => {
 
     if (!cube) {
       req.flash('danger', 'Cube not found');
-      return res.redirect('404');
+      return res.redirect('/404');
     }
 
     const countQ = Blog.countDocuments({ cube: cube._id });
@@ -579,7 +579,7 @@ router.get('/rss/:id', async (req, res) => {
     res.set('Content-Type', 'text/xml');
     return res.status(200).send(feed.xml());
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404/');
+    return util.handleRouteError(req, res, err, '/404');
   }
 });
 
@@ -652,7 +652,7 @@ router.get('/compare/:idA/to/:idB', async (req, res) => {
       },
     );
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404/');
+    return util.handleRouteError(req, res, err, '/404');
   }
 });
 
@@ -1222,7 +1222,7 @@ router.post('/bulkupload/:id', ensureAuth, async (req, res) => {
     const cube = await Cube.findOne(buildIdQuery(req.params.id));
     if (!cube) {
       req.flash('danger', 'Cube not found');
-      return res.redirect('404');
+      return res.redirect('/404');
     }
     if (!req.user._id.equals(cube.owner)) {
       req.flash('danger', 'Not Authorized');
@@ -1248,7 +1248,7 @@ router.post('/bulkuploadfile/:id', ensureAuth, async (req, res) => {
     const cube = await Cube.findOne(buildIdQuery(req.params.id));
     if (!cube) {
       req.flash('danger', 'Cube not found');
-      return res.redirect('404');
+      return res.redirect('/404');
     }
     if (!req.user._id.equals(cube.owner)) {
       req.flash('danger', 'Not Authorized');
@@ -1274,7 +1274,7 @@ router.post('/bulkreplacefile/:id', ensureAuth, async (req, res) => {
     const { cards } = await Cube.findOne(buildIdQuery(req.params.id), 'cards').lean();
     if (!cube) {
       req.flash('danger', 'Cube not found');
-      return res.redirect('404');
+      return res.redirect('/404');
     }
     if (!req.user._id.equals(cube.owner)) {
       req.flash('danger', 'Not Authorized');
@@ -1551,7 +1551,7 @@ router.post(
 
       if (!cube) {
         req.flash('danger', 'Cube not found');
-        return res.redirect('404');
+        return res.redirect('/404');
       }
 
       if (cube.cards.length < numCards) {
@@ -1651,7 +1651,7 @@ router.post('/startsealed/:id', body('packs').toInt({ min: 1, max: 16 }), body('
 
     if (!cube) {
       req.flash('danger', 'Cube not found');
-      return res.redirect('404');
+      return res.redirect('/404');
     }
 
     if (cube.cards.length < numCards) {
@@ -2001,7 +2001,7 @@ router.post(
 
       if (!cube) {
         req.flash('danger', 'Cube not found');
-        return res.redirect('404');
+        return res.redirect('/404');
       }
 
       if (cube.cards.length === 0) {
@@ -2110,20 +2110,20 @@ router.get('/griddraft/:id', async (req, res) => {
     const draft = await GridDraft.findById(req.params.id).lean();
     if (!draft) {
       req.flash('danger', 'Draft not found');
-      return res.redirect('404');
+      return res.redirect('/404');
     }
 
     const cube = await Cube.findOne(buildIdQuery(draft.cube)).lean();
 
     if (!cube) {
       req.flash('danger', 'Cube not found');
-      return res.redirect('404');
+      return res.redirect('/404');
     }
 
     const user = await User.findById(cube.owner);
     if (!user) {
       req.flash('danger', 'Owner not found');
-      return res.redirect('404');
+      return res.redirect('/404');
     }
 
     // insert card details everywhere that needs them
@@ -2182,20 +2182,20 @@ router.get('/draft/:id', async (req, res) => {
     const draft = await Draft.findById(req.params.id).lean();
     if (!draft) {
       req.flash('danger', 'Draft not found');
-      return res.redirect('404');
+      return res.redirect('/404');
     }
 
     const cube = await Cube.findOne(buildIdQuery(draft.cube)).lean();
 
     if (!cube) {
       req.flash('danger', 'Cube not found');
-      return res.redirect('404');
+      return res.redirect('/404');
     }
 
     const user = await User.findById(cube.owner);
     if (!user) {
       req.flash('danger', 'Owner not found');
-      return res.redirect('404');
+      return res.redirect('/404');
     }
 
     // insert card details everywhere that needs them
@@ -2703,7 +2703,7 @@ router.post('/editdeck/:id', ensureAuth, async (req, res) => {
 
     if (!deckOwner || !deckOwner._id.equals(req.user._id)) {
       req.flash('danger', 'Unauthorized');
-      return res.redirect('404');
+      return res.redirect('/404');
     }
 
     const newdeck = JSON.parse(req.body.draftraw);
@@ -2852,7 +2852,7 @@ router.delete('/deletedeck/:id', ensureAuth, async (req, res) => {
 
     if (!deckOwner || !deckOwner._id.equals(req.user._id)) {
       req.flash('danger', 'Unauthorized');
-      return res.redirect('404');
+      return res.redirect('/404');
     }
 
     await Deck.deleteOne(query);
@@ -2878,7 +2878,7 @@ router.get('/decks/:cubeid/:page', async (req, res) => {
 
     if (!cube) {
       req.flash('danger', 'Cube not found');
-      return res.redirect('404');
+      return res.redirect('/404');
     }
 
     const decksq = Deck.find(
@@ -2934,7 +2934,7 @@ router.get('/rebuild/:id/:index', ensureAuth, async (req, res) => {
     const base = await Deck.findById(req.params.id).lean();
     if (!base) {
       req.flash('danger', 'Deck not found');
-      return res.redirect('404');
+      return res.redirect('/404');
     }
     const cube = await Cube.findById(base.cube);
     const srcDraft = await Draft.findById(base.draft).lean();
@@ -3073,7 +3073,7 @@ router.get('/redraft/:id', async (req, res) => {
 
     if (!(base && base.draft)) {
       req.flash('danger', 'Deck not found');
-      return res.redirect('404');
+      return res.redirect('/404');
     }
 
     const srcDraft = await Draft.findById(base.draft).lean();
@@ -3218,7 +3218,7 @@ router.get('/deckbuilder/:id', async (req, res) => {
     const deck = await Deck.findById(req.params.id).lean();
     if (!deck) {
       req.flash('danger', 'Deck not found');
-      return res.redirect('404');
+      return res.redirect('/404');
     }
     const draft = deck.draft
       ? (await Draft.findById(deck.draft).lean()) || (await GridDraft.findById(deck.draft).lean())
@@ -3254,7 +3254,7 @@ router.get('/deckbuilder/:id', async (req, res) => {
 
     if (!cube) {
       req.flash('danger', 'Cube not found');
-      return res.redirect('404');
+      return res.redirect('/404');
     }
 
     return render(
@@ -3286,20 +3286,20 @@ router.get('/deck/:id', async (req, res) => {
   try {
     if (!req.params.id || req.params.id === 'null' || req.params.id === 'false') {
       req.flash('danger', 'Invalid deck ID.');
-      return res.redirect('404');
+      return res.redirect('/404');
     }
 
     const deck = await Deck.findById(req.params.id).lean();
 
     if (!deck) {
       req.flash('danger', 'Deck not found');
-      return res.redirect('404');
+      return res.redirect('/404');
     }
 
     const cube = await Cube.findOne(buildIdQuery(deck.cube), Cube.LAYOUT_FIELDS).lean();
     if (!cube) {
       req.flash('danger', 'Cube not found');
-      return res.redirect('404');
+      return res.redirect('/404');
     }
 
     let draft = null;
@@ -3914,7 +3914,7 @@ router.delete('/blog/remove/:id', ensureAuth, async (req, res) => {
 
     if (!req.user._id.equals(blog.owner)) {
       req.flash('danger', 'Unauthorized');
-      return res.redirect('404');
+      return res.redirect('/404');
     }
     await Blog.deleteOne(query);
 

--- a/routes/tools_routes.js
+++ b/routes/tools_routes.js
@@ -260,7 +260,7 @@ router.get('/topcards', async (req, res) => {
       },
     );
   } catch (err) {
-    return util.handleRouteError(req, res, err, `/404`);
+    return util.handleRouteError(req, res, err, '/404');
   }
 });
 
@@ -334,7 +334,7 @@ router.get('/card/:id', async (req, res) => {
       },
     );
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404/');
+    return util.handleRouteError(req, res, err, '/404');
   }
 });
 
@@ -369,7 +369,7 @@ router.get('/cardimage/:id', async (req, res) => {
 
     return res.redirect(card.image_normal);
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404/');
+    return util.handleRouteError(req, res, err, '/404');
   }
 });
 
@@ -404,7 +404,7 @@ router.get('/cardimageflip/:id', async (req, res) => {
 
     return res.redirect(card.image_flip);
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404/');
+    return util.handleRouteError(req, res, err, '/404');
   }
 });
 

--- a/routes/users_routes.js
+++ b/routes/users_routes.js
@@ -103,7 +103,7 @@ router.get('/follow/:id', ensureAuth, async (req, res) => {
 
     if (!other) {
       req.flash('danger', 'User not found');
-      return res.redirect('404');
+      return res.redirect('/404');
     }
 
     if (!other.users_following.includes(user.id)) {
@@ -133,7 +133,7 @@ router.get('/unfollow/:id', ensureAuth, async (req, res) => {
 
     if (!other) {
       req.flash('danger', 'User not found');
-      return res.redirect('404');
+      return res.redirect('/404');
     }
 
     other.users_following = other.users_following.filter((id) => !req.user._id.equals(id));
@@ -477,7 +477,7 @@ router.get('/view/:id', async (req, res) => {
       ).lean();
       if (!user) {
         req.flash('danger', 'User not found');
-        return res.redirect('404');
+        return res.redirect('/404');
       }
     }
 
@@ -550,7 +550,7 @@ router.get('/decks/:userid/:page', async (req, res) => {
 
     if (!user) {
       req.flash('danger', 'User not found');
-      return res.redirect('404');
+      return res.redirect('/404');
     }
 
     const followers = await User.find(


### PR DESCRIPTION
Fixes #1685 .

## Cause of issue
When requesting `cubecobra.com/user/view/xxx`, where `xxx` is a nonexistent username, the server would try to redirect to `'404'`. Since this is a relative path, the redirect would resolve to `cubecobra.com/user/view/404`. However, since there is no user named 404, this would trigger the redirect again, causing an infinite loop. The same issue could also be found in some redirects from `cube_routes`.

## Fix
Change the redirect to `/404`, which is always an available page.

## Additional notes
A lot of the changes made in `cube_routes` aren't actually due to redirect loops. Some were even left as `'404'`, because a cube with that id exists. Other problems fixed in this PR are
- some routes expected a draft id or a deck id, so when using the `'404'` redirect, the page would still redirect to `/404`, except with a cryptic database error instead of a clearer specified message. Those redirects were changed to `/404`.
- the POST requests for editing cubes would redirect to the 404 cube, which would then result in a 'Not Authorized' error, since most people don't have write access to that cube. This should probably almost never happen, since these routes are pretty much exclusively accessed from links, but I felt that the extra error could be confusing, so those redirects were also changed to `/404`.