### PR TITLE
Removed server HTML sanitization from deck descriptions

### DIFF
--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -2930,7 +2930,7 @@ router.delete('/deletedeck/:id', ensureAuth, async (req, res) => {
     const deck = await Deck.findById(req.params.id);
     const deckOwner = (await User.findById(deck.seats[0].userid)) || {};
 
-    if (!deckOwner._id.equals(req.user._id) && !deck.cubeOwner == req.user._id) {
+    if (!deckOwner._id.equals(req.user._id) && !deck.cubeOwner === req.user._id) {
       req.flash('danger', 'Unauthorized');
       return res.redirect('/404');
     }

--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -10,7 +10,6 @@ Canvas.Image = Image;
 
 const {
   generatePack,
-  sanitize,
   setCubeType,
   cardsAreEquivalent,
   getBasics,
@@ -2789,7 +2788,7 @@ router.post('/editdeck/:id', ensureAuth, async (req, res) => {
 
     const newdeck = JSON.parse(req.body.draftraw);
     const name = JSON.parse(req.body.name);
-    const description = sanitize(JSON.parse(req.body.description));
+    const description = JSON.parse(req.body.description);
 
     deck.seats[0].deck = newdeck.playerdeck;
     deck.seats[0].sideboard = newdeck.playersideboard;


### PR DESCRIPTION
Fixes #1776 

We don't need to sanitize HTML from deck descriptions when submitting them, because the only place they are used is in the `DeckCard` component, which just passes them to the markdown renderer, which escapes HTML itself when rendering. Furthermore, this server-side sanitization was overly greedy, which caused #1776. Therefore, I removed it from the route handler.