### PR TITLE
Safeguards around card download

### DIFF
--- a/serverjs/updatecards.js
+++ b/serverjs/updatecards.js
@@ -786,7 +786,7 @@ async function updateCardbase(ratings = [], basePath = 'private', defaultPath = 
     await module.exports.downloadDefaultCards(basePath, defaultPath, allPath);
   } catch (error) {
     winston.error('Downloading card data failed:');
-    winston.error(error.message);
+    winston.error(error.message, error);
     winston.error('Cardbase was not updated');
     return;
   }
@@ -796,7 +796,7 @@ async function updateCardbase(ratings = [], basePath = 'private', defaultPath = 
     await saveAllCards(ratings, basePath, defaultPath, allPath);
   } catch (error) {
     winston.error('Updating cardbase objects failed:');
-    winston.error(error.message);
+    winston.error(error.message, error);
     winston.error('Cardbase update may not have fully completed');
   }
 

--- a/serverjs/updatecards.js
+++ b/serverjs/updatecards.js
@@ -120,6 +120,9 @@ async function downloadDefaultCards(basePath = 'private', defaultSourcePath = nu
     }
   }
 
+  if (!defaultUrl) throw new Error('URL for Default Cards not found in /bulk-data response');
+  if (!allUrl) throw new Error('URL for All Cards not found in /bulk-data response');
+
   return Promise.all([
     downloadFile(defaultUrl, defaultSourcePath || path.resolve(basePath, 'cards.json')),
     downloadFile(allUrl, allSourcePath || path.resolve(basePath, 'all-cards.json')),

--- a/serverjs/updatecards.js
+++ b/serverjs/updatecards.js
@@ -92,7 +92,12 @@ function downloadFile(url, filePath) {
         }
 
         const stream = response.pipe(file);
-        stream.on('error', (err) => reject(new Error(`Error downloading file from '${url}':\n${err.message}`)));
+        response.on('error', (err) => {
+          reject(new Error(`Response error downloading file from '${url}':\n${err.message}`));
+          response.unpipe(stream);
+          stream.destroy();
+        });
+        stream.on('error', (err) => reject(new Error(`Pipe error downloading file from '${url}':\n${err.message}`)));
         stream.on('finish', resolve);
       })
       .on('error', (err) => reject(new Error(`Download error for '${url}':\n${err.message}`)));
@@ -781,7 +786,7 @@ async function updateCardbase(ratings = [], basePath = 'private', defaultPath = 
   } catch (error) {
     winston.error('Downloading card data failed:');
     winston.error(error.message);
-    winston.error('\nCardbase was not updated');
+    winston.error('Cardbase was not updated');
     return;
   }
 

--- a/serverjs/updatecards.js
+++ b/serverjs/updatecards.js
@@ -770,6 +770,7 @@ async function saveAllCards(ratings = [], basePath = 'private', defaultPath = nu
       .on('close', resolve),
   );
 
+  winston.info('Saving cardbase files...');
   await writeCatalog(basePath);
 }
 
@@ -791,7 +792,13 @@ async function updateCardbase(ratings = [], basePath = 'private', defaultPath = 
   }
 
   winston.info('Creating objects...');
-  await saveAllCards(ratings, basePath, defaultPath, allPath);
+  try {
+    await saveAllCards(ratings, basePath, defaultPath, allPath);
+  } catch (error) {
+    winston.error('Updating cardbase objects failed:');
+    winston.error(error.message);
+    winston.error('Cardbase update may not have fully completed');
+  }
 
   winston.info('Finished cardbase update...');
 }

--- a/serverjs/updatecards.js
+++ b/serverjs/updatecards.js
@@ -91,16 +91,16 @@ function downloadFile(url, filePath) {
 }
 
 async function downloadDefaultCards(basePath = 'private', defaultSourcePath = null, allSourcePath = null) {
-  let defaultUrl = 'https://archive.scryfall.com/json/scryfall-default-cards.json';
-  let allUrl = 'https://archive.scryfall.com/json/scryfall-all-cards.json';
+  let defaultUrl;
+  let allUrl;
 
-  const res = await fetch(`https://api.scryfall.com/bulk-data`);
+  const res = await fetch('https://api.scryfall.com/bulk-data');
   const json = await res.json();
 
   for (const data of json.data) {
-    if (data.name === 'Default Cards') {
+    if (data.type === 'default_cards') {
       defaultUrl = data.download_uri;
-    } else if (data.name === 'All Cards') {
+    } else if (data.type === 'all_cards') {
       allUrl = data.download_uri;
     }
   }


### PR DESCRIPTION
This PR adds some error handling around the card-fetching script. In particular, it wraps the download and the processing in `try...catch` blocks so that errors don't bubble through and crash the whole server, introduces some new checks and handlers so that errors don't propagate too far before throwing, and adds some error logging for easier detection and inspection of issues. It also gets rid of the deprecated `archive.scryfall.com` default for URLs, relying purely on `/bulk-data` information.

As a side note, a possible future improvement to the script would include not running the update if the Scryfall data didn't change. The `/bulk-data` endpoint includes information about when each file was last updated, so keeping a local copy of that timestamp and comparing it to the fetched value can be an easy check for whether we need to download the file at all. 