### PR TITLE
Added warning page for outside links

### DIFF
--- a/routes/root.js
+++ b/routes/root.js
@@ -687,4 +687,10 @@ router.get('/c/:id', (req, res) => {
   res.redirect(`/cube/list/${req.params.id}`);
 });
 
+router.get('/leave', (req, res) => {
+  return render(req, res, 'LeaveWarningPage', {
+    url: req.query.url,
+  });
+});
+
 module.exports = router;

--- a/serverjs/render.js
+++ b/serverjs/render.js
@@ -73,6 +73,7 @@ if (NODE_ENV === 'production') {
   pages.BrowseContentPage = require('../dist/pages/BrowseContentPage').default;
   pages.BulkUploadPage = require('../dist/pages/BulkUploadPage').default;
   pages.CardPage = require('../dist/pages/CardPage').default;
+  pages.LeaveWarningPage = require('../dist/pages/LeaveWarningPage').default;
 }
 
 const getPage = (page) => pages[page] || pages.Loading;

--- a/src/components/Markdown.js
+++ b/src/components/Markdown.js
@@ -45,15 +45,17 @@ const renderLink = (node) => {
         </a>
       );
     }
+
     return (
       <a target="_blank" rel="noopener noreferrer" href={ref}>
         {node.children}
       </a>
     );
   }
+
   return (
     /* eslint-disable-next-line jsx-a11y/anchor-is-valid */
-    <Link href="#" modalProps={{ link: ref }}>
+    <Link href={`/leave?url=${encodeURIComponent(ref)}`} modalProps={{ link: ref }}>
       {node.children}
     </Link>
   );

--- a/src/pages/LeaveWarningPage.js
+++ b/src/pages/LeaveWarningPage.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import UserPropType from 'proptypes/UserPropType';
+
+import { Card, CardHeader, CardBody, Button } from 'reactstrap';
+import DynamicFlash from 'components/DynamicFlash';
+import MainLayout from 'layouts/MainLayout';
+import ButtonLink from 'components/ButtonLink';
+import RenderToRoot from 'utils/RenderToRoot';
+
+const LeaveWarningPage = ({ user, url, loginCallback }) => (
+  <MainLayout user={user} loginCallback={loginCallback}>
+    <DynamicFlash />
+    <Card className="my-3">
+      <CardHeader>
+        <h4>You are about to leave CubeCobra</h4>
+      </CardHeader>
+      <CardBody>
+        <p>
+          This link leads to: <code>{url}</code>
+        </p>
+        <p>Are you sure you wish to proceed?</p>
+        <p>
+          <ButtonLink href={url} color="danger" outline>
+            Yes, continue
+          </ButtonLink>
+          <Button color="secondary" onClick={window.history.back}>
+            Go back
+          </Button>
+        </p>
+      </CardBody>
+    </Card>
+  </MainLayout>
+);
+
+LeaveWarningPage.propTypes = {
+  user: UserPropType,
+  url: PropTypes.string.isRequired,
+  loginCallback: PropTypes.string,
+};
+
+LeaveWarningPage.defaultProps = {
+  user: null,
+  loginCallback: '/',
+};
+
+export default RenderToRoot(LeaveWarningPage);

--- a/src/pages/LeaveWarningPage.js
+++ b/src/pages/LeaveWarningPage.js
@@ -8,6 +8,8 @@ import MainLayout from 'layouts/MainLayout';
 import ButtonLink from 'components/ButtonLink';
 import RenderToRoot from 'utils/RenderToRoot';
 
