### PR TITLE
Fix style issues in dark mode

### DIFF
--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -89,6 +89,8 @@ body {
 .list-group-item {
 	display: block;
 	border: none;
+	background-color: var(--bg);
+	color: var(--text);
 }
 
 .list-group-item.list-group-heading {
@@ -229,6 +231,11 @@ body {
 
 .tag-color.card-list-item:after {
 	background: var(--hover-inverse);
+}
+
+.tag-color-row {
+	background-color: var(--bg);
+	color: var(--text);
 }
 
 .card-list-item:hover:after {


### PR DESCRIPTION
Fixes part of #1639.

Changes the background for the recommender suggestions, set tag colors popup, and names in the draftbot analysis table to match dark mode. The other style problems in #1639 are related to Markdown, and it sounds like they will be fixed by the Markdown replacement in #1688.

The recommender suggestions and draftbot analysis table are styled with the `.list-group-item` rule, and the set tag colors popup is styled with the `.tag-color-row` rule.

Here's what the changes look like:

### Recommender suggestions
![image](https://user-images.githubusercontent.com/52982949/99914752-21ab8380-2cc5-11eb-8816-8b750c5d7ae6.png)


### Draftbot analysis
![image](https://user-images.githubusercontent.com/52982949/99914777-620b0180-2cc5-11eb-90e5-a63d9173f831.png)

### Set tag colors
![image](https://user-images.githubusercontent.com/52982949/99914798-88c93800-2cc5-11eb-9db8-fffee25d8f4a.png)

I've noticed that with some tag colors the name of the tag is very difficult to read, at least for me. Maybe this is better as a separate issue though. (Red and brown are particularly bad, and purple is a little hard to read as well.)
![image](https://user-images.githubusercontent.com/52982949/99914894-05f4ad00-2cc6-11eb-949f-40c48228b7ac.png)
