### PR TITLE
Fixed oracle filter regression

### DIFF
--- a/src/filtering/FuncOperations.js
+++ b/src/filtering/FuncOperations.js
@@ -73,7 +73,7 @@ export const nameStringOperation = (op, value) => {
     if (shorthand) {
       expandedValue = expandedValue.replace(new RegExp(shorthand, 'g'), NAME_PLACEHOLDER);
     }
-    return strOp(expandedValue);
+    return strOp(fieldValue) || strOp(expandedValue);
   };
 };
 


### PR DESCRIPTION
### Issue
When we introduced the ability to use "\~" in the `o:` filter, we did it by replacing instances of the card's name in its oracle text with "~", and then ran a regular string comparison on that. The problem with that is that now the oracle filter doesn't see the original names anymore, so filtering by them stopped working. For example, [Valki](https://scryfall.com/card/khm/114/valki-god-of-lies-tibalt-cosmic-impostor) would be correctly matched by `o:~`, but now won't be matched by `o:Valki`, which is an issue.

### Solution
Run the regular string comparison first and use the "~"-expanded one only if that doesn't match.

### Additional Notes
This solution leaves a potential corner case where using both the literal name and "\~" in the same `o:` filter will fail to match cards (For example, if we replace just the second instance of "Valki" in its last ability with "\~", the regular comparison will fail on "~" and the expanded comparison will fail on "Valki".) I don't see this as a problem, because A) there aren't any real scenarios where such a filter pattern is useful, and B) Scryfall will [also fail to match it](https://scryfall.com/search?q=o%3A%22choose+a+creature+card+exiled+with+Valki+with+converted+mana+cost+X.+%7E+becomes+a+copy+of+that+card%22&unique=cards&as=grid&order=name), so we aren't breaking compatibility.