### PR TITLE
Remove extra quote in CSV export

### DIFF
--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -1367,7 +1367,7 @@ function writeCard(res, card, maybe) {
   res.write(`${card.status},`);
   res.write(`${card.finish},`);
   res.write(`${maybe},`);
-  res.write(`${imgUrl},"`);
+  res.write(`${imgUrl},`);
   res.write(`${imgBackUrl},"`);
   card.tags.forEach((tag, tagIndex) => {
     if (tagIndex !== 0) {


### PR DESCRIPTION
The CSV export broke recently (there's an extra unclosed quote now).

I didn't see any unit tests for this code, so I tested the fix manually.

My test cube has 3 cards:
* Malcolm, Keen-Eyed Navigator: (no tags)
* Battle Hymn: Tier 1, Strategy - Awesome
* Reaper King: Foo, Bar

CSV export before fix, note the extra unclosed quote in the "Image Back URL" column:
```
Name,CMC,Type,Color,Set,Collector Number,Rarity,Color Category,Status,Finish,Maybeboard,Image URL,Image Back URL,Tags,Notes,MTGO ID
"Malcolm, Keen-Eyed Navigator",3,"Legendary Creature - Siren Pirate",U,"cmr","79",uncommon,u,Owned,Non-foil,false,,","","",,
"Battle Hymn",2,"Instant",R,"avr","128",common,r,Owned,Non-foil,false,,","Tier 1, Strategy - Awesome","",44183,
"Reaper King",10,"Legendary Artifact Creature - Scarecrow",BGRUW,"sld","9",mythic,m,Owned,Non-foil,false,,","Foo, Bar","",,
```

After fix:
```
Name,CMC,Type,Color,Set,Collector Number,Rarity,Color Category,Status,Finish,Maybeboard,Image URL,Image Back URL,Tags,Notes,MTGO ID
"Malcolm, Keen-Eyed Navigator",3,"Legendary Creature - Siren Pirate",U,"cmr","79",uncommon,u,Owned,Non-foil,false,,,"","",,
"Battle Hymn",2,"Instant",R,"avr","128",common,r,Owned,Non-foil,false,,,"Tier 1, Strategy - Awesome","",44183,
"Reaper King",10,"Legendary Artifact Creature - Scarecrow",BGRUW,"sld","9",mythic,m,Owned,Non-foil,false,,,"Foo, Bar","",,
```

