### PR TITLE
Changed "Random Cube" selection results

### DIFF
--- a/routes/root.js
+++ b/routes/root.js
@@ -102,10 +102,16 @@ router.get('/explore', async (req, res) => {
 });
 
 router.get('/random', async (req, res) => {
-  const count = await Cube.estimatedDocumentCount();
-  const random = Math.floor(Math.random() * count);
-  const cube = await Cube.findOne().skip(random).lean();
-  res.redirect(`/cube/overview/${encodeURIComponent(getCubeId(cube))}`);
+  const lastMonth = () => {
+    const ret = new Date();
+    ret.setMonth(ret.getMonth() - 1);
+    return ret;
+  };
+
+  const [randCube] = await Cube.aggregate()
+    .match({ isListed: true, card_count: { $gte: 360 }, date_updated: { $gte: lastMonth() } })
+    .sample(1);
+  res.redirect(`/cube/overview/${encodeURIComponent(getCubeId(randCube))}`);
 });
 
 router.get('/dashboard', async (req, res) => {


### PR DESCRIPTION
Fixes #1826.

Replaces the current random cube search with an aggregate pipeline that lets us easily add filter conditions to the search. The filter is currently set according to #1826, i.e. it returns only listed cubes of at least 360 cards updated in the last month. I'm not completely sure about the performance implications of this, but I'm guessing it won't be a performance bottleneck and we don't need to look at refactoring it until there's a problem. 

Note that this PR assumes we're running MongoDB 3.2 or newer, otherwise `sample` isn't available.