### PR TITLE
Added null check to theme provider

### DIFF
--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -147,7 +147,7 @@ const MainLayout = ({ user, children, loginCallback }) => {
         </Container>
       </Navbar>
       <Container className="flex-grow">
-        <ThemeContext.Provider value={user.theme}>
+        <ThemeContext.Provider value={user?.theme ?? 'default'}>
           <ErrorBoundary>{children}</ErrorBoundary>
         </ThemeContext.Provider>
       </Container>


### PR DESCRIPTION
If a logged-out user tried to load the site, it would crash with an error caused by undefined reference of `user.theme` by the ThemeContext provider. This PR adds a null check to that reference.﻿
