### PR TITLE
Fixed pagination inconsistency

### DIFF
--- a/src/components/Paginate.js
+++ b/src/components/Paginate.js
@@ -5,7 +5,12 @@ import { Pagination, PaginationItem, PaginationLink } from 'reactstrap';
 
 const RealPage = ({ index, active, urlF, onClick }) => (
   <PaginationItem active={active === index}>
-    <PaginationLink tag="a" href={urlF(index)} data-index={onClick ? index : undefined} onClick={() => onClick(index)}>
+    <PaginationLink
+      data-index={onClick ? index : undefined}
+      onClick={() => onClick(index)}
+      // the button tag needs to have a set type to not accidentally submit forms
+      {...(urlF ? { tag: 'a', href: urlF(index) } : { tag: 'button', type: 'button' })}
+    >
       {index + 1}
     </PaginationLink>
   </PaginationItem>
@@ -19,7 +24,7 @@ RealPage.propTypes = {
 };
 
 RealPage.defaultProps = {
-  urlF: () => '#',
+  urlF: undefined,
   onClick: () => {},
 };
 
@@ -83,21 +88,19 @@ const Paginate = ({ count, active, urlF, onClick }) => {
     <Pagination aria-label="Table page" className="mt-3">
       <PaginationItem disabled={active === 0}>
         <PaginationLink
-          tag="a"
           previous
-          href={urlF(active - 1)}
           data-index={onClick ? active - 1 : undefined}
           onClick={() => onClick(active - 1)}
+          {...(urlF ? { tag: 'a', href: urlF(active - 1) } : { tag: 'button', type: 'button' })}
         />
       </PaginationItem>
       {count < 8 ? smallPagination : bigPagination}
       <PaginationItem disabled={active === count - 1}>
         <PaginationLink
-          tag="a"
           next
-          href={urlF(active + 1)}
           data-index={onClick ? active + 1 : undefined}
           onClick={() => onClick(active + 1)}
+          {...(urlF ? { tag: 'a', href: urlF(active + 1) } : { tag: 'button', type: 'button' })}
         />
       </PaginationItem>
     </Pagination>
@@ -112,7 +115,7 @@ Paginate.propTypes = {
 };
 
 Paginate.defaultProps = {
-  urlF: () => '#',
+  urlF: undefined,
   onClick: () => {},
 };
 

--- a/src/components/Paginate.js
+++ b/src/components/Paginate.js
@@ -30,7 +30,7 @@ RealPage.defaultProps = {
 
 const FakePage = ({ text }) => (
   <PaginationItem disabled>
-    <PaginationLink tag="a">{text}</PaginationLink>
+    <PaginationLink>{text}</PaginationLink>
   </PaginationItem>
 );
 


### PR DESCRIPTION
### Issue
Since we introduced the `useQueryParam` hook, pagination links that simply set a URL parameter without redirecting to another page would cause the page to refresh with its old parameter in Firefox. 

### Cause
I go into more detail about the possible cause in the Discord channels, but the short version is that pagination links are rendered as `<a href="#">` with an onClick handler that sets the query parameter. Because the parameter is set asynchronously through a `setValue` function of a `useState` hook, some race condition occurs which changes the URL and then reloads the page to the old one.  

### Fix
Don't use `<a href="#">` on pagination links that don't lead to URLs. Aside from causing this inconsistency, it's also wrong on a semantic level.

This PR replaces the default URL generating function of `Paginate` from `() => '#'` to `undefined`. When the function isn't defined, the pagination links are instead rendered as `<button type="button">`, which eliminates this issue, as a button click doesn't have the implicit behavior of directing to a URL.

I tested this manually on as many pages that use pagination as I reasonably could, and while it wasn't all of them, I'm confident this shouldn't break anything.

### Additional notes
The `PaginationLink` component actually renders as a button if a `href` attribute isn't specified (hence the non-functional change to `FakePage`. The reason we need more adjustments than just setting the default URL generator to `() => {}` is that pagination links can appear inside forms (and already do with List View), and a button in a form without a set type has a default type of `submit`, which completely breaks List View as it's currently implemented. To avoid this, we need to manually set the type of button pagination links to `button`.