### PR TITLE
Fixed regression

### DIFF
--- a/src/components/DraftbotBreakdown.js
+++ b/src/components/DraftbotBreakdown.js
@@ -291,7 +291,7 @@ Internal.propTypes = {
 };
 
 const DraftbotBreakdown = ({ draft, seatIndex, deck, defaultIndex }) => {
-  const [index, setIndex] = useQueryParam(defaultIndex ?? 0);
+  const [index, setIndex] = useQueryParam('pick', defaultIndex ?? 0);
 
   // Have to do useMemo so it happens immediately
   useMemo(() => init(draft), [draft]);


### PR DESCRIPTION
Fixed issue introduced in #1786

When creating the `useQueryParam` hook, the parameters of this call weren't updated from the previous `useState` call, ultimately resulting in a crash whenever you try to open the Draftbot Analysis view (since the `index` was now being set to `null` instead of a number, which further code wasn't expecting).