### PR TITLE
Crash hotfix

### DIFF
--- a/routes/tools_routes.js
+++ b/routes/tools_routes.js
@@ -45,8 +45,8 @@ async function matchingCards(filter) {
       const history = historyDict.get(card.oracle_id);
       return {
         ...card,
-        picks: history?.current.picks,
-        cubes: history?.current.cubes,
+        picks: history ? history.current.picks : undefined,
+        cubes: history ? history.current.cubes : undefined,
         secondPass: true,
       };
     });


### PR DESCRIPTION
In #1807, I forgot that route files aren't run through Babel. Because Node doesn't support optional chaining, the server would crash on start.