### PR TITLE
Update health check policy

### DIFF
--- a/.ebextensions/03_autoscaling.config
+++ b/.ebextensions/03_autoscaling.config
@@ -1,0 +1,6 @@
+Resources:
+  AWSEBAutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      HealthCheckType: ELB
+      HealthCheckGracePeriod: 900


### PR DESCRIPTION
This change is described here: https://aws.amazon.com/premiumsupport/knowledge-center/elastic-beanstalk-instance-automation/

### Problem
The previous behavior is that unhealthy instances are removed from the load balancer group but not the autoscaling group. So if an instance becomes unhealthy and doesn't recover, it takes up autoscaling capacity. This causes transient errors to pile up and eventually take out the service when every instance in the has been taken out of the load balancing group, and so the service just 503s because the load balancing group is empty.

### Solution
Adjust autoscaling config so that unhealthy instances are removed from the autoscaling group, not the load balancing group.