### PR TITLE
Don't open links to same page in new tab

### DIFF
--- a/src/components/Markdown.js
+++ b/src/components/Markdown.js
@@ -13,7 +13,7 @@ import withAutocard from 'components/WithAutocard';
 import withModal from 'components/WithModal';
 import LinkModal from 'components/LinkModal';
 import FoilCardImage from 'components/FoilCardImage';
-import { isInternalURL } from 'utils/Util';
+import { isInternalURL, isSamePageURL } from 'utils/Util';
 
 import { Col, Row, Card, CardBody } from 'reactstrap';
 
@@ -41,8 +41,9 @@ const renderLink = (node) => {
       );
     }
 
+    const props = isSamePageURL(ref) ? {} : { target: '_blank', rel: 'noopener noreferrer' };
     return (
-      <a target="_blank" rel="noopener noreferrer" href={ref}>
+      <a href={ref} {...props}>
         {node.children}
       </a>
     );

--- a/src/utils/Util.js
+++ b/src/utils/Util.js
@@ -190,6 +190,15 @@ export function isInternalURL(to) {
   }
 }
 
+export function isSamePageURL(to) {
+  try {
+    const url = new URL(to, window.location.origin);
+    return url.hostname === window.location.hostname && url.pathname === window.location.pathname;
+  } catch {
+    return false;
+  }
+}
+
 export default {
   arraysEqual,
   arrayRotate,
@@ -207,4 +216,5 @@ export default {
   getCubeId,
   getCubeDescription,
   isInternalURL,
+  isSamePageURL,
 };

--- a/src/utils/Util.js
+++ b/src/utils/Util.js
@@ -192,7 +192,7 @@ export function isInternalURL(to) {
 
 export function isSamePageURL(to) {
   try {
-    const url = new URL(to, window.location.origin);
+    const url = new URL(to, window.location.href);
     return (
       url.hostname === window.location.hostname &&
       url.pathname === window.location.pathname &&

--- a/src/utils/Util.js
+++ b/src/utils/Util.js
@@ -193,7 +193,11 @@ export function isInternalURL(to) {
 export function isSamePageURL(to) {
   try {
     const url = new URL(to, window.location.origin);
-    return url.hostname === window.location.hostname && url.pathname === window.location.pathname;
+    return (
+      url.hostname === window.location.hostname &&
+      url.pathname === window.location.pathname &&
+      url.search === window.location.search
+    );
   } catch {
     return false;
   }


### PR DESCRIPTION
Resolves #1821.

With this PR, markdown links that lead to the same page the document is rendered on (including query parameters) won't open in a new tab.