### PR TITLE
Fix comment edit route

### DIFF
--- a/routes/comment_routes.js
+++ b/routes/comment_routes.js
@@ -83,7 +83,7 @@ router.post(
     const comment = new Comment();
 
     comment.parent = req.params.parent.substring(0, 500);
-    comment.parentType = req.params.type.substring(0, 500);
+    comment.parentType = req.params.type;
     comment.owner = poster._id;
     comment.ownerName = poster.username;
     comment.image = poster.image;
@@ -148,7 +148,7 @@ router.post(
       : 'https://img.scryfall.com/cards/art_crop/front/0/c/0c082aa8-bf7f-47f2-baf8-43ad253fd7d7.jpg?1562826021';
     comment.artist = newComment.owner ? 'Allan Pollack' : req.user.artist;
     comment.updated = true;
-    comment.content = sanitize(newComment.content.substring(0, 500));
+    comment.content = sanitize(newComment.content.substring(0, 5000));
     // the -1000 is to prevent weird time display error
     comment.timePosted = Date.now() - 1000;
 


### PR DESCRIPTION
Editing comments caused them to be truncated to 500 characters instead of the correct 5000. This PR fixes that issue. I also removed the character limit on the comment parent type, since we already checked its value 10 lines earlier.