### PR TITLE
Changed wrong useQueryParam default values

### DIFF
--- a/src/components/CreatorArticles.js
+++ b/src/components/CreatorArticles.js
@@ -13,7 +13,7 @@ const PAGE_SIZE = 24;
 
 const CreatorArticles = ({ user }) => {
   const [articles, setArticles] = useState([]);
-  const [page, setPage] = useQueryParam('page', '0');
+  const [page, setPage] = useQueryParam('page', 0);
   const [pages, setPages] = useState(0);
   const [loading, setLoading] = useState(true);
 

--- a/src/components/PagedList.js
+++ b/src/components/PagedList.js
@@ -5,7 +5,7 @@ import Paginate from 'components/Paginate';
 import useQueryParam from 'hooks/useQueryParam';
 
 const PagedList = ({ pageSize, rows, showBottom, pageWrap }) => {
-  const [page, setPage] = useQueryParam('page', '0');
+  const [page, setPage] = useQueryParam('page', 0);
 
   const validPages = [...Array(Math.ceil(rows.length / pageSize)).keys()];
   const current = Math.min(parseInt(page, 10), validPages.length - 1);

--- a/src/components/PagedList.js
+++ b/src/components/PagedList.js
@@ -5,7 +5,7 @@ import Paginate from 'components/Paginate';
 import useQueryParam from 'hooks/useQueryParam';
 
 const PagedList = ({ pageSize, rows, showBottom, pageWrap }) => {
-  const [page, setPage] = useQueryParam('page', 0);
+  const [page, setPage] = useQueryParam('page', '0');
 
   const validPages = [...Array(Math.ceil(rows.length / pageSize)).keys()];
   const current = Math.min(parseInt(page, 10), validPages.length - 1);

--- a/src/components/PagedTable.js
+++ b/src/components/PagedTable.js
@@ -7,7 +7,7 @@ import Paginate from 'components/Paginate';
 import useQueryParam from 'hooks/useQueryParam';
 
 const PagedTable = ({ pageSize, rows, children, ...props }) => {
-  const [page, setPage] = useQueryParam('page', '0');
+  const [page, setPage] = useQueryParam('page', 0);
 
   const validPages = [...Array(Math.ceil(rows.length / pageSize)).keys()];
   const current = Math.min(parseInt(page, 10), validPages.length - 1);


### PR DESCRIPTION
In some components that use pagination, the default value for the active page is being set to `'0'`. The `Paginate` component expects an integer value in that parameter though, so if a query parameter isn't specified, no pagination link is highlighted as active, because each link compares its (integer) index to the passed `active` value and no integer can match with `'0'` under strict equality.

The fix is as simple as setting the default to be `0` instead.