### PR TITLE
Improved card filter performance

### DIFF
--- a/nearley/cardFilters.ne
+++ b/nearley/cardFilters.ne
@@ -16,6 +16,7 @@ import {
   setElementOperation,
   setCountOperation,
   devotionOperation,
+  fetchedOperation,
 } from 'filtering/FuncOperations';
 import {
   cardCmc,
@@ -158,9 +159,9 @@ castableCostCondition -> ("cw"i | "cast"i | "castable"i | "castwith"i | "castabl
 devotionCondition -> ("d"i | "dev"i | "devotion"i | "devotionto"i) ("w"i | "u"i | "b"i | "r"i | "g"i) anyOperator integerValue {% ([, [color], op, value]) => genericCondition('parsed_cost', (c) => c, devotionOperation(op, color, value)) %}
   | ("d"i | "dev"i | "devotion"i | "devotionto"i) devotionOpValue {% ([, valuePred]) => genericCondition('parsed_cost', (c) => c, valuePred) %}
 
-picksCondition -> "picks" integerOpValue  {% ([,valuePred]) => genericCondition('picks', (card) => card.details.picks, valuePred) %}
+picksCondition -> "picks" fetchedIntegerOpValue  {% ([,valuePred]) => genericCondition('picks', (card) => card.details.picks, valuePred) %}
 
-cubesCondition -> "cubes" integerOpValue  {% ([,valuePred]) => genericCondition('cubes', (card) => card.details.cubes, valuePred) %}
+cubesCondition -> "cubes" fetchedIntegerOpValue  {% ([,valuePred]) => genericCondition('cubes', (card) => card.details.cubes, valuePred) %}
 
 collectorNumberCondition -> ("cn"i | "number"i) stringExactOpValue {% ([, valuePred]) => genericCondition('collector_number', cardCollectorNumber, valuePred) %}
 

--- a/nearley/values.ne
+++ b/nearley/values.ne
@@ -9,6 +9,7 @@
 # const manaCostOperation = (op, value) => ...
 # const castableCostOperation = (op, value) => ...
 # const setElementOperation = (value) => ...
+# const fetchedOperation = (op, value) => ...
 
 positiveHalfIntOpValue -> anyOperator positiveHalfIntValue {% ([op, value]) => defaultOperation(op, value) %}
 
@@ -23,6 +24,9 @@ halfIntValue ->
   | "." ("0" | "5") {% ([, digit]) => digit === '5' ? 0.5 : 0 %}
 
 integerOpValue -> anyOperator integerValue {% ([op, value]) => defaultOperation(op, value) %}
+
+# used for fields that are fetched from the database
+fetchedIntegerOpValue -> anyOperator integerValue {% ([op, value]) => fetchedOperation(op, value) %}
 
 integerValue -> [0-9]:+ {% ([digits]) => parseInt(digits.join(''), 10) %}
 

--- a/routes/tools_routes.js
+++ b/routes/tools_routes.js
@@ -39,8 +39,9 @@ async function matchingCards(filter) {
       const history = historyDict.get(card.oracle_id);
       return {
         ...card,
-        picks: history ? history.current.picks : null,
-        cubes: history ? history.current.cubes : null,
+        picks: history ? history.current.picks : undefined,
+        cubes: history ? history.current.cubes : undefined,
+        secondPass: true,
       };
     });
     return filterCardsDetails(cards, filter);

--- a/routes/tools_routes.js
+++ b/routes/tools_routes.js
@@ -24,6 +24,7 @@ const PAGE_SIZE = 96;
 
 async function matchingCards(filter) {
   let cards = carddb.allCards().filter((card) => !card.digital && !card.isToken);
+  cards = filterCardsDetails(cards, filter);
   // In the first pass, cards don't have rating or picks, and so match all those filters.
   // In the second pass, we add that information.
   if (filterUses(filter, 'rating') || filterUses(filter, 'picks') || filterUses(filter, 'cubes')) {
@@ -42,8 +43,11 @@ async function matchingCards(filter) {
         cubes: history ? history.current.cubes : null,
       };
     });
+
+    cards = filterCardsDetails(cards, filter);
   }
