### PR TITLE
Add layout filters

### DIFF
--- a/__tests__/serverjs/updatecards.test.js
+++ b/__tests__/serverjs/updatecards.test.js
@@ -55,6 +55,7 @@ const convertedExampleCard = {
   type: 'Creature — Human Knight',
   full_art: false,
   language: 'en',
+  layout: 'normal',
   tcgplayer_id: 198561,
   power: '2',
   toughness: '2',
@@ -113,6 +114,7 @@ const convertedExampleDoubleFacedCard = {
   parsed_cost: [''],
   power: '1',
   promo: false,
+  layout: 'transform',
   rarity: 'common',
   scryfall_uri: 'https://scryfall.com/card/dka/125/scorned-villager-moonscarred-werewolf?utm_source=api',
   set: 'dka',
@@ -169,6 +171,7 @@ const convertedExampleDoubleFacedCardFlipFace = {
   colors: [],
   type: 'Creature — Werewolf',
   tcgplayer_id: 57617,
+  layout: 'transform',
   power: '2',
   toughness: '2',
   image_normal: 'https://img.scryfall.com/cards/normal/back/6/f/6f35e364-81d9-4888-993b-acc7a53d963c.jpg?1562921188',
@@ -231,6 +234,7 @@ const convertedExampleDoubleFacedPlaneswalkerCard = {
   language: 'en',
   tcgplayer_id: 96603,
   power: '2',
+  layout: 'transform',
   toughness: '3',
   image_small: 'https://img.scryfall.com/cards/small/front/9/f/9f25e1cf-eeb4-458d-8fb2-b3a2f86bdd54.jpg?1562033824',
   image_normal: 'https://img.scryfall.com/cards/normal/front/9/f/9f25e1cf-eeb4-458d-8fb2-b3a2f86bdd54.jpg?1562033824',
@@ -282,6 +286,7 @@ const convertedExampleAdventureCard = {
   mtgo_id: 78444,
   name: 'Flaxen Intruder',
   name_lower: 'flaxen intruder',
+  layout: 'adventure',
   oracle_id: 'bacedc99-46d9-4757-8a27-8df77d7c2f02',
   oracle_text:
     'Whenever Flaxen Intruder deals combat damage to a player, you may sacrifice it. When you do, destroy target artifact or enchantment.\nCreate three 2/2 green Bear creature tokens. (Then exile this card. You may cast the creature later from exile.)',
@@ -316,6 +321,7 @@ const convertedExampleAdventureCardAdventure = {
   image_small: 'https://img.scryfall.com/cards/small/front/0/6/06bd1ad2-fb5d-4aef-87d1-13a341c686fa.jpg?1572490543',
   isToken: false,
   language: 'en',
+  layout: 'adventure',
   // ADventure's don't have legalities
   legalities: {
     Brawl: 'not_legal',

--- a/nearley/cardFilters.ne
+++ b/nearley/cardFilters.ne
@@ -39,6 +39,7 @@ import {
   cardRarity,
   cardStatus,
   cardCost,
+  cardLayout,
   cardDevotion,
   cardLegalIn
 } from 'utils/Card';
@@ -87,6 +88,7 @@ condition -> (
   | picksCondition
   | cubesCondition
   | legalityCondition
+  | layoutCondition
 ) {% ([[condition]]) => condition %}
 
 @{%
@@ -138,6 +140,8 @@ loyaltyCondition -> ("l"i | "loy"i | "loyal"i | "loyalty"i) integerOpValue {% ([
 
 artistCondition -> ("a"i | "art"i | "artist"i) stringOpValue {% ([, valuePred]) => genericCondition('artist', cardArtist, valuePred) %}
 
+layoutCondition -> "layout"i  stringOpValue {% ([, valuePred]) => genericCondition('layout', cardLayout, valuePred) %}
+
 eloCondition -> "elo"i integerOpValue {% ([, valuePred]) => genericCondition('elo', cardElo, valuePred) %}
 
 nameCondition -> ("n"i | "name"i) stringOpValue {% ([, valuePred]) => genericCondition('name_lower', cardNameLower, valuePred) %}
@@ -158,4 +162,4 @@ isCondition -> "is"i isOpValue {% ([, valuePred]) => genericCondition('details',
 
 isOpValue -> ":" isValue {% ([, category]) => (fieldValue) => CARD_CATEGORY_DETECTORS[category](fieldValue) %}
 
-isValue -> ("gold"i | "twobrid"i | "hybrid"i | "phyrexian"i | "promo"i | "digital"i | "reasonable"i) {% ([[category]]) => category.toLowerCase() %}
+isValue -> ("gold"i | "twobrid"i | "hybrid"i | "phyrexian"i | "promo"i | "digital"i | "reasonable"i | "dfc"i | "mdfc"i | "meld"i | "transform"i) {% ([[category]]) => category.toLowerCase() %}

--- a/serverjs/updatecards.js
+++ b/serverjs/updatecards.js
@@ -633,6 +633,7 @@ function convertCard(card, isExtra) {
   newcard.full_art = card.full_art;
   newcard.language = card.lang;
   newcard.mtgo_id = card.mtgo_id;
+  newcard.layout = card.layout;
 
   if (card.tcgplayer_id) {
     newcard.tcgplayer_id = card.tcgplayer_id;

--- a/src/pages/FiltersPage.js
+++ b/src/pages/FiltersPage.js
@@ -536,6 +536,48 @@ const ContactPage = ({ user, loginCallback }) => (
           </table>
         </p>
       </Accordion>
+      <Accordion title="Layout">
+        <p>
+          You can use <code>layout:</code> to filter cards by layout.
+        </p>
+        <p>
+          <strong>Options:</strong>
+          <table className="table">
+            {[
+              ['normal', 'A standard Magic card with one face'],
+              ['split', 'A split-faced card'],
+              ['flip', 'Cards that invert vertically with the flip keyword'],
+              ['transform', 'Double-sided cards that transform'],
+              ['modal_dfc', 'Double-sided cards that can be played either-side'],
+              ['meld', 'Cards with meld parts printed on the backsc'],
+              ['leveler', 'Cards with Level Up'],
+              ['saga', 'Saga-type cards'],
+              ['adventure', 'Cards with an Adventure spell part'],
+              ['planar', 'Plane and Phenomenon-type cards'],
+              ['scheme', 'Scheme-type cards'],
+              ['vanguard', 'Vanguard-type cards'],
+              ['token', 'Token cards'],
+              ['double_faced_token', 'Tokens with another token printed on the back'],
+              ['emblem', 'Emblem cards'],
+              ['augment', 'Cards with Augment'],
+              ['host', 'Host-type cards'],
+              ['art_series', 'Art Series collectable double-faced cards'],
+              ['double_sided', 'A Magic card with two sides that are unrelated'],
+            ].map((tuple) => (
+              <tr>
+                <td>
+                  <code>{tuple[0]}</code>
+                </td>
+                <td>{tuple[1]}</td>
+              </tr>
+            ))}
+          </table>
+        </p>
+        <p>
+          Additionally, you can use <code>is:dfc</code>, <code>is:mdfc</code>, <code>is:meld</code>,{' '}
+          <code>is:transform</code>.
+        </p>
+      </Accordion>
       <Accordion title="Miscellaneous">
         <p>
           You can use <code>elo:</code> to filter cards by their ELO rating.

--- a/src/utils/Card.js
+++ b/src/utils/Card.js
@@ -62,6 +62,10 @@ export const CARD_CATEGORY_DETECTORS = {
     details.set !== 'myb' &&
     details.set !== 'mb1' &&
     details.collector_number.indexOf('★') === -1,
+  dfc: (details) => ['transform', 'modal_dfc', 'meld', 'double_faced_token', 'double_sided'].includes(details.layout),
+  mdfc: (details) => details.layout === 'modal_dfc',
+  meld: (details) => details.layout === 'meld',
+  transform: (details) => details.layout === 'transform',
   // Others from Scryfall:
   //   commander, reserved, reprint, new, old, hires, foil,
   //   spotlight, unique, bikeland, cycleland, bicycleland,
@@ -72,7 +76,7 @@ export const CARD_CATEGORY_DETECTORS = {
   //   spell, permanent, historic, modal, vanilla, funny,
   //   booster, datestamped, prerelease, planeswalker_deck,
   //   league, buyabox, giftbox, intro_pack, gameday, release,
-  //   foil, nonfoil, full, split, meld, transform, flip,
+  //   foil, nonfoil, full, split, flip,
   //   leveler,
 };
 
@@ -210,6 +214,8 @@ export const cardTokens = (card) => card.details.tokens;
 
 export const cardElo = (card) => card.details.elo;
 
+export const cardLayout = (card) => card.details.layout;
+
 export const cardDevotion = (card, color) =>
   cardCost(card)?.reduce((count, symbol) => count + (symbol.includes(color.toLowerCase()) ? 1 : 0), 0) ?? 0;
 
@@ -283,6 +289,7 @@ export default {
   cardImageFlip,
   cardTokens,
   cardDevotion,
+  cardLayout,
   cardIsSpecialZoneType,
   cardElo,
   COLOR_COMBINATIONS,


### PR DESCRIPTION
Fixes #1699

Adds `is:dfc`, `is:mdfc`, `is:transform` and `is:meld`

Also adds the ability to filter by any layout with `layout:dfc`, as described here:
https://scryfall.com/docs/api/layouts