### PR TITLE
Add API path to expose Cube.date_updated

### DIFF
--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -4185,7 +4185,7 @@ router.get('/api/date_updated/:id',
       });
     }
     return res.status(200).send({
-      date_updated: cube.date_updated,
+      date_updated: cube.date_updated.valueOf(),
     });
   }),
 );

--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -4289,15 +4289,16 @@ router.get(
   '/api/date_updated/:id',
   util.wrapAsyncApi(async (req, res) => {
     const { id } = req.params;
-    const cube = await Cube.findOne(buildIdQuery(id)).lean();
-    if (!cube) {
+    const result = await Cube.findOne(buildIdQuery(id), { date_updated: 1, _id: 0 }).lean();
+    if (!result) {
       return res.status(404).send({
         success: 'false',
         message: 'No such cube.',
       });
     }
     return res.status(200).send({
-      date_updated: cube.date_updated.valueOf(),
+      success: 'true',
+      date_updated: result.date_updated.valueOf(),
     });
   }),
 );

--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -4184,7 +4184,6 @@ router.get('/api/date_updated/:id',
         message: 'No such cube.',
       });
     }
-
     return res.status(200).send({
       date_updated: cube.date_updated,
     });

--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -4174,4 +4174,21 @@ router.get(
   }),
 );
 
+router.get('/api/date_updated/:id',
+  util.wrapAsyncApi(async (req, res) => {
+    const { id } = req.params;
+    const cube = await Cube.findOne(buildIdQuery(id)).lean();
+    if (!cube) {
+      return res.status(404).send({
+        success: 'false',
+        message: 'No such cube.',
+      });
+    }
+
+    return res.status(200).send({
+      date_updated: cube.date_updated,
+    });
+  }),
+);
+
 module.exports = router;