-  return filterCardsDetails(cards, filter);
+
+  return cards;
 }
 
 async function topCards(filter, sortField = 'elo', page = 0, direction = 'descending', minPicks = MIN_PICKS) {

--- a/routes/tools_routes.js
+++ b/routes/tools_routes.js
@@ -23,7 +23,7 @@ const MIN_PICKS = 100;
 const PAGE_SIZE = 96;
 
 async function matchingCards(filter) {
-  let cards = carddb.allCards().filter((card) => !card.digital && !card.isToken);
+  let cards = carddb.printedCardList;
   cards = filterCardsDetails(cards, filter);
   // In the first pass, cards don't have rating or picks, and so match all those filters.
   // In the second pass, we add that information.

--- a/routes/tools_routes.js
+++ b/routes/tools_routes.js
@@ -25,20 +25,19 @@ const PAGE_SIZE = 96;
 async function matchingCards(filter) {
   let cards = carddb.printedCardList;
   cards = filterCardsDetails(cards, filter);
-  // In the first pass, cards don't have rating or picks, and so match all those filters.
+  // In the first pass, cards don't have picks or cube information, and so match all those filters.
   // In the second pass, we add that information.
-  if (filterUses(filter, 'rating') || filterUses(filter, 'picks') || filterUses(filter, 'cubes')) {
+  if (filterUses(filter, 'picks') || filterUses(filter, 'cubes')) {
     const oracleIds = cards.map(({ oracle_id }) => oracle_id); // eslint-disable-line camelcase
     const historyObjects = await CardHistory.find(
       { oracleId: { $in: oracleIds } },
-      'oracleId current.rating current.picks current.cubes',
+      'oracleId current.picks current.cubes',
     ).lean();
     const historyDict = new Map(historyObjects.map((h) => [h.oracleId, h]));
     cards = cards.map((card) => {
       const history = historyDict.get(card.oracle_id);
       return {
         ...card,
-        rating: history ? history.current.rating : null,
         picks: history ? history.current.picks : null,
         cubes: history ? history.current.cubes : null,
       };

--- a/routes/tools_routes.js
+++ b/routes/tools_routes.js
@@ -31,13 +31,11 @@ async function matchingCards(filter) {
   // In the first pass, cards don't have picks or cube information, and so match all those filters.
   // In the second pass, we add that information if needed.
   if (DB_FIELDS.some((field) => filterUses(filter, field))) {
-    let dbFilter;
+    let dbFilter = {};
     // if the filter uses *only* database fields, simply fetch the whole database without creating an ID query
     if (usesNonDbField) {
       const oracleIds = cards.map(({ oracle_id }) => oracle_id); // eslint-disable-line camelcase
       dbFilter = { oracleId: { $in: oracleIds } };
-    } else {
-      dbFilter = {};
     }
 
     const historyObjects = await CardHistory.find(dbFilter, 'oracleId current.picks current.cubes').lean();

--- a/routes/tools_routes.js
+++ b/routes/tools_routes.js
@@ -24,26 +24,24 @@ const PAGE_SIZE = 96;
 
 async function matchingCards(filter) {
   let cards = carddb.allCards().filter((card) => !card.digital && !card.isToken);
-  if (filter) {
-    // In the first pass, cards don't have rating or picks, and so match all those filters.
-    // In the second pass, we add that information.
-    if (filterUses(filter, 'rating') || filterUses(filter, 'picks') || filterUses(filter, 'cubes')) {
-      const oracleIds = cards.map(({ oracle_id }) => oracle_id); // eslint-disable-line camelcase
-      const historyObjects = await CardHistory.find(
-        { oracleId: { $in: oracleIds } },
-        'oracleId current.rating current.picks current.cubes',
-      ).lean();
-      const historyDict = new Map(historyObjects.map((h) => [h.oracleId, h]));
-      cards = cards.map((card) => {
-        const history = historyDict.get(card.oracle_id);
-        return {
-          ...card,
-          rating: history ? history.current.rating : null,
-          picks: history ? history.current.picks : null,
-          cubes: history ? history.current.cubes : null,
-        };
-      });
-    }
+  // In the first pass, cards don't have rating or picks, and so match all those filters.
+  // In the second pass, we add that information.
+  if (filterUses(filter, 'rating') || filterUses(filter, 'picks') || filterUses(filter, 'cubes')) {
+    const oracleIds = cards.map(({ oracle_id }) => oracle_id); // eslint-disable-line camelcase
+    const historyObjects = await CardHistory.find(
+      { oracleId: { $in: oracleIds } },
+      'oracleId current.rating current.picks current.cubes',
+    ).lean();
+    const historyDict = new Map(historyObjects.map((h) => [h.oracleId, h]));
+    cards = cards.map((card) => {
+      const history = historyDict.get(card.oracle_id);
+      return {
+        ...card,
+        rating: history ? history.current.rating : null,
+        picks: history ? history.current.picks : null,
+        cubes: history ? history.current.cubes : null,
+      };
+    });
   }
   return filterCardsDetails(cards, filter);
 }

--- a/routes/tools_routes.js
+++ b/routes/tools_routes.js
@@ -47,8 +47,8 @@ async function matchingCards(filter) {
       const history = historyDict.get(card.oracle_id);
       return {
         ...card,
-        picks: history ? history.current.picks : undefined,
-        cubes: history ? history.current.cubes : undefined,
+        picks: history?.current.picks,
+        cubes: history?.current.cubes,
         secondPass: true,
       };
     });

--- a/routes/tools_routes.js
+++ b/routes/tools_routes.js
@@ -26,7 +26,7 @@ async function matchingCards(filter) {
   let cards = carddb.printedCardList;
   cards = filterCardsDetails(cards, filter);
   // In the first pass, cards don't have picks or cube information, and so match all those filters.
-  // In the second pass, we add that information.
+  // In the second pass, we add that information if needed.
   if (filterUses(filter, 'picks') || filterUses(filter, 'cubes')) {
     const oracleIds = cards.map(({ oracle_id }) => oracle_id); // eslint-disable-line camelcase
     const historyObjects = await CardHistory.find(
@@ -34,6 +34,7 @@ async function matchingCards(filter) {
       'oracleId current.picks current.cubes',
     ).lean();
     const historyDict = new Map(historyObjects.map((h) => [h.oracleId, h]));
+
     cards = cards.map((card) => {
       const history = historyDict.get(card.oracle_id);
       return {
@@ -42,8 +43,7 @@ async function matchingCards(filter) {
         cubes: history ? history.current.cubes : null,
       };
     });
-
-    cards = filterCardsDetails(cards, filter);
+    return filterCardsDetails(cards, filter);
   }
 
   return cards;

--- a/serverjs/cards.js
+++ b/serverjs/cards.js
@@ -12,6 +12,7 @@ let data = {
   oracleToId: {},
   english: {},
   _carddict: {},
+  printedCardList: [], // for card filters
 };
 
 const fileToAttribute = {
@@ -123,13 +124,19 @@ function initializeCardDb(dataRoot, skipWatchers) {
       registerFileWatcher(filepath, attribute);
     }
   }
-  return Promise.all(promises).then(() => winston.info('Finished loading carddb.'));
+  return Promise.all(promises)
+    .then(() => {
+      // cache cards used in card filters
+      data.printedCardList = Object.values(data._carddict).filter((card) => !card.digital && !card.isToken);
+    })
+    .then(() => winston.info('Finished loading carddb.'));
 }
 
 function unloadCardDb() {
   for (const attribute of Object.values(fileToAttribute)) {
     delete data[attribute];
   }
+  delete data.printedCardList;
 }
 
 function reasonableCard(card) {

--- a/src/filtering/FilterCards.js
+++ b/src/filtering/FilterCards.js
@@ -10,6 +10,8 @@ export const operatorsRegex = new RegExp(`(?:${ALL_OPERATORS.join('|')})`);
 
 export const filterUses = (filter, name) => (filter?.fieldsUsed?.indexOf?.(name) ?? -1) >= 0;
 
+export const filterUsedFields = (filter) => filter?.fieldsUsed ?? [];
+
 export const filterToString = (filter) => filter?.stringify ?? 'empty filter';
 
 export function makeFilter(filterText) {
@@ -48,6 +50,7 @@ export default {
   operators: ALL_OPERATORS,
   operatorsRegex,
   filterUses,
+  filterUsedFields,
   filterToString,
   makeFilter,
   filterCardsDetails,

--- a/src/filtering/FuncOperations.js
+++ b/src/filtering/FuncOperations.js
@@ -26,7 +26,7 @@ export const defaultOperation = (op, value) => {
 // those fields always have to match in the first filter pass, before the actual values are set for them
 export const fetchedOperation = (op, value) => {
   const defOp = defaultOperation(op, value);
-  return (fieldValue) => typeof fieldValue === 'undefined' || defOp(fieldValue);
+  return (fieldValue, card) => !card.details.secondPass || defOp(fieldValue);
 };
 
 export const stringOperation = (op, value) => {

--- a/src/filtering/FuncOperations.js
+++ b/src/filtering/FuncOperations.js
@@ -22,6 +22,13 @@ export const defaultOperation = (op, value) => {
   }
 };
 
+// Used for fields that are fetched from database - picks, cubes
+// those fields always have to match in the first filter pass, before the actual values are set for them
+export const fetchedOperation = (op, value) => {
+  const defOp = defaultOperation(op, value);
+  return (fieldValue) => typeof fieldValue === 'undefined' || defOp(fieldValue);
+};
+
 export const stringOperation = (op, value) => {
   value = value.toLowerCase();
   switch (op.toString()) {


### PR DESCRIPTION
Hopefully addresses the issues with database-backed filter fields. 

This PR changes the flow of card filtering. Instead of filtering in only a single pass, and fetching the database for the whole collection whenever it's needed, it now works in two steps - the first filters any fields that are present directly in card objects, and the second adds the database information for possible matches. 

The `picks` and `cubes` filters were modified so that they always match on the first pass and only actually compare values on the second pass. In addition, the base collection of objects that the filter operates on is now preloaded in memory (so digital cards and tokens don't have to be filtered out every time), and the database isn't sent an `oracle_id` query in cases when it needs to return all objects anyway. It also changes the value of nonexistent `picks` and `cubes` fields from `null` to `undefined` to prevent the same coercion issues that were discussed in #1805 for card prices.



