### PR TITLE
Fixing issues with price and elo card filters

### DIFF
--- a/routes/tools_routes.js
+++ b/routes/tools_routes.js
@@ -26,7 +26,7 @@ async function matchingCards(filter) {
   let cards = carddb.allCards().filter((card) => !card.digital && !card.isToken);
   if (filter) {
     // In the first pass, cards don't have rating or picks, and so match all those filters.
-    // In the seoncd pass, we add that information.
+    // In the second pass, we add that information.
     if (filterUses(filter, 'rating') || filterUses(filter, 'picks') || filterUses(filter, 'cubes')) {
       const oracleIds = cards.map(({ oracle_id }) => oracle_id); // eslint-disable-line camelcase
       const historyObjects = await CardHistory.find(

--- a/routes/tools_routes.js
+++ b/routes/tools_routes.js
@@ -40,6 +40,7 @@ async function matchingCards(filter) {
           ...card,
           rating: history ? history.current.rating : null,
           picks: history ? history.current.picks : null,
+          cubes: history ? history.current.cubes : null,
         };
       });
     }

--- a/src/components/GroupModal.js
+++ b/src/components/GroupModal.js
@@ -215,10 +215,10 @@ const GroupModal = ({ cubeID, canEdit, children, ...props }) => {
     return contextChildren;
   }
 
-  const totalPriceUsd = cards.length ? cards.reduce((total, card) => total + cardPrice(card), 0) : 0;
-  const totalPriceUsdFoil = cards.length ? cards.reduce((total, card) => total + cardFoilPrice(card), 0) : 0;
-  const totalPriceEur = cards.length ? cards.reduce((total, card) => total + cardPriceEur(card), 0) : 0;
-  const totalPriceTix = cards.length ? cards.reduce((total, card) => total + cardTix(card), 0) : 0;
+  const totalPriceUsd = cards.length ? cards.reduce((total, card) => total + (cardPrice(card) ?? 0), 0) : 0;
+  const totalPriceUsdFoil = cards.length ? cards.reduce((total, card) => total + (cardFoilPrice(card) ?? 0), 0) : 0;
+  const totalPriceEur = cards.length ? cards.reduce((total, card) => total + (cardPriceEur(card) ?? 0), 0) : 0;
+  const totalPriceTix = cards.length ? cards.reduce((total, card) => total + (cardTix(card) ?? 0), 0) : 0;
 
   return (
     <>

--- a/src/utils/Card.js
+++ b/src/utils/Card.js
@@ -106,17 +106,17 @@ export const cardNotes = (card) => card.notes;
 export const cardColorCategory = (card) => card.colorCategory ?? card.details.color_category;
 
 export const cardPrice = (card) =>
-  cardFinish(card) === 'Foil'
+  (cardFinish(card) === 'Foil'
     ? card.details.prices.usd_foil ?? card.details.prices.usd
-    : card.details.prices.usd ?? card.details.prices.usd_foil;
+    : card.details.prices.usd ?? card.details.prices.usd_foil) ?? undefined;
 
-export const cardNormalPrice = (card) => card.details.prices.usd;
+export const cardNormalPrice = (card) => card.details.prices.usd ?? undefined;
 
-export const cardFoilPrice = (card) => card.details.prices.usd_foil;
+export const cardFoilPrice = (card) => card.details.prices.usd_foil ?? undefined;
 
-export const cardPriceEur = (card) => card.details.prices.eur;
+export const cardPriceEur = (card) => card.details.prices.eur ?? undefined;
 
-export const cardTix = (card) => card.details.prices.tix;
+export const cardTix = (card) => card.details.prices.tix ?? undefined;
 
 export const cardIsFullArt = (card) => card.details.full_art;
 

--- a/src/utils/Card.js
+++ b/src/utils/Card.js
@@ -105,6 +105,8 @@ export const cardNotes = (card) => card.notes;
 
 export const cardColorCategory = (card) => card.colorCategory ?? card.details.color_category;
 
+// prices being null causes unwanted coercing behaviour in price filters,
+// so nullish price values are transformed to undefined instead
 export const cardPrice = (card) =>
   (cardFinish(card) === 'Foil'
     ? card.details.prices.usd_foil ?? card.details.prices.usd


### PR DESCRIPTION
Fixes #1783.

### Bug
Price filters don't work. Filtering a card by an upper bound with `eur`, `normal`, or `tix` would cause false positives, where e.g. Black Lotus would be matched by `eur<1`. Filtering a card by `elo`, `price`, or `priceFoil` would fail to match any cards at all.

### Cause of Issue
There are a several factors at play.
1. Unset prices have a value of `null`. When looking at a card without a known price, we're then comparing against `null`, and numeric comparisons coerce null to +0. That's why `eur<1` will match a Black Lotus, because there are versions of it without a set price (which is therefore treated as 0).
2. When filtering by `price`, `price_foil`, or `elo`, the filter tries to pull data from the `CardHistory` database objects, even though they're not actually needed. The hypothesis is that this either takes to long or is somehow broken in production, because the server returns 504 errors on those filters. (I could not reproduce this on my local install.)

### Fix
1. Changed the price accessors to return `undefined` instead of `null` on unset values. Since `undefined` coerces into `NaN`, all numeric comparisons with it fail, which is what we want. I believe this change is functional only in the `GroupModal` reduce functions, where it was adjusted for.
2. Since we don't need `CardHistory` for price or elo information, they aren't used anymore with those filters. This should hopefully fix that problem.

### Additional Notes
- The other filters which require `CardHistory` information, picks and cubes, are also broken in production. This PR does not address that.
- There is a check for a `rating` value being used in the filter that pulls in `CardHistory` and a corresponding `rating` value being added by it, but no filters currently use that value. It was left in place in case I missed something, but its inclusion warrants closer inspection.