### PR TITLE
Fixed 'Create new cube' links

### DIFF
--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -2931,7 +2931,7 @@ router.delete('/deletedeck/:id', ensureAuth, async (req, res) => {
     const deck = await Deck.findById(req.params.id);
     const deckOwner = (await User.findById(deck.seats[0].userid)) || {};
 
-    if (!deckOwner._id.equals(req.user._id) && !deck.cubeOwner == req.user._id) {
+    if (!deckOwner._id.equals(req.user._id) && !deck.cubeOwner === req.user._id) {
       req.flash('danger', 'Unauthorized');
       return res.redirect('/404');
     }

--- a/src/layouts/UserLayout.js
+++ b/src/layouts/UserLayout.js
@@ -6,8 +6,10 @@ import { Button, Nav, Navbar, NavItem, NavLink, Row } from 'reactstrap';
 import ErrorBoundary from 'components/ErrorBoundary';
 import FollowersModal from 'components/FollowersModal';
 import withModal from 'components/WithModal';
+import CreateCubeModal from 'components/CreateCubeModal';
 
 const FollowersModalLink = withModal('a', FollowersModal);
+const CreateCubeModalLink = withModal(NavLink, CreateCubeModal);
 
 const UserLayout = ({ user, followers, following, canEdit, activeLink, children }) => {
   const numFollowers = followers.length;
@@ -61,9 +63,7 @@ const UserLayout = ({ user, followers, following, canEdit, activeLink, children 
         <Navbar light className="usercontrols">
           <Nav navbar>
             <NavItem>
-              <NavLink href="#" data-toggle="modal" data-target="#cubeModal">
-                Create New Cube
-              </NavLink>
+              <CreateCubeModalLink>Create New Cube</CreateCubeModalLink>
             </NavItem>
           </Nav>
         </Navbar>

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -14,8 +14,12 @@ import Advertisement from 'components/Advertisement';
 import DynamicFlash from 'components/DynamicFlash';
 import MainLayout from 'layouts/MainLayout';
 import RenderToRoot from 'utils/RenderToRoot';
+import withModal from 'components/WithModal';
+import CreateCubeModal from 'components/CreateCubeModal';
 
 import { Button, Card, Col, Row, CardHeader, CardBody, CardFooter } from 'reactstrap';
+
+const CreateCubeModalButton = withModal(Button, CreateCubeModal);
 
 const DashboardPage = ({ posts, cubes, decks, user, loginCallback, content }) => {
   const filteredDecks = cubes.length > 2 ? decks : decks.slice(0, 6);
@@ -41,9 +45,7 @@ const DashboardPage = ({ posts, cubes, decks, user, loginCallback, content }) =>
                 ) : (
                   <p className="m-2">
                     You don't have any cubes.{' '}
-                    <Button data-toggle="modal" data-target="#cubeModal" color="success">
-                      Add a new cube?
-                    </Button>
+                    <CreateCubeModalButton color="success">Add a new cube?</CreateCubeModalButton>
                   </p>
                 )}
               </Row>


### PR DESCRIPTION
Fixes #1779 

Apparently when we moved the layout to React, the `Create new cube` link in the main navbar was updated to use the new `CreateCubeModal` component, but the ones in the profile page and dashboard were never changed, which is why they stopped working.