### PR TITLE
Fixed CSV download query parameters

### DIFF
--- a/src/utils/Sort.js
+++ b/src/utils/Sort.js
@@ -790,7 +790,7 @@ export function sortDeep(cards, ...sorts) {
     return [...cards].sort(alphaCompare);
   }
   const [first, ...rest] = sorts;
-  const result = sortGroupsOrdered(cards, first);
+  const result = sortGroupsOrdered(cards, first ?? 'Unsorted');
   for (const labelGroup of result) {
     if (rest.length > 0) {
       labelGroup[1] = sortDeep(labelGroup[1], ...rest);


### PR DESCRIPTION
Fixes #1762 

### Cause of issue
When the `sortForCSVDownload` function was called with sort parameters undefined by the query, it passed `[undefined, undefined, undefined]` as the `sorts` array to `sortDeep`. That then called other sort functions with a `sort` value set to `undefined`, which they didn't expect, so they were returning empty results. This resulted in none of the mainboard cards being shown unless all three sorts were explicitly set.

### Fix
Set a default value of `Unsorted` to the sort parameter in `sortDeep` when passed a null-ish value.

### Additional notes
We could also rewrite the sorting functions to handle undefined sort parameters better, but most of their callers are on the client side and get their sort parameters from `SortContext`, so it's probably not a big deal.