### PR TITLE
Fix cube url alias

### DIFF
--- a/models/cube.js
+++ b/models/cube.js
@@ -192,7 +192,8 @@ cubeSchema.index({
 
 const Cube = mongoose.model('Cube', cubeSchema);
 
-Cube.LAYOUT_FIELDS = '_id owner name type card_count overrideCategory categoryOverride categoryPrefixes image_uri';
+Cube.LAYOUT_FIELDS =
+  '_id owner name type card_count overrideCategory categoryOverride categoryPrefixes image_uri urlAlias';
 Cube.PREVIEW_FIELDS =
   '_id shortId urlAlias name card_count type overrideCategory categoryOverride categoryPrefixes image_name image_artist image_uri owner owner_name image_uri';
 

--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -677,7 +677,7 @@ router.get('/compare/:idA/to/:idB', async (req, res) => {
 router.get('/list/:id', async (req, res) => {
   try {
     const fields =
-      'cards maybe name owner card_count type tag_colors default_sorts overrideCategory categoryOverride categoryPrefixes image_uri';
+      'cards maybe name owner card_count type tag_colors default_sorts overrideCategory categoryOverride categoryPrefixes image_uri urlAlias';
     const cube = await Cube.findOne(buildIdQuery(req.params.id), fields).lean();
     if (!cube) {
       req.flash('danger', 'Cube not found');

--- a/src/contexts/CubeContext.js
+++ b/src/contexts/CubeContext.js
@@ -5,7 +5,6 @@ const CubeContext = React.createContext({
   cube: {},
   canEdit: false,
   cubeID: null,
-  cubeAlias: null,
   hasCustomImages: false,
   updateCubeCard: () => {},
   updateCubeCards: () => {},
@@ -37,11 +36,13 @@ export const CubeContextProvider = ({ initialCube, canEdit, ...props }) => {
     });
   }, []);
 
+  const cubeID = cube._id;
+
   const hasCustomImages = cube.cards.some(
     (card) => (card.imgUrl && card.imgUrl.length > 0) || (card.imgBackUrl && card.imgBackUrl.length > 0),
   );
 
-  const value = { cube, canEdit, hasCustomImages, setCube, updateCubeCard, updateCubeCards };
+  const value = { cube, canEdit, cubeID, hasCustomImages, setCube, updateCubeCard, updateCubeCards };
 
   return <CubeContext.Provider value={value} {...props} />;
 };

--- a/src/contexts/CubeContext.js
+++ b/src/contexts/CubeContext.js
@@ -5,12 +5,13 @@ const CubeContext = React.createContext({
   cube: {},
   canEdit: false,
   cubeID: null,
+  cubeAlias: null,
   hasCustomImages: false,
   updateCubeCard: () => {},
   updateCubeCards: () => {},
 });
 
-export const CubeContextProvider = ({ initialCube, canEdit, cubeID, ...props }) => {
+export const CubeContextProvider = ({ initialCube, canEdit, ...props }) => {
   const [cube, setCube] = useState({
     ...initialCube,
     cards: initialCube.cards ? initialCube.cards.map((card, index) => ({ ...card, index })) : [],
@@ -40,7 +41,11 @@ export const CubeContextProvider = ({ initialCube, canEdit, cubeID, ...props }) 
     (card) => (card.imgUrl && card.imgUrl.length > 0) || (card.imgBackUrl && card.imgBackUrl.length > 0),
   );
 
-  const value = { cube, canEdit, cubeID, hasCustomImages, setCube, updateCubeCard, updateCubeCards };
+  const cubeID = cube._id;
+
+  const cubeAlias = cube.urlAlias || cube.shortId || cube._id;
+
+  const value = { cube, canEdit, cubeAlias, hasCustomImages, setCube, updateCubeCard, updateCubeCards };
 
   return <CubeContext.Provider value={value} {...props} />;
 };

--- a/src/contexts/CubeContext.js
+++ b/src/contexts/CubeContext.js
@@ -41,11 +41,7 @@ export const CubeContextProvider = ({ initialCube, canEdit, ...props }) => {
     (card) => (card.imgUrl && card.imgUrl.length > 0) || (card.imgBackUrl && card.imgBackUrl.length > 0),
   );
 
-  const cubeID = cube._id;
-
-  const cubeAlias = cube.urlAlias || cube.shortId || cube._id;
-
-  const value = { cube, canEdit, cubeAlias, hasCustomImages, setCube, updateCubeCard, updateCubeCards };
+  const value = { cube, canEdit, hasCustomImages, setCube, updateCubeCard, updateCubeCards };
 
   return <CubeContext.Provider value={value} {...props} />;
 };

--- a/src/layouts/CubeLayout.js
+++ b/src/layouts/CubeLayout.js
@@ -1,18 +1,16 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import CubePropType from 'proptypes/CubePropType';
-
 import { NavItem, NavLink } from 'reactstrap';
-
 import CubeContext, { CubeContextProvider } from 'contexts/CubeContext';
 import ErrorBoundary from 'components/ErrorBoundary';
-import { getCubeDescription } from 'utils/Util';
+import { getCubeDescription, getCubeId } from 'utils/Util';
 
 const CubeNavItem = ({ link, activeLink, children }) => {
-  const { cubeAlias } = useContext(CubeContext);
+  const { cube } = useContext(CubeContext);
   return (
     <NavItem>
-      <NavLink href={`/cube/${link}/${cubeAlias}`} active={link === activeLink}>
+      <NavLink href={`/cube/${link}/${getCubeId(cube)}`} active={link === activeLink}>
         {children}
       </NavLink>
     </NavItem>

--- a/src/layouts/CubeLayout.js
+++ b/src/layouts/CubeLayout.js
@@ -30,11 +30,7 @@ CubeNavItem.defaultProps = {
 };
 
 const CubeLayout = ({ cube, canEdit, activeLink, children }) => {
-  const categories =
-    cube.categoryPrefixes && cube.categoryPrefixes.length > 0 ? `${cube.categoryPrefixes.join(' ')} ` : '';
-  const subtitle = cube.overrideCategory
-    ? `${cube.card_count} Card ${categories}${cube.categoryOverride} Cube`
-    : `${cube.card_count} Card ${cube.type} Cube`;
+  const subtitle = getCubeDescription(cube);
   return (
     <CubeContextProvider initialCube={cube} canEdit={canEdit}>
       <div className="mb-3">

--- a/src/layouts/CubeLayout.js
+++ b/src/layouts/CubeLayout.js
@@ -37,31 +37,32 @@ const CubeLayout = ({ cube, canEdit, activeLink, children }) => {
     : `${cube.card_count} Card ${cube.type} Cube`;
   return (
     <CubeContextProvider initialCube={cube} canEdit={canEdit}>
-      <link rel="stylesheet" href="/css/autocomplete.css" />
-      <ul className="cubenav nav nav-tabs nav-fill d-flex flex-column flex-sm-row pt-2">
-        <div className="nav-item px-lg-4 px-3 text-sm-left text-center font-weight-boldish mt-auto mb-2">
-          {cube.name}
-          {cube.type && <span className="d-sm-inline"> ({subtitle})</span>}
-        </div>
-        <div className="d-flex flex-row flex-wrap">
-          <CubeNavItem link="overview" activeLink={activeLink}>
-            Overview
-          </CubeNavItem>
-          <CubeNavItem link="list" activeLink={activeLink}>
-            List
-          </CubeNavItem>
-          <CubeNavItem link="playtest" activeLink={activeLink}>
-            Playtest
-          </CubeNavItem>
-          <CubeNavItem link="analysis" activeLink={activeLink}>
-            Analysis
-          </CubeNavItem>
-          <CubeNavItem link="blog" activeLink={activeLink}>
-            Blog
-          </CubeNavItem>
-        </div>
-      </ul>
-      <ErrorBoundary className="mt-3">{children}</ErrorBoundary>
+      <div className="mb-3">
+        <ul className="cubenav nav nav-tabs nav-fill d-flex flex-column flex-sm-row pt-2">
+          <div className="nav-item px-lg-4 px-3 text-sm-left text-center font-weight-boldish mt-auto mb-2">
+            {cube.name}
+            {cube.type && <span className="d-sm-inline"> ({subtitle})</span>}
+          </div>
+          <div className="d-flex flex-row flex-wrap">
+            <CubeNavItem link="overview" activeLink={activeLink}>
+              Overview
+            </CubeNavItem>
+            <CubeNavItem link="list" activeLink={activeLink}>
+              List
+            </CubeNavItem>
+            <CubeNavItem link="playtest" activeLink={activeLink}>
+              Playtest
+            </CubeNavItem>
+            <CubeNavItem link="analysis" activeLink={activeLink}>
+              Analysis
+            </CubeNavItem>
+            <CubeNavItem link="blog" activeLink={activeLink}>
+              Blog
+            </CubeNavItem>
+          </div>
+        </ul>
+        <ErrorBoundary className="mt-3">{children}</ErrorBoundary>
+      </div>
     </CubeContextProvider>
   );
 };

--- a/src/layouts/CubeLayout.js
+++ b/src/layouts/CubeLayout.js
@@ -9,10 +9,10 @@ import ErrorBoundary from 'components/ErrorBoundary';
 import { getCubeDescription } from 'utils/Util';
 
 const CubeNavItem = ({ link, activeLink, children }) => {
-  const { cubeID } = useContext(CubeContext);
+  const { cubeAlias } = useContext(CubeContext);
   return (
     <NavItem>
-      <NavLink href={`/cube/${link}/${cubeID}`} active={link === activeLink}>
+      <NavLink href={`/cube/${link}/${cubeAlias}`} active={link === activeLink}>
         {children}
       </NavLink>
     </NavItem>
@@ -29,43 +29,45 @@ CubeNavItem.defaultProps = {
   children: false,
 };
 
-const CubeLayout = ({ cube, cubeID, canEdit, activeLink, children }) => {
-  const subtitle = getCubeDescription(cube);
+const CubeLayout = ({ cube, canEdit, activeLink, children }) => {
+  const categories =
+    cube.categoryPrefixes && cube.categoryPrefixes.length > 0 ? `${cube.categoryPrefixes.join(' ')} ` : '';
+  const subtitle = cube.overrideCategory
+    ? `${cube.card_count} Card ${categories}${cube.categoryOverride} Cube`
+    : `${cube.card_count} Card ${cube.type} Cube`;
   return (
-    <CubeContextProvider initialCube={cube} cubeID={cubeID} canEdit={canEdit}>
-      <div className="mb-3">
-        <ul className="cubenav nav nav-tabs nav-fill d-flex flex-column flex-sm-row pt-2">
-          <div className="nav-item px-lg-4 px-3 text-sm-left text-center font-weight-boldish mt-auto mb-2">
-            {cube.name}
-            {cube.type && <span className="d-sm-inline"> ({subtitle})</span>}
-          </div>
-          <div className="d-flex flex-row flex-wrap">
-            <CubeNavItem link="overview" activeLink={activeLink}>
-              Overview
-            </CubeNavItem>
-            <CubeNavItem link="list" activeLink={activeLink}>
-              List
-            </CubeNavItem>
-            <CubeNavItem link="playtest" activeLink={activeLink}>
-              Playtest
-            </CubeNavItem>
-            <CubeNavItem link="analysis" activeLink={activeLink}>
-              Analysis
-            </CubeNavItem>
-            <CubeNavItem link="blog" activeLink={activeLink}>
-              Blog
-            </CubeNavItem>
-          </div>
-        </ul>
-        <ErrorBoundary className="mt-3">{children}</ErrorBoundary>
-      </div>
+    <CubeContextProvider initialCube={cube} canEdit={canEdit}>
+      <link rel="stylesheet" href="/css/autocomplete.css" />
+      <ul className="cubenav nav nav-tabs nav-fill d-flex flex-column flex-sm-row pt-2">
+        <div className="nav-item px-lg-4 px-3 text-sm-left text-center font-weight-boldish mt-auto mb-2">
+          {cube.name}
+          {cube.type && <span className="d-sm-inline"> ({subtitle})</span>}
+        </div>
+        <div className="d-flex flex-row flex-wrap">
+          <CubeNavItem link="overview" activeLink={activeLink}>
+            Overview
+          </CubeNavItem>
+          <CubeNavItem link="list" activeLink={activeLink}>
+            List
+          </CubeNavItem>
+          <CubeNavItem link="playtest" activeLink={activeLink}>
+            Playtest
+          </CubeNavItem>
+          <CubeNavItem link="analysis" activeLink={activeLink}>
+            Analysis
+          </CubeNavItem>
+          <CubeNavItem link="blog" activeLink={activeLink}>
+            Blog
+          </CubeNavItem>
+        </div>
+      </ul>
+      <ErrorBoundary className="mt-3">{children}</ErrorBoundary>
     </CubeContextProvider>
   );
 };
 
 CubeLayout.propTypes = {
   cube: CubePropType.isRequired,
-  cubeID: PropTypes.string.isRequired,
   canEdit: PropTypes.bool,
   activeLink: PropTypes.string.isRequired,
   children: PropTypes.node,

--- a/src/pages/BulkUploadPage.js
+++ b/src/pages/BulkUploadPage.js
@@ -49,7 +49,7 @@ const BulkUploadPageRaw = ({ cubeID, missing, blogpost, cube, canEdit }) => {
   );
 
   return (
-    <CubeLayout cube={cube} cubeID={cubeID} canEdit={canEdit} activeLink="list">
+    <CubeLayout cube={cube} canEdit={canEdit} activeLink="list">
       <Card className="mt-3">
         <CardHeader>
           <h5>Confirm Upload</h5>

--- a/src/pages/CubeAnalysisPage.js
+++ b/src/pages/CubeAnalysisPage.js
@@ -180,7 +180,7 @@ const CubeAnalysisPage = ({
 
   return (
     <MainLayout loginCallback={loginCallback} user={user}>
-      <CubeLayout cube={cube} cubeID={cubeID} canEdit={false} activeLink="analysis">
+      <CubeLayout cube={cube} canEdit={false} activeLink="analysis">
         <DynamicFlash />
         {cube.cards.length === 0 ? (
           <h5 className="mt-3 mb-3">This cube doesn't have any cards. Add cards to see analytics.</h5>

--- a/src/pages/CubeBlogPage.js
+++ b/src/pages/CubeBlogPage.js
@@ -95,7 +95,7 @@ const CubeBlogPage = ({ user, cube, pages, activePage, posts, loginCallback }) =
 
   return (
     <MainLayout loginCallback={loginCallback} user={user}>
-      <CubeLayout cube={cube} cubeID={cube._id} canEdit={user && cube.owner === user.id} activeLink="blog">
+      <CubeLayout cube={cube} canEdit={user && cube.owner === user.id} activeLink="blog">
         <Navbar expand light className="usercontrols mb-3">
           <Collapse navbar>
             <Nav navbar>

--- a/src/pages/CubeDeckPage.js
+++ b/src/pages/CubeDeckPage.js
@@ -103,7 +103,7 @@ const CubeDeckPage = ({ user, cube, deck, draft, loginCallback }) => {
 
   return (
     <MainLayout loginCallback={loginCallback} user={user}>
-      <CubeLayout cube={cube} cubeID={deck.cube} activeLink="playtest">
+      <CubeLayout cube={cube} activeLink="playtest">
         <DisplayContextProvider>
           <CSRFForm
             key="submitdeck"

--- a/src/pages/CubeDeckbuilderPage.js
+++ b/src/pages/CubeDeckbuilderPage.js
@@ -113,7 +113,7 @@ const CubeDeckbuilderPage = ({ user, cube, initialDeck, basics, draft, loginCall
 
   return (
     <MainLayout loginCallback={loginCallback} user={user}>
-      <CubeLayout cube={cube} cubeID={cube._id} activeLink="playtest">
+      <CubeLayout cube={cube} activeLink="playtest">
         <DisplayContextProvider>
           <DeckbuilderNavbar
             deck={currentDeck}

--- a/src/pages/CubeDecksPage.js
+++ b/src/pages/CubeDecksPage.js
@@ -16,7 +16,7 @@ import RenderToRoot from 'utils/RenderToRoot';
 const CubeDecksPage = ({ user, cube, decks, pages, activePage, loginCallback }) => (
   <MainLayout loginCallback={loginCallback} user={user}>
     <DynamicFlash />
-    <CubeLayout cube={cube} cubeID={cube._id} activeLink="playtest">
+    <CubeLayout cube={cube} activeLink="playtest">
       <div className="my-3">
         {pages > 1 && <Paginate count={pages} active={activePage} urlF={(i) => `/cube/decks/${cube._id}/${i}`} />}
         <Card>

--- a/src/pages/CubeDraftPage.js
+++ b/src/pages/CubeDraftPage.js
@@ -190,7 +190,7 @@ const CubeDraftPage = ({ user, cube, initialDraft, loginCallback }) => {
   const seen = getSeen(0);
   return (
     <MainLayout loginCallback={loginCallback} user={user}>
-      <CubeLayout cube={cube} cubeID={cube._id} activeLink="playtest">
+      <CubeLayout cube={cube} activeLink="playtest">
         <DisplayContextProvider>
           <Navbar expand="xs" light className="usercontrols">
             <Collapse navbar>

--- a/src/pages/CubeListPage.js
+++ b/src/pages/CubeListPage.js
@@ -151,7 +151,7 @@ const CubeListPage = ({
   loginCallback,
 }) => (
   <MainLayout loginCallback={loginCallback} user={user}>
-    <CubeLayout cube={cube} cubeID={cube._id} canEdit={user && cube.owner === user.id} activeLink="list">
+    <CubeLayout cube={cube} canEdit={user && cube.owner === user.id} activeLink="list">
       <CubeListPageRaw
         defaultShowTagColors={defaultShowTagColors}
         defaultFilterText={defaultFilterText}

--- a/src/pages/CubeOverviewPage.js
+++ b/src/pages/CubeOverviewPage.js
@@ -129,7 +129,7 @@ class CubeOverview extends Component {
 
     return (
       <MainLayout loginCallback={loginCallback} user={user}>
-        <CubeLayout cube={cube} cubeID={cube._id} canEdit={user && cube.owner === user.id} activeLink="overview">
+        <CubeLayout cube={cube} canEdit={user && cube.owner === user.id} activeLink="overview">
           {user && cube.owner === user.id ? (
             <Navbar expand="md" light className="usercontrols mb-3">
               <Nav navbar>

--- a/src/pages/CubePlaytestPage.js
+++ b/src/pages/CubePlaytestPage.js
@@ -516,7 +516,7 @@ const CubePlaytestPage = ({ user, cube, decks, draftFormats, loginCallback }) =>
   );
   return (
     <MainLayout loginCallback={loginCallback} user={user}>
-      <CubeLayout cube={cube} cubeID={cube._id} canEdit={user && cube.owner === user.id} activeLink="playtest">
+      <CubeLayout cube={cube} canEdit={user && cube.owner === user.id} activeLink="playtest">
         {user && cube.owner === user.id ? (
           <Navbar light expand className="usercontrols mb-3">
             <Nav navbar>

--- a/src/pages/CubeSamplePackPage.js
+++ b/src/pages/CubeSamplePackPage.js
@@ -16,7 +16,7 @@ import RenderToRoot from 'utils/RenderToRoot';
 const SamplePackPage = ({ user, seed, pack, cube, loginCallback }) => {
   return (
     <MainLayout loginCallback={loginCallback} user={user}>
-      <CubeLayout cube={cube} cubeID={cube._id} canEdit={user && cube.owner === user.id} activeLink="playtest">
+      <CubeLayout cube={cube} canEdit={user && cube.owner === user.id} activeLink="playtest">
         <DynamicFlash />
         <div className="container" />
         <br />

--- a/src/pages/GridDraftPage.js
+++ b/src/pages/GridDraftPage.js
@@ -337,7 +337,7 @@ const GridDraftPage = ({ user, cube, initialDraft, loginCallback }) => {
 
   return (
     <MainLayout loginCallback={loginCallback} user={user}>
-      <CubeLayout cube={cube} cubeID={cube._id} activeLink="playtest">
+      <CubeLayout cube={cube} activeLink="playtest">
         <DisplayContextProvider>
           <Navbar expand="xs" light className="usercontrols">
             <Collapse navbar>


### PR DESCRIPTION
Cube urls use the long id instead of the cube alias when set. This fixes a number of urls of the tabs on the cube page.