### PR TITLE
Added card ID to card page

### DIFF
--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -1128,7 +1128,7 @@ audio {
 	border-color: var(--border) !important;
 }
 
-.input-group-text {
+.input-group-text, .input-group-button {
 	background-color: var(--bg-dark);
 	color:var(--text);
 	border-color: var(--border);

--- a/src/pages/CardPage.js
+++ b/src/pages/CardPage.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import UserPropType from 'proptypes/UserPropType';
 import CardPricePropType from 'proptypes/CardPricePropType';
@@ -20,6 +20,7 @@ import {
   Table,
   Badge,
   Button,
+  Input,
 } from 'reactstrap';
 
 import ChartComponent from 'react-chartjs-2';
@@ -45,6 +46,7 @@ import Tab from 'components/Tab';
 
 import { cardPrice, cardFoilPrice, cardPriceEur, cardTix, cardElo } from 'utils/Card';
 import { getTCGLink, getCardMarketLink, getCardHoarderLink, getCardKingdomLink } from 'utils/Affiliate';
+import { CheckIcon, ClippyIcon } from '@primer/octicons-react';
 
 const AutocardA = withAutocard('a');
 const AddModal = withModal(Button, AddToCubeModal);
@@ -177,6 +179,33 @@ LegalityBadge.propTypes = {
   status: PropTypes.string.isRequired,
 };
 
+const CardIdBadge = ({ id }) => {
+  const [copied, setCopied] = useState(false);
+
+  const onCopyClick = async () => {
+    await navigator.clipboard.writeText(id);
+    setCopied(true);
+  };
+
+  return (
+    <InputGroup className="flex-nowrap mb-3" size="sm">
+      <InputGroupAddon addonType="prepend">
+        <InputGroupText>Card ID</InputGroupText>
+      </InputGroupAddon>
+      <Input id="card-id" className="bg-white" value={id} disabled />
+      <InputGroupAddon addonType="append" style={{ width: 'auto' }}>
+        <Button className="btn-sm" onClick={onCopyClick}>
+          {copied ? <CheckIcon size={16} /> : <ClippyIcon size={16} />}
+        </Button>
+      </InputGroupAddon>
+    </InputGroup>
+  );
+};
+
+CardIdBadge.propTypes = {
+  id: PropTypes.string.isRequired,
+};
+
 const getPriceTypeUnit = {
   price: 'USD',
   price_foil: 'USD',
@@ -231,11 +260,12 @@ const CardPage = ({ user, card, data, versions, related, cubes, loginCallback })
                 color="success"
                 block
                 outline
-                className="mb-2 mr-2"
+                className="mb-1 mr-2"
                 modalProps={{ card, cubes, hideAnalytics: true }}
               >
                 Add to Cube...
               </AddModal>
+              <CardIdBadge id={card._id} />
               {card.prices && Number.isFinite(cardPrice({ details: card })) && (
                 <TextBadge name="Price" className="mt-1" fill>
                   <Tooltip text="TCGPlayer Market Price">${cardPrice({ details: card }).toFixed(2)}</Tooltip>

--- a/src/pages/CardPage.js
+++ b/src/pages/CardPage.js
@@ -192,7 +192,7 @@ const CardIdBadge = ({ id }) => {
       <InputGroupAddon addonType="prepend">
         <InputGroupText>Card ID</InputGroupText>
       </InputGroupAddon>
-      <Input id="card-id" className="bg-white" value={id} disabled />
+      <Input className="bg-white" value={id} disabled />
       <InputGroupAddon addonType="append" style={{ width: 'auto' }}>
         <Button className="btn-sm" onClick={onCopyClick}>
           {copied ? <CheckIcon size={16} /> : <ClippyIcon size={16} />}

--- a/src/pages/CardPage.js
+++ b/src/pages/CardPage.js
@@ -194,7 +194,7 @@ const CardIdBadge = ({ id }) => {
       </InputGroupAddon>
       <Input className="bg-white" value={id} disabled />
       <InputGroupAddon addonType="append" style={{ width: 'auto' }}>
-        <Button className="btn-sm" onClick={onCopyClick}>
+        <Button className="btn-sm input-group-button" onClick={onCopyClick}>
           {copied ? <CheckIcon size={16} /> : <ClippyIcon size={16} />}
         </Button>
       </InputGroupAddon>


### PR DESCRIPTION
Resolves #1803.

This PR puts the ID of a card's version directly to that version's card page, so users don't have to search for it in URLs. It also adds a way to easily copy that ID.

## Pictures
### Desktop
![Screenshot from 2021-02-04 20-12-20](https://user-images.githubusercontent.com/38463785/106943587-82bbf280-671d-11eb-9634-092971c008e9.png)
### Mobile
![Screenshot from 2021-02-04 20-12-34](https://user-images.githubusercontent.com/38463785/106943754-be56bc80-671d-11eb-9a96-3d56b8c64e05.png)
### Dark Mode
![Screenshot from 2021-02-04 20-13-44](https://user-images.githubusercontent.com/38463785/106943728-b6971800-671d-11eb-9d99-d2c8a9bd2a5f.png)
### Copy Buton Hover
![Screenshot from 2021-02-04 20-15-00](https://user-images.githubusercontent.com/38463785/106943823-d1698c80-671d-11eb-8d3c-75d54fcc5d27.png)
![Screenshot from 2021-02-04 20-14-07](https://user-images.githubusercontent.com/38463785/106943844-d6c6d700-671d-11eb-86e5-35ef96bdc033.png)
### Copy Buton Clicked
![Screenshot from 2021-02-04 20-15-11](https://user-images.githubusercontent.com/38463785/106943880-dfb7a880-671d-11eb-81dc-f899902491b7.png)
![Screenshot from 2021-02-04 20-14-22](https://user-images.githubusercontent.com/38463785/106943898-e47c5c80-671d-11eb-992a-abfb6245f3c5.png)



