### PR TITLE
Changed heading color on Compare Cubes page

### DIFF
--- a/src/components/CubeCompareNavbar.js
+++ b/src/components/CubeCompareNavbar.js
@@ -54,11 +54,11 @@ class CubeCompareNavbar extends Component {
             <li className="nav-item">
               <h5 style={{ color: '#218937' }}>Compare Cubes</h5>
               <h6 className="my-3" style={{ color: '#218937' }}>
-                <span style={{ color: '#495057' }}>Base Cube:</span>{' '}
+                <span className="text-muted">Base Cube:</span>{' '}
                 <a href={`/cube/list/${cubeAID}`} className="mr-3" style={{ color: '#218937' }}>
                   {cubeA.name} ({cubeA.card_count} cards)
                 </a>{' '}
-                <span style={{ color: '#495057' }}>Comparison Cube:</span>{' '}
+                <span className="text-muted">Comparison Cube:</span>{' '}
                 <a href={`/cube/list/${cubeBID}`} style={{ color: '#218937' }}>
                   {cubeB.name} ({cubeB.card_count} cards)
                 </a>


### PR DESCRIPTION
Fixes #1726.

The heading had its color manually defined in an inline style. I replaced that with the `.text-muted` class, which has higher contrast in dark mode and is used elsewhere, making this page more consistent with the rest of CC.

### Before:
![Screenshot from 2020-12-03 14-58-24](https://user-images.githubusercontent.com/38463785/101027772-5f839400-3570-11eb-98e2-c66c3c4dc22f.png)
### After:
![Screenshot from 2020-12-03 14-59-41](https://user-images.githubusercontent.com/38463785/101027807-6dd1b000-3570-11eb-986d-3fc2f2878e05.png)
### Before:
![Screenshot from 2020-12-03 14-58-57](https://user-images.githubusercontent.com/38463785/101027780-614d5780-3570-11eb-8ad2-c9ed7960fb7f.png)
### After:
![Screenshot from 2020-12-03 14-59-20](https://user-images.githubusercontent.com/38463785/101027802-6d391980-3570-11eb-8bc0-e8f8f718b802.png)

