### PR TITLE
Use monospaced font for markdown input

### DIFF
--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -1214,4 +1214,3 @@ a{
 .pvtTable {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !important
 }
-

--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -1082,6 +1082,10 @@ audio {
 	min-height: 20rem;
 }
 
+.markdown-input {
+	font-family: "Fira Mono", monospace;
+}
+
 .card-header {
 	background-color: var(--header);
 }
@@ -1213,3 +1217,4 @@ a{
 .pvtTable {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !important
 }
+

--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -1078,12 +1078,9 @@ audio {
 	width: 100%;
 }
 
-.text-input {
-	min-height: 20rem;
-}
-
 .markdown-input {
 	font-family: "Fira Mono", monospace;
+	min-height: 20rem;
 }
 
 .card-header {

--- a/src/components/TextEntry.js
+++ b/src/components/TextEntry.js
@@ -29,7 +29,7 @@ const TextEntry = ({ name, value, onChange, maxLength }) => {
               type="textarea"
               name="textarea"
               maxLength={maxLength}
-              className="w-100 text-input"
+              className="w-100 text-input markdown-input"
               value={value}
               onChange={onChange}
             />

--- a/src/components/TextEntry.js
+++ b/src/components/TextEntry.js
@@ -29,7 +29,7 @@ const TextEntry = ({ name, value, onChange, maxLength }) => {
               type="textarea"
               name="textarea"
               maxLength={maxLength}
-              className="w-100 text-input markdown-input"
+              className="w-100 markdown-input"
               value={value}
               onChange={onChange}
             />

--- a/views/main.pug
+++ b/views/main.pug
@@ -26,6 +26,7 @@ html(lang='en')
 		link(rel='stylesheet' href='/css/stylesheet.css')
 		link(rel='stylesheet' href='/css/tags.css')
 		link(href='//cdnjs.cloudflare.com/ajax/libs/KaTeX/0.12.0/katex.min.css', rel='stylesheet')
+		link(href='https://code.cdn.mozilla.net/fonts/fira.css' rel='stylesheet')
 		link(href='https://unpkg.com/react-pivottable@0.9.0/pivottable.css', rel='stylesheet')
 
 	body


### PR DESCRIPTION
When writing Markdown source through the `TextEntry` component, the site now uses a monospaced typeface rather than the default sans-serif. I chose Fira Mono for this purpose because it's FOSS, I enjoy how it looks, and I don't feel worried that using Mozilla's CDN will harvest people's data. 

(The change from `.text-input` to `.markdown-input` is nonfunctional, as `TextEntry` is the only place where this class appears)

Some comparison photos:
### New
![mono_new](https://user-images.githubusercontent.com/38463785/110373712-b4d7b180-8047-11eb-94b6-e0247fd1c278.png)
### Old
![mono_old](https://user-images.githubusercontent.com/38463785/110373728-bb662900-8047-11eb-9153-e4253e41e575.png)