+const back = () => window.history.back();
+
 const LeaveWarningPage = ({ user, url, loginCallback }) => (
   <MainLayout user={user} loginCallback={loginCallback}>
     <DynamicFlash />
@@ -24,7 +26,7 @@ const LeaveWarningPage = ({ user, url, loginCallback }) => (
           <ButtonLink href={url} color="danger" outline>
             Yes, continue
           </ButtonLink>
-          <Button color="secondary" onClick={window.history.back}>
+          <Button className="btn" color="secondary" onClick={back}>
             Go back
           </Button>
         </p>

--- a/src/pages/LeaveWarningPage.js
+++ b/src/pages/LeaveWarningPage.js
@@ -8,7 +8,7 @@ import MainLayout from 'layouts/MainLayout';
 import ButtonLink from 'components/ButtonLink';
 import RenderToRoot from 'utils/RenderToRoot';
 
-const back = () => window.history.back();
+const back = () => (window.history.length > 1 ? window.history.back() : window.close());
 
 const LeaveWarningPage = ({ user, url, loginCallback }) => (
   <MainLayout user={user} loginCallback={loginCallback}>
@@ -24,10 +24,10 @@ const LeaveWarningPage = ({ user, url, loginCallback }) => (
         <p>Are you sure you want to proceed?</p>
       </CardBody>
       <CardFooter>
-        <ButtonLink href={url} color="danger" outline>
+        <ButtonLink href={url} color="danger">
           Yes, continue
         </ButtonLink>
-        <Button className="ml-1" color="secondary" onClick={back}>
+        <Button className="ml-2" color="secondary" onClick={back}>
           Go back
         </Button>
       </CardFooter>

--- a/src/pages/LeaveWarningPage.js
+++ b/src/pages/LeaveWarningPage.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import UserPropType from 'proptypes/UserPropType';
 
-import { Card, CardHeader, CardBody, Button } from 'reactstrap';
+import { Card, CardHeader, CardBody, Button, CardFooter } from 'reactstrap';
 import DynamicFlash from 'components/DynamicFlash';
 import MainLayout from 'layouts/MainLayout';
 import ButtonLink from 'components/ButtonLink';
@@ -21,16 +21,16 @@ const LeaveWarningPage = ({ user, url, loginCallback }) => (
         <p>
           This link leads to: <code>{url}</code>
         </p>
-        <p>Are you sure you wish to proceed?</p>
-        <p>
-          <ButtonLink href={url} color="danger" outline>
-            Yes, continue
-          </ButtonLink>
-          <Button className="btn" color="secondary" onClick={back}>
-            Go back
-          </Button>
-        </p>
+        <p>Are you sure you want to proceed?</p>
       </CardBody>
+      <CardFooter>
+        <ButtonLink href={url} color="danger" outline>
+          Yes, continue
+        </ButtonLink>
+        <Button className="ml-1" color="secondary" onClick={back}>
+          Go back
+        </Button>
+      </CardFooter>
     </Card>
   </MainLayout>
 );

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -91,6 +91,7 @@ const clientConfig = merge(config, {
     PodcastsPage: './src/pages/PodcastsPage.js',
     PodcastEpisodePage: './src/pages/PodcastEpisodePage.js',
     BrowseContentPage: './src/pages/BrowseContentPage.js',
+    LeaveWarningPage: './src/pages/LeaveWarningPage.js',
   },
   output: {
     filename: '[name].bundle.js',
@@ -169,6 +170,7 @@ const serverConfig = merge(config, {
     'pages/PodcastsPage': './src/pages/PodcastsPage.js',
     'pages/PodcastEpisodePage': './src/pages/PodcastEpisodePage.js',
     'pages/BrowseContentPage': './src/pages/BrowseContentPage.js',
+    'pages/LeaveWarningPage': './src/pages/LeaveWarningPage.js',
     'utils/Card': './src/utils/Card.js',
     'utils/draftutil': './src/utils/draftutil.js',
     'utils/Draft': './src/utils/Draft.js',


### PR DESCRIPTION
![Screenshot from 2021-01-13 13-50-23](https://user-images.githubusercontent.com/38463785/104454549-f09d5000-559d-11eb-8dd3-9b45512dca1b.png)

Currently, if you try to open a user-written link from Markdown in a new tab, it doesn't work. That's because the link displays a warning modal and its `href` attribute is set to `'#'`. This PR redirects links to a dedicated "/leave" page instead (shown above), so that users are able to open links in new tabs and a warning will still be shown. The regular `onClick` event of these links remains unchanged and still just displays the modal as before.