--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -384,20 +384,26 @@ router.get('/overview/:id', async (req, res) => {
     const blogsQ = Blog.find({
       cube: cube._id,
     })
-      .sort({ date: -1 })
+      .sort({
+        date: -1,
+      })
       .limit(1)
       .lean();
 
     const followersQ = User.find(
       {
-        _id: { $in: cube.users_following },
+        _id: {
+          $in: cube.users_following,
+        },
       },
       '_id username image artist users_following',
     ).lean();
 
     // calc cube prices
     for (const card of cube.cards) {
-      card.details = { ...carddb.cardFromId(card.cardID, 'name prices') };
+      card.details = {
+        ...carddb.cardFromId(card.cardID, 'name prices'),
+      };
     }
     const nameToCards = {};
     for (const card of cube.cards) {
@@ -503,11 +509,15 @@ router.get('/blog/:id/:page', async (req, res) => {
       return res.redirect('/404');
     }
 
-    const countQ = Blog.countDocuments({ cube: cube._id });
+    const countQ = Blog.countDocuments({
+      cube: cube._id,
+    });
     const blogsQ = Blog.find({
       cube: cube._id,
     })
-      .sort({ date: -1 })
+      .sort({
+        date: -1,
+      })
       .skip(page * 10)
       .limit(10)
       .lean();
@@ -550,7 +560,9 @@ router.get('/rss/:id', async (req, res) => {
     const blogs = await Blog.find({
       cube: cube._id,
     })
-      .sort({ date: -1 })
+      .sort({
+        date: -1,
+      })
       .exec();
 
     const feed = new RSS({
@@ -638,7 +650,11 @@ router.get('/compare/:idA/to/:idB', async (req, res) => {
         onlyA: aNames,
         onlyB: bNames,
         both: inBoth.map((card) => card.details.name),
-        cards: allCards.map((card, index) => Object.assign(card, { index })),
+        cards: allCards.map((card, index) =>
+          Object.assign(card, {
+            index,
+          }),
+        ),
         defaultTagColors: [...cubeA.tag_colors, ...cubeB.tag_colors],
         defaultShowTagColors: !req.user || !req.user.hide_tag_colors,
         defaultSorts: cubeA.default_sorts,
@@ -824,7 +840,14 @@ router.get('/analysis/:id', async (req, res) => {
         defaultFormatId: Number(req.query.formatId),
         defaultFilterText: req.query.f,
         defaultTab: req.query.tab ? Number(req.query.tab) : 0,
-        cubes: req.user ? await Cube.find({ owner: req.user._id }, 'name _id') : [],
+        cubes: req.user
+          ? await Cube.find(
+              {
+                owner: req.user._id,
+              },
+              'name _id',
+            )
+          : [],
       },
       {
         metadata: generateMeta(
@@ -937,14 +960,24 @@ async function updateCubeAndBlog(req, res, cube, changelog, added, missing) {
         canEdit: true,
         cubeID: req.params.id,
         missing,
-        added: added.map(({ _id, name, image_normal, image_flip }) => ({ _id, name, image_normal, image_flip })),
+        added: added.map(({ _id, name, image_normal, image_flip }) => ({
+          _id,
+          name,
+          image_normal,
+          image_flip,
+        })),
         blogpost: blogpost.toObject(),
       });
     }
     await blogpost.save();
     cube = setCubeType(cube, carddb);
     try {
-      await Cube.updateOne({ _id: cube._id }, cube);
+      await Cube.updateOne(
+        {
+          _id: cube._id,
+        },
+        cube,
+      );
     } catch (err) {
       req.logger.error(err);
       req.flash('danger', 'Error adding cards. Please try again.');
@@ -1040,7 +1073,9 @@ const createDraftForSingleDeck = async (deck) => {
   try {
     const response = await fetch(`${process.env.FLASKROOT}/embeddings/`, {
       method: 'post',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+      },
       body: JSON.stringify({
         cards: populatedCards.map((card) => carddb.cardFromId(card.cardID).name_lower),
       }),
@@ -1295,7 +1330,13 @@ router.post('/bulkreplacefile/:id', ensureAuth, async (req, res) => {
         cube.maybe = newMaybe;
         const addDetails = (cardList) =>
           cardList.map((card, index) => {
-            card = { ...card, details: { ...carddb.cardFromId(card.cardID) }, index };
+            card = {
+              ...card,
+              details: {
+                ...carddb.cardFromId(card.cardID),
+              },
+              index,
+            };
             if (!card.type_line) {
               card.type_line = card.details.type;
             }
@@ -1543,7 +1584,10 @@ function shuffle(a) {
 
 router.post(
   '/startgriddraft/:id',
-  body('packs').toInt({ min: 1, max: 16 }),
+  body('packs').toInt({
+    min: 1,
+    max: 16,
+  }),
   body('defaultStatus', 'Status must be valid.').isIn(['bot', '2playerlocal']),
   async (req, res) => {
     try {
@@ -1580,8 +1624,12 @@ router.post(
       try {
         const response = await fetch(`${process.env.FLASKROOT}/embeddings/`, {
           method: 'post',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ cards: source.map((card) => carddb.cardFromId(card.cardID).name_lower) }),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            cards: source.map((card) => carddb.cardFromId(card.cardID).name_lower),
+          }),
         });
         if (response.ok) {
           gridDraft.synergies = await response.json();
@@ -1638,115 +1686,123 @@ router.post(
   },
 );
 
-router.post('/startsealed/:id', body('packs').toInt({ min: 1, max: 16 }), body('cards').toInt(), async (req, res) => {
-  try {
-    const user = await User.findById(req.user);
+router.post(
+  '/startsealed/:id',
+  body('packs').toInt({
+    min: 1,
+    max: 16,
+  }),
+  body('cards').toInt(),
+  async (req, res) => {
+    try {
+      const user = await User.findById(req.user);
 
-    if (!user) {
-      req.flash('danger', 'Please Login to build a sealed deck.');
-      return res.redirect(`/cube/playtest/${req.params.id}`);
-    }
-
-    const packs = parseInt(req.body.packs, 10);
-    const cards = parseInt(req.body.cards, 10);
-
-    const numCards = packs * cards;
-
-    const cube = await Cube.findOne(
-      buildIdQuery(req.params.id),
-      '_id name draft_formats card_count type cards owner numDecks disableNotifications',
-    );
-
-    if (!cube) {
-      req.flash('danger', 'Cube not found');
-      return res.redirect('/404');
-    }
-
-    if (cube.cards.length < numCards) {
-      req.flash('danger', `Not enough cards, need ${numCards} cards for sealed with ${packs} packs of ${cards}.`);
-      return res.redirect(`/cube/playtest/${req.params.id}`);
-    }
-
-    const source = shuffle(cube.cards).slice(0, numCards);
-    const pool = [];
-    for (let i = 0; i < 16; i += 1) {
-      pool.push([]);
-    }
-
-    for (const card of source) {
-      let index = 0;
-
-      // sort by color
-      const details = carddb.cardFromId(card.cardID);
-      const type = card.type_line || details.type;
-      const colors = card.colors || details.colors;
-
-      if (type.toLowerCase().includes('land')) {
-        index = 7;
-      } else if (colors.length === 1) {
-        index = ['W', 'U', 'B', 'R', 'G'].indexOf(colors[0].toUpperCase());
-      } else if (colors.length === 0) {
-        index = 6;
-      } else {
-        index = 5;
+      if (!user) {
+        req.flash('danger', 'Please Login to build a sealed deck.');
+        return res.redirect(`/cube/playtest/${req.params.id}`);
       }
 
-      if (!type.toLowerCase().includes('creature')) {
-        index += 8;
-      }
+      const packs = parseInt(req.body.packs, 10);
+      const cards = parseInt(req.body.cards, 10);
 
-      if (pool[index]) {
-        pool[index].push(card);
-      } else {
-        pool[0].push(card);
-      }
-    }
+      const numCards = packs * cards;
 
-    const deck = new Deck();
-    deck.cube = cube._id;
-    deck.cubeOwner = cube.owner;
-    deck.date = Date.now();
-    deck.cubename = cube.name;
-    deck.seats = [];
-    deck.owner = user._id;
-
-    deck.seats.push({
-      userid: user._id,
-      username: user.username,
-      pickorder: [],
-      name: `Sealed from ${cube.name}`,
-      description: '',
-      cols: 16,
-      deck: pool,
-      sideboard: [],
-    });
-    deck.draft = await createDraftForSingleDeck(deck);
-
-    await deck.save();
-
-    if (!cube.numDecks) {
-      cube.numDecks = 0;
-    }
-    cube.numDecks += 1;
-
-    await cube.save();
-
-    const cubeOwner = await User.findById(cube.owner);
-
-    if (!cube.disableNotifications) {
-      await util.addNotification(
-        cubeOwner,
-        user,
-        `/cube/deck/${deck._id}`,
-        `${user.username} built a sealed deck from your cube: ${cube.name}`,
+      const cube = await Cube.findOne(
+        buildIdQuery(req.params.id),
+        '_id name draft_formats card_count type cards owner numDecks disableNotifications',
       );
-    }
 
-    return res.redirect(`/cube/deckbuilder/${deck._id}`);
-  } catch (err) {
-    return util.handleRouteError(req, res, err, `/cube/playtest/${req.params.id}`);
-  }
-});
+      if (!cube) {
+        req.flash('danger', 'Cube not found');
+        return res.redirect('/404');
+      }
+
+      if (cube.cards.length < numCards) {
+        req.flash('danger', `Not enough cards, need ${numCards} cards for sealed with ${packs} packs of ${cards}.`);
+        return res.redirect(`/cube/playtest/${req.params.id}`);
+      }
+
+      const source = shuffle(cube.cards).slice(0, numCards);
+      const pool = [];
+      for (let i = 0; i < 16; i += 1) {
+        pool.push([]);
+      }
+
+      for (const card of source) {
+        let index = 0;
+
+        // sort by color
+        const details = carddb.cardFromId(card.cardID);
+        const type = card.type_line || details.type;
+        const colors = card.colors || details.colors;
+
+        if (type.toLowerCase().includes('land')) {
+          index = 7;
+        } else if (colors.length === 1) {
+          index = ['W', 'U', 'B', 'R', 'G'].indexOf(colors[0].toUpperCase());
+        } else if (colors.length === 0) {
+          index = 6;
+        } else {
+          index = 5;
+        }
+
+        if (!type.toLowerCase().includes('creature')) {
+          index += 8;
+        }
+
+        if (pool[index]) {
+          pool[index].push(card);
+        } else {
+          pool[0].push(card);
+        }
+      }
+
+      const deck = new Deck();
+      deck.cube = cube._id;
+      deck.cubeOwner = cube.owner;
+      deck.date = Date.now();
+      deck.cubename = cube.name;
+      deck.seats = [];
+      deck.owner = user._id;
+
+      deck.seats.push({
+        userid: user._id,
+        username: user.username,
+        pickorder: [],
+        name: `Sealed from ${cube.name}`,
+        description: '',
+        cols: 16,
+        deck: pool,
+        sideboard: [],
+      });
+      deck.draft = await createDraftForSingleDeck(deck);
+
+      await deck.save();
+
+      if (!cube.numDecks) {
+        cube.numDecks = 0;
+      }
+      cube.numDecks += 1;
+
+      await cube.save();
+
+      const cubeOwner = await User.findById(cube.owner);
+
+      if (!cube.disableNotifications) {
+        await util.addNotification(
+          cubeOwner,
+          user,
+          `/cube/deck/${deck._id}`,
+          `${user.username} built a sealed deck from your cube: ${cube.name}`,
+        );
+      }
+
+      return res.redirect(`/cube/deckbuilder/${deck._id}`);
+    } catch (err) {
+      return util.handleRouteError(req, res, err, `/cube/playtest/${req.params.id}`);
+    }
+  },
+);
 
 router.get('/deck/download/xmage/:id/:seat', async (req, res) => {
   try {
@@ -1999,9 +2055,18 @@ router.post(
   '/startdraft/:id',
   body('id').toInt(),
   body('botsOnly').toBoolean(),
-  body('seats').toInt({ min: 2, max: 16 }),
-  body('packs').toInt({ min: 1, max: 36 }),
-  body('cards').toInt({ min: 1, max: 90 }),
+  body('seats').toInt({
+    min: 2,
+    max: 16,
+  }),
+  body('packs').toInt({
+    min: 1,
+    max: 36,
+  }),
+  body('cards').toInt({
+    min: 1,
+    max: 90,
+  }),
   async (req, res) => {
     try {
       const cube = await Cube.findOne(
@@ -2043,7 +2108,11 @@ router.post(
           cube.cards,
           bots,
           params.seats,
-          req.user ? req.user : { username: 'Anonymous' },
+          req.user
+            ? req.user
+            : {
+                username: 'Anonymous',
+              },
         );
       } catch (err) {
         // This is a 4XX error, not a 5XX error
@@ -2062,8 +2131,12 @@ router.post(
       try {
         const response = await fetch(`${process.env.FLASKROOT}/embeddings/`, {
           method: 'post',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ cards: cards.map((card) => carddb.cardFromId(card.cardID).name_lower) }),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            cards: cards.map((card) => carddb.cardFromId(card.cardID).name_lower),
+          }),
         });
         if (response.ok) {
           draft.synergies = await response.json();
@@ -2284,7 +2357,9 @@ router.post('/edit/:id', ensureAuth, async (req, res) => {
         // add id
         const details = carddb.cardFromId(edit.substring(1));
         if (!details) {
-          req.logger.error({ message: `Card not found: ${edit}` });
+          req.logger.error({
+            message: `Card not found: ${edit}`,
+          });
         } else {
           adds.push(details);
           changelog += addCardHtml(details);
@@ -2309,7 +2384,9 @@ router.post('/edit/:id', ensureAuth, async (req, res) => {
         const [outStr, idIn] = edit.substring(1).split('>');
         const detailsIn = carddb.cardFromId(idIn);
         if (!detailsIn) {
-          req.logger.error({ message: `Card not found: ${edit}` });
+          req.logger.error({
+            message: `Card not found: ${edit}`,
+          });
         } else {
           adds.push(detailsIn);
         }
@@ -2396,10 +2473,15 @@ router.get('/blogpost/:id', async (req, res) => {
 router.post(
   '/api/editoverview',
   ensureAuth,
-  body('name', 'Cube name should be between 5 and 100 characters long.').isLength({ min: 5, max: 100 }),
+  body('name', 'Cube name should be between 5 and 100 characters long.').isLength({
+    min: 5,
+    max: 100,
+  }),
   body('name', 'Cube name may not use profanity.').custom((value) => !util.hasProfanity(value)),
   body('urlAlias', 'Custom URL must contain only alphanumeric characters or underscores.').matches(/[A-Za-z0-9]*/),
-  body('urlAlias', `Custom URL may not be longer than 100 characters.`).isLength({ max: 100 }),
+  body('urlAlias', `Custom URL may not be longer than 100 characters.`).isLength({
+    max: 100,
+  }),
   body('urlAlias', 'Custom URL may not use profanity.').custom((value) => !util.hasProfanity(value)),
   jsonValidationErrors,
   util.wrapAsyncApi(async (req, res) => {
@@ -2536,7 +2618,9 @@ router.post(
     }
 
     await cube.save();
-    return res.status(200).send({ success: 'true' });
+    return res.status(200).send({
+      success: 'true',
+    });
   }),
 );
 
@@ -3338,8 +3422,12 @@ router.get('/deck/:id', async (req, res) => {
 
         const response = await fetch(`${process.env.FLASKROOT}/embeddings/`, {
           method: 'post',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ cards: cards.map((card) => carddb.cardFromId(card.cardID).name_lower) }),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            cards: cards.map((card) => carddb.cardFromId(card.cardID).name_lower),
+          }),
         });
         if (response.ok) {
           // we want to save this for later so we don't have to do this every time
@@ -3739,7 +3827,9 @@ router.post(
       )}`,
     );
     if (!response.ok) {
-      req.logger.error({ message: 'Flask server response not OK.' });
+      req.logger.error({
+        message: 'Flask server response not OK.',
+      });
       return res.status(500).send({
         success: 'false',
         result: {},
@@ -3778,7 +3868,10 @@ router.post(
 
     return res.status(200).send({
       success: 'true',
-      result: { toAdd: addlist, toCut: cutlist },
+      result: {
+        toAdd: addlist,
+        toCut: cutlist,
+      },
     });
   }),
 );
@@ -3851,7 +3944,10 @@ router.post(
     const withRemoved = maybe.filter((_, index) => !removeIndices.includes(index));
 
     const addCards = Array.isArray(req.body.add) ? req.body.add : [];
-    const addCardsNoDetails = addCards.map(({ details, ...card }) => ({ ...util.newCard(details), ...card }));
+    const addCardsNoDetails = addCards.map(({ details, ...card }) => ({
+      ...util.newCard(details),
+      ...card,
+    }));
     const withAdded = [...withRemoved, ...addCardsNoDetails];
 
     cube.maybe = withAdded;
@@ -4047,9 +4143,17 @@ const ELO_SPEED = 1000;
 router.post(
   '/api/draftpickcard/:id',
   util.wrapAsyncApi(async (req, res) => {
-    const draftQ = Draft.findById({ _id: req.body.draft_id }).lean();
-    const ratingQ = CardRating.findOne({ name: req.body.pick }).then((rating) => rating || new CardRating());
-    const packQ = CardRating.find({ name: { $in: req.body.pack } });
+    const draftQ = Draft.findById({
+      _id: req.body.draft_id,
+    }).lean();
+    const ratingQ = CardRating.findOne({
+      name: req.body.pick,
+    }).then((rating) => rating || new CardRating());
+    const packQ = CardRating.find({
+      name: {
+        $in: req.body.pack,
+      },
+    });
 
     const [draft, rating, packRatings] = await Promise.all([draftQ, ratingQ, packQ]);
 
@@ -4130,7 +4234,9 @@ router.post(
 );
 
 router.post('/api/submitdraft/:id', async (req, res) => {
-  const draft = await Draft.findOne({ _id: req.body._id });
+  const draft = await Draft.findOne({
+    _id: req.body._id,
+  });
 
   draft.seats = req.body.seats;
   draft.unopenedPacks = req.body.unopenedPacks;
@@ -4143,7 +4249,12 @@ router.post('/api/submitdraft/:id', async (req, res) => {
 });
 
 router.post('/api/submitgriddraft/:id', async (req, res) => {
-  await GridDraft.updateOne({ _id: req.body._id }, req.body);
+  await GridDraft.updateOne(
+    {
+      _id: req.body._id,
+    },
+    req.body,
+  );
 
   return res.status(200).send({
     success: 'true',
@@ -4174,7 +4285,8 @@ router.get(
   }),
 );
 
-router.get('/api/date_updated/:id',
+router.get(
+  '/api/date_updated/:id',
   util.wrapAsyncApi(async (req, res) => {
     const { id } = req.params;
     const cube = await Cube.findOne(buildIdQuery(id)).lean();

--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -4289,7 +4289,7 @@ router.get(
   '/api/date_updated/:id',
   util.wrapAsyncApi(async (req, res) => {
     const { id } = req.params;
-    const result = await Cube.findOne(buildIdQuery(id), { date_updated: 1, _id: 0 }).lean();
+    const result = await Cube.findOne(buildIdQuery(id), 'date_updated').lean();
     if (!result) {
       return res.status(404).send({
         success: 'false',


### PR DESCRIPTION
I am writing a bot that needs to keep a local copy of a given cube in sync with Cube Cobra. Instead of polling for the current state of the Cube, I thought it would be preferable to create a new, light-weight path to indicate whether changes have been made to the cube since the last time the bot checked; that way, the bot can only pull down the contents of the cube when it needs to.