### PR TITLE
Changed Markdown URL handling

### DIFF
--- a/src/components/Markdown.js
+++ b/src/components/Markdown.js
@@ -20,21 +20,16 @@ import { Col, Row, Card, CardBody } from 'reactstrap';
 const AutocardLink = withAutocard('a');
 const Link = withModal('a', LinkModal);
 
-const renderBlockQuote = (node) => {
-  return (
-    <Card className="quote">
-      <CardBody>{node.children}</CardBody>
-    </Card>
-  );
-};
+const renderBlockQuote = (node) => (
+  <Card className="quote">
+    <CardBody>{node.children}</CardBody>
+  </Card>
+);
 
-const renderImage = (node) => {
-  return <img className="markdown-image" src={node.src} alt={node.alt} title={node.title} />;
-};
+const renderImage = (node) => <img className="markdown-image" src={node.src} alt={node.alt} title={node.title} />;
 
 const renderLink = (node) => {
-  const ref = encodeURI(node.href ?? '');
-  console.log(node);
+  const ref = node.href ?? '';
 
   if (isInternalURL(ref)) {
     // heading autolink
@@ -61,9 +56,8 @@ const renderLink = (node) => {
   );
 };
 
-const renderHeading = (node) => {
-  return React.createElement(`h${node.level}`, node.node?.data?.hProperties ?? {}, node.children);
-};
+const renderHeading = (node) =>
+  React.createElement(`h${node.level}`, node.node?.data?.hProperties ?? {}, node.children);
 
 const renderCode = (node) => {
   const mode = getComputedStyle(document.body).getPropertyValue('--mode').trim();
@@ -76,21 +70,15 @@ const renderCode = (node) => {
   );
 };
 
-const renderTable = (node) => {
-  return (
-    <div className="table-responsive">
-      <table className="table table-bordered">{node.children}</table>
-    </div>
-  );
-};
+const renderTable = (node) => (
+  <div className="table-responsive">
+    <table className="table table-bordered">{node.children}</table>
+  </div>
+);
 
-const renderMath = (node) => {
-  return <Latex trusted={false} displayMode>{`$$ ${node.value} $$`}</Latex>;
-};
+const renderMath = (node) => <Latex trusted={false} displayMode>{`$$ ${node.value} $$`}</Latex>;
 
-const renderInlineMath = (node) => {
-  return <Latex trusted={false}>{`$ ${node.value} $`}</Latex>;
-};
+const renderInlineMath = (node) => <Latex trusted={false}>{`$ ${node.value} $`}</Latex>;
 
 const renderUserlink = (node) => {
   const name = node.value;
@@ -132,13 +120,9 @@ const renderCardImage = (node) => {
   );
 };
 
-const renderCentering = (node) => {
-  return <div className="centered-markdown">{node.children}</div>;
-};
+const renderCentering = (node) => <div className="centered-markdown">{node.children}</div>;
 
-const renderCardrow = (node) => {
-  return <Row className="cardRow">{node.children}</Row>;
-};
+const renderCardrow = (node) => <Row className="cardRow">{node.children}</Row>;
 
 const RENDERERS = {
   // overridden defaults


### PR DESCRIPTION
In #1790, we added an `encodeURI` call to the URL we are rendering. That causes an issue where already well-formed URLs can be double-escaped, since `%` isn't treated as a special character (so for example the text `https://cubecobra.com/?q=a%20b` would link to `https://cubecobra.com/?q=a%2520b`). That's bad, and this PR removes that.

Of course, this means that any malformed URLs now won't be encoded, but since users are expected to write actual URLs and not just unescaped strings, that's really on them.

The PR also simplifies the syntax of some renderers that are just simple return statements and removes a chatty `console.log` statement.