### PR TITLE
Added 'e' alias to set filter

### DIFF
--- a/nearley/cardFilters.ne
+++ b/nearley/cardFilters.ne
@@ -112,7 +112,7 @@ typeCondition -> ("t"i |  "type"i | "type_line"i | "typeline"i) stringContainOpV
 
 oracleCondition -> ("o"i | "oracle"i | "text"i) nameStringOpValue {% ([, valuePred]) => genericCondition('oracle_text', cardOracleText, valuePred) %}
 
-setCondition -> ("s"i | "set"i) alphaNumericOpValue {% ([, valuePred]) => genericCondition('set', cardSet, valuePred) %}
+setCondition -> ("s"i | "set"i | "e"i | "edition"i) alphaNumericOpValue {% ([, valuePred]) => genericCondition('set', cardSet, valuePred) %}
 
 powerCondition -> ("pow"i | "power"i) halfIntOpValue {% ([, valuePred]) => genericCondition('power', (c) => parseFloat(cardPower(c), 10), valuePred) %}
 


### PR DESCRIPTION
Scryfall supports `e:` and `edition:` as aliases for `set:`﻿. This PR adds that alias to our card search. 
