### PR TITLE
Added 'collector number' filter

### DIFF
--- a/nearley/cardFilters.ne
+++ b/nearley/cardFilters.ne
@@ -24,6 +24,7 @@ import {
   cardType,
   cardOracleText,
   cardSet,
+  cardCollectorNumber,
   cardPower,
   cardToughness,
   cardTags,
@@ -91,6 +92,7 @@ condition -> (
   | cubesCondition
   | legalityCondition
   | layoutCondition
+  | collectorNumberCondition
 ) {% ([[condition]]) => condition %}
 
 @{%
@@ -159,6 +161,8 @@ devotionCondition -> ("d"i | "dev"i | "devotion"i | "devotionto"i) ("w"i | "u"i 
 picksCondition -> "picks" integerOpValue  {% ([,valuePred]) => genericCondition('picks', (card) => card.details.picks, valuePred) %}
 
 cubesCondition -> "cubes" integerOpValue  {% ([,valuePred]) => genericCondition('cubes', (card) => card.details.cubes, valuePred) %}
+
+collectorNumberCondition -> ("cn"i | "number"i) stringExactOpValue {% ([, valuePred]) => genericCondition('collector_number', cardCollectorNumber, valuePred) %}
 
 isCondition -> "is"i isOpValue {% ([, valuePred]) => genericCondition('details', ({ details }) => details, valuePred) %}
 

--- a/nearley/values.ne
+++ b/nearley/values.ne
@@ -148,6 +148,8 @@ stringOpValue -> equalityOperator stringValue {% ([op, value]) => stringOperatio
 
 stringContainOpValue -> equalityOperator stringValue {% ([op, value]) => stringContainOperation(op, value) %}
 
+stringExactOpValue -> equalityOperator stringValue {% ([op, value]) => equalityOperation(op, value) %}
+
 nameStringOpValue -> equalityOperator stringValue {% ([op, value]) => nameStringOperation(op, value) %}
 
 stringValue -> (noQuoteStringValue | dqstring | sqstring) {% ([[value]]) => value.toLowerCase() %}


### PR DESCRIPTION
Scryfall supports `cn:` or `number:` as a filter that matches on collector numbers. This PR adds support for that filter.

The argument to this filter is a string and not a number, because collector number is stored as a string, because some collector numbers include non-numeric characters (e.g. '★')﻿
