### PR TITLE
Add option to disable draft notifications by cube

### DIFF
--- a/models/cube.js
+++ b/models/cube.js
@@ -144,6 +144,10 @@ const cubeSchema = mongoose.Schema({
     // Values: first, recent
     default: 'recent',
   },
+  disableNotifications: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 cubeSchema.index({

--- a/src/components/CubeSettingsModal.js
+++ b/src/components/CubeSettingsModal.js
@@ -73,6 +73,15 @@ const CubeSettingsModal = ({ addAlert, onCubeUpdate, isOpen, toggle }) => {
               <option value="first">First</option>
             </CustomInput>
           </FormGroup>
+          <FormGroup check>
+            <Input
+              id="disableNotifications"
+              name="disableNotifications"
+              type="checkbox"
+              defaultChecked={cube.disableNotifications || false}
+            />
+            <Label for="disableNotifications">Disable Draft Notifications</Label>
+          </FormGroup>
         </CSRFForm>
       </ModalBody>
       <ModalFooter>

--- a/src/proptypes/CubePropType.js
+++ b/src/proptypes/CubePropType.js
@@ -17,6 +17,7 @@ const CubePropType = PropTypes.shape({
   image_uri: PropTypes.string.isRequired,
   owner: PropTypes.string.isRequired,
   owner_name: PropTypes.string.isRequired,
+  disableNotifications: PropTypes.bool,
 });
 
 export default CubePropType;


### PR DESCRIPTION
Adds the ability yo disable all playtest notifications by cube. I'm not sure if this was a requested feature - but as I own the 'modo' cubes, I get hundreds of draft notifications a day and it's made notifications useless.