### PR TITLE
Fix cube list page filtering based on URL params

### DIFF
--- a/src/components/FilterCollapse.js
+++ b/src/components/FilterCollapse.js
@@ -445,7 +445,7 @@ class FilterCollapse extends Component {
   }
 
   async updateFilters(overrideFilter) {
-    if (this.props.filter != null && Query.get('f') === this.state.filterInput) {
+    if (this.props.filter && Query.get('f') === this.state.filterInput) {
       return;
     }
 

--- a/src/components/FilterCollapse.js
+++ b/src/components/FilterCollapse.js
@@ -445,7 +445,7 @@ class FilterCollapse extends Component {
   }
 
   async updateFilters(overrideFilter) {
-    if (Query.get('f') === this.state.filterInput) {
+    if (this.props.filter != null && Query.get('f') === this.state.filterInput) {
       return;
     }
 


### PR DESCRIPTION
Fixes https://github.com/dekkerglen/CubeCobra/issues/1773

Seems like this was introduced by https://github.com/dekkerglen/CubeCobra/pull/1751

From what I can tell, for the Cube List page, when the components are initialized, the `filterInput` will be set to the filter expression from the query params. However, the filter object is not initialized yet, since it's relying on the `updateFilters` method here to do that. Then it hits this condition and returns, so the filter object never gets created.

It seems the Search Cards page works slightly differently, even though it reuses this component, so it didn't have this problem.

My fix seems like a hack on top of a hack - it doesn't feel like this component should have to care about the query parameters, which is global state - but I'm not familiar enough with React / this codebase to come up with something better. I'm happy to try out other fixes if you have any better ideas.

Manually tested:
* List page, no URL params, apply a filter
* List page, URL params with a filter
* Search cards page, no URL params, apply a filter
* Search cards page, URL params with a filter
* Search cards page, apply a filter, then hit apply again (the original infinite load bug)
