### PR TITLE
Use filter in CSV export

### DIFF
--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -1433,6 +1433,22 @@ router.get('/download/csv/:id', async (req, res) => {
       const details = carddb.cardFromId(card.cardID);
       card.details = details;
     }
+
+    if (req.query.filter) {
+      const { filter, err } = filterutil.makeFilter(req.query.filter);
+      if (err) {
+        return util.handleRouteError(
+          req,
+          res,
+          'Error parsing filter.',
+          `/cube/list/${encodeURIComponent(req.params.id)}`,
+        );
+      }
+      if (filter) {
+        cube.cards = cube.cards.filter(filter);
+      }
+    }
+
     cube.cards = sortutil.sortForCSVDownload(cube.cards, req.query.primary, req.query.secondary, req.query.tertiary);
 
     res.setHeader('Content-disposition', `attachment; filename=${cube.name.replace(/\W/g, '')}.csv`);

--- a/src/components/CubeListNavbar.js
+++ b/src/components/CubeListNavbar.js
@@ -339,6 +339,11 @@ const CubeListNavbar = ({
   const handleToggleTagColorsModal = useCallback(() => setTagColorsModalOpen(false), []);
   const handleToggleSelectEmptyModal = useCallback(() => setSelectEmptyModalOpen(false), []);
 
+  const enc = encodeURIComponent;
+  const sortUrlSegment = `primary=${enc(primary)}&secondary=${enc(secondary)}&tertiary=${enc(tertiary)}`;
+  const filterString = filter?.stringify ?? '';
+  const filterUrlSegment = filterString ? `&filter=${enc(filterString)}` : '';
+
   return (
     <div className={`usercontrols${className ? ` ${className}` : ''}`}>
       <Navbar expand="md" className="navbar-light">
@@ -430,9 +435,7 @@ const CubeListNavbar = ({
                 )}
                 <DropdownItem href={`/cube/clone/${cubeID}`}>Clone Cube</DropdownItem>
                 <DropdownItem href={`/cube/download/plaintext/${cubeID}`}>Card Names (.txt)</DropdownItem>
-                <DropdownItem
-                  href={`/cube/download/csv/${cubeID}?primary=${primary}&secondary=${secondary}&tertiary=${tertiary}`}
-                >
+                <DropdownItem href={`/cube/download/csv/${cubeID}?${sortUrlSegment}${filterUrlSegment}`}>
                   Comma-Separated (.csv)
                 </DropdownItem>
                 <DropdownItem href={`/cube/download/forge/${cubeID}`}>Forge (.dck)</DropdownItem>


### PR DESCRIPTION
Resolves #1157.

When exporting to CSV, the current filter is now used to determine which cards should be included in the output.