### PR TITLE
Added null check

### DIFF
--- a/src/pages/CubeDecksPage.js
+++ b/src/pages/CubeDecksPage.js
@@ -28,7 +28,7 @@ const CubeDecksPage = ({ user, cube, decks, pages, activePage, loginCallback }) 
               <DeckPreview
                 key={deck._id}
                 deck={deck}
-                canEdit={user.id === deck.owner}
+                canEdit={user?.id === deck.owner}
                 nextURL={`/cube/decks/${cube._id}/${activePage}`}
               />
             ))}


### PR DESCRIPTION
Fixes #1637 
When not logged in, the decklist page would crash, because it tried to reference `user.id` with `user === null`. I added a null check to that comparison so that this doesn't happen.