### PR TITLE
URL encoded cube aliases

### DIFF
--- a/routes/root.js
+++ b/routes/root.js
@@ -14,6 +14,7 @@ const carddb = require('../serverjs/cards');
 const { makeFilter } = require('../serverjs/filterCubes');
 const { render } = require('../serverjs/render');
 const { csrfProtection } = require('./middleware');
+const { getCubeId } = require('../serverjs/cubefn');
 
 const router = express.Router();
 
@@ -104,7 +105,7 @@ router.get('/random', async (req, res) => {
   const count = await Cube.estimatedDocumentCount();
   const random = Math.floor(Math.random() * count);
   const cube = await Cube.findOne().skip(random).lean();
-  res.redirect(`/cube/overview/${cube.urlAlias ? cube.urlAlias : cube.shortID}`);
+  res.redirect(`/cube/overview/${encodeURIComponent(getCubeId(cube))}`);
 });
 
 router.get('/dashboard', async (req, res) => {

--- a/src/components/CubeOverviewModal.js
+++ b/src/components/CubeOverviewModal.js
@@ -20,7 +20,7 @@ import {
 } from 'reactstrap';
 
 import { csrfFetch } from 'utils/CSRF';
-import { getCubeDescription } from 'utils/Util';
+import { getCubeDescription, getCubeId } from 'utils/Util';
 
 import AutocompleteInput from 'components/AutocompleteInput';
 import LoadingButton from 'components/LoadingButton';
@@ -194,10 +194,8 @@ class CubeOverviewModal extends Component {
     const json = await response.json();
     if (response.ok) {
       if (this.state.urlChanged) {
-        let cubeID = this.state.cube._id;
-        if (this.state.cube.shortID) cubeID = this.state.cube.shortID;
-        if (this.state.cube.urlAlias) cubeID = this.state.cube.urlAlias;
-        window.location.href = `/cube/overview/${cubeID}`;
+        let cubeID = getCubeId(this.state.cube);
+        window.location.href = `/cube/overview/${encodeURIComponent(cubeID)}`;
       }
       this.props.onCubeUpdate(cube);
     } else {

--- a/src/components/CubePreview.js
+++ b/src/components/CubePreview.js
@@ -15,7 +15,7 @@ const CubePreview = ({ cube }) => {
   const handleClick = useCallback(
     (event) => {
       if (!event.target.getAttribute('data-sublink')) {
-        window.location.href = `/cube/overview/${getCubeId(cube)}`;
+        window.location.href = `/cube/overview/${encodeURIComponent(getCubeId(cube))}`;
       }
     },
     [cube],

--- a/src/layouts/CubeLayout.js
+++ b/src/layouts/CubeLayout.js
@@ -10,7 +10,7 @@ const CubeNavItem = ({ link, activeLink, children }) => {
   const { cube } = useContext(CubeContext);
   return (
     <NavItem>
-      <NavLink href={`/cube/${link}/${getCubeId(cube)}`} active={link === activeLink}>
+      <NavLink href={`/cube/${link}/${encodeURIComponent(getCubeId(cube))}`} active={link === activeLink}>
         {children}
       </NavLink>
     </NavItem>


### PR DESCRIPTION
Fixes #1781

Since user-submitted URL aliases of their cubes can contain any characters, we have to escape them when inserting them into a URL. These are all the instances I could find of cube URL aliases potentially entering URLs, now escaped.

Because `cube._id` is a hexadecimal digit string and `cube.shortID` is a base36-encoded string, both are safe to use in URLs without modification (and therefore so is the `cubeID` property of `CubeContext`, which is equal to `cube._id`)