### PR TITLE
Fix 1690 cube overview description

### DIFF
--- a/src/components/CubeOverviewModal.js
+++ b/src/components/CubeOverviewModal.js
@@ -28,13 +28,35 @@ import TagInput from 'components/TagInput';
 import { TagContextProvider } from 'components/TagContext';
 import TextEntry from 'components/TextEntry';
 
+/**
+ * A utility for safely picking the current working description from a Cube.
+ *
+ * @param { Cube } cube
+ * @returns { string }
+ */
+const pickDescriptionFromCube = (cube) => {
+  /** 2020-11-24 strusdell:
+   * @phulin believes that the check for the string literal 'undefined' here is
+   * deliberate. Presumably this would represent bad data, and should be ignored.
+   *
+   * NOTE: This may introduce weird behavior if the user enters 'undefined' as their
+   * description.
+   */
+  return Object.prototype.hasOwnProperty.call(cube, 'raw_desc') && cube.raw_desc !== 'undefined'
+    ? cube.raw_desc
+    : cube.description;
+};
+
 class CubeOverviewModal extends Component {
   constructor(props) {
     super(props);
 
     this.state = {
       isOpen: false,
-      tags: (props.cube.tags ? props.cube.tags : []).map((tag) => ({ id: tag, text: tag })),
+      tags: (props.cube.tags ? props.cube.tags : []).map((tag) => ({
+        id: tag,
+        text: tag,
+      })),
       cube: JSON.parse(JSON.stringify(props.cube)),
       urlChanged: false,
       image_dict: {},
@@ -322,11 +344,7 @@ class CubeOverviewModal extends Component {
                 <br />
 
                 <h6>Description</h6>
-                <TextEntry
-                  name="blog"
-                  value={cube.raw_desc && cube.raw_desc !== 'undefined' ? cube.raw_desc : cube.description}
-                  onChange={this.handleDescriptionChange}
-                />
+                <TextEntry name="blog" value={pickDescriptionFromCube(cube)} onChange={this.handleDescriptionChange} />
                 <FormText>
                   Having trouble formatting your posts? Check out the{' '}
                   <a href="/markdown" target="_blank">

--- a/src/components/CubeOverviewModal.js
+++ b/src/components/CubeOverviewModal.js
@@ -1,4 +1,6 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import CubePropType from 'proptypes/CubePropType';
 
 import {
   Modal,
@@ -364,5 +366,11 @@ class CubeOverviewModal extends Component {
     );
   }
 }
+CubeOverviewModal.propTypes = {
+  cube: CubePropType.isRequired,
+  onError: PropTypes.func.isRequired,
+  onCubeUpdate: PropTypes.func.isRequired,
+};
+CubeOverviewModal.defaultProps = {};
 
 export default CubeOverviewModal;


### PR DESCRIPTION
Fixes #1690

There was a conditional in the TextEntry.value for the Cube description part of
the form that was passing the `cube.description` to the input if the current
`cube.raw_desc` was falsy.

`cube.raw_desc && cube.raw_desc !== 'undefined' ? cube.raw_desc : cube.description`

Because `''` is falsy in javascript, this meant that
deleting the last character of your description would invert the conditional and
put `cube.description` into the input instead of `cube.raw_desc`.

I replaced the truthiness check `cube.raw_desc &&` with an object property check
`Object.prototype.hasOwnProperty.call(cube, 'raw_desc')` and pulled the whole ternary
out into a function so it could be better documented.

I spoke with @phulin, and was informed that the check against the string literal
`'undefined'` was deliberate, so I left it in.