### PR TITLE
Fixed Sample Hand

### DIFF
--- a/src/pages/CubeDeckPage.js
+++ b/src/pages/CubeDeckPage.js
@@ -116,7 +116,7 @@ const CubeDeckPage = ({ user, cube, deck, draft, loginCallback }) => {
             <Collapse isOpen={isOpen} navbar>
               <Nav navbar>
                 <NavItem>
-                  <SampleHandModal deck={deck.seats[seatIndex].main} />
+                  <SampleHandModal deck={deck.seats[seatIndex].deck} />
                 </NavItem>
                 {user && deck.owner === user.id && (
                   <NavItem>


### PR DESCRIPTION
Fixes #1811 
It looks like a typo in #1789 caused a nonexistent `main` object to be passed into the modal instead of the actual `deck` object.