### PR TITLE
Correctly parse specific IDs in cardimage markdown links

### DIFF
--- a/src/components/Markdown.js
+++ b/src/components/Markdown.js
@@ -105,7 +105,7 @@ const renderSymbol = (node) => {
 };
 
 const renderCardlink = ({ name, id, dfc }) => {
-  const idURL = encodeURIComponent(id ?? name);
+  const idURL = encodeURIComponent(id);
   const details = { image_normal: `/tool/cardimage/${idURL}` };
   if (dfc) details.image_flip = `/tool/cardimageflip/${idURL}`;
 
@@ -117,14 +117,13 @@ const renderCardlink = ({ name, id, dfc }) => {
 };
 
 const renderCardImage = (node) => {
-  const name = node.value;
-  const nameURL = encodeURIComponent(name);
-  const details = { image_normal: `/tool/cardimage/${nameURL}` };
-  if (node.dfc) details.image_flip = `/tool/cardimageflip/${nameURL}`;
+  const idURL = encodeURIComponent(node.id);
+  const details = { image_normal: `/tool/cardimage/${idURL}` };
+  if (node.dfc) details.image_flip = `/tool/cardimageflip/${idURL}`;
 
   return (
     <Col className="card-image" xs="6" md="4" lg="3">
-      <a href={`/tool/card/${nameURL}`} target="_blank" rel="noopener noreferrer">
+      <a href={`/tool/card/${idURL}`} target="_blank" rel="noopener noreferrer">
         <FoilCardImage autocard card={{ details }} className="clickable" />
       </a>
     </Col>

--- a/src/markdown/cardlink/index.js
+++ b/src/markdown/cardlink/index.js
@@ -14,20 +14,15 @@ function oncard(node) {
     node.dfc = true;
   }
 
-  if (node.type === 'cardlink') {
-    [node.name, node.id] = node.value.split('|');
-  }
-}
-
-function transform(tree) {
-  visit(tree, 'cardlink', oncard);
+  [node.name, node.id] = node.value.split('|');
+  if (typeof node.id === 'undefined') node.id = node.name;
 }
 
 function cardlinks() {
   const data = this.data();
   add(data, 'micromarkExtensions', syntax);
   add(data, 'fromMarkdownExtensions', fromMarkdown);
-  return transform;
+  return (tree) => visit(tree, 'cardlink', oncard);
 }
 
 export default cardlinks;

--- a/src/markdown/cardlink/index.js
+++ b/src/markdown/cardlink/index.js
@@ -14,6 +14,11 @@ function oncard(node) {
     node.dfc = true;
   }
 
+  if (node.value[0] === '!' && node.type !== 'cardimage') {
+    node.value = node.value.substring(1);
+    node.type = 'cardimage';
+  }
+
   [node.name, node.id] = node.value.split('|');
   if (typeof node.id === 'undefined') node.id = node.name;
 }


### PR DESCRIPTION
Fixes #1771 

### Cause of issue
For some reason, the split on `|` was only done for card links, not card image links (probably because I thought card images didn't need to have names). 

### Fix
Removed the check that applied the split only to card links.

### Additional notes
While I was there, I added support for starting DFC image links with `[[/!` as well as the original `[[!/`, because I always forget the order.