### PR TITLE
Sort type constant

### DIFF
--- a/src/utils/Sort.js
+++ b/src/utils/Sort.js
@@ -262,22 +262,7 @@ function getLabelsRaw(cube, sort) {
     return ['White', 'Blue', 'Black', 'Red', 'Green', 'Colorless'];
   }
   if (sort === 'Type') {
-    return [
-      'Creature',
-      'Planeswalker',
-      'Instant',
-      'Sorcery',
-      'Artifact',
-      'Enchantment',
-      'Conspiracy',
-      'Contraption',
-      'Phenomenon',
-      'Plane',
-      'Scheme',
-      'Vanguard',
-      'Land',
-      'Other',
-    ];
+    return CARD_TYPES.concat(['Other']);
   }
   if (sort === 'Supertype') {
     return ['Snow', 'Legendary', 'Tribal', 'Basic', 'Elite', 'Host', 'Ongoing', 'World'];
@@ -352,48 +337,11 @@ function getLabelsRaw(cube, sort) {
     return [...types];
   }
   if (sort === 'Types-Multicolor') {
-    return [
-      'Creature',
-      'Planeswalker',
-      'Instant',
-      'Sorcery',
-      'Artifact',
-      'Enchantment',
-      'Conspiracy',
-      'Contraption',
-      'Phenomenon',
-      'Plane',
-      'Scheme',
-      'Vanguard',
-      'Azorius',
-      'Dimir',
-      'Rakdos',
-      'Gruul',
-      'Selesnya',
-      'Orzhov',
-      'Golgari',
-      'Simic',
-      'Izzet',
-      'Boros',
-      'Bant',
-      'Esper',
-      'Grixis',
-      'Jund',
-      'Naya',
-      'Abzan',
-      'Jeskai',
-      'Sultai',
-      'Mardu',
-      'Temur',
-      'Non-White',
-      'Non-Blue',
-      'Non-Black',
-      'Non-Red',
-      'Non-Green',
-      'Five Color',
-      'Land',
-      'Other',
-    ];
+    return CARD_TYPES.slice(0, -1)
+      .concat(GUILDS)
+      .concat(SHARDS_AND_WEDGES)
+      .concat(FOUR_AND_FIVE_COLOR)
+      .concat(['Land', 'Other']);
   }
   if (sort === 'Legality') {
     return ['Standard', 'Modern', 'Legacy', 'Vintage', 'Pioneer', 'Brawl', 'Historic', 'Pauper', 'Penny', 'Commander'];

--- a/src/utils/Sort.js
+++ b/src/utils/Sort.js
@@ -55,6 +55,22 @@ const ALL_CMCS = Array.from(Array(33).keys())
   .map((x) => (x / 2).toString())
   .concat(['1000000']);
 
+const CARD_TYPES = [
+  'Creature',
+  'Planeswalker',
+  'Instant',
+  'Sorcery',
+  'Artifact',
+  'Enchantment',
+  'Conspiracy',
+  'Contraption',
+  'Phenomenon',
+  'Plane',
+  'Scheme',
+  'Vanguard',
+  'Land',
+];
+
 const SINGLE_COLOR = ['White', 'Blue', 'Black', 'Red', 'Green'];
 const GUILDS = ['Azorius', 'Dimir', 'Rakdos', 'Gruul', 'Selesnya', 'Orzhov', 'Izzet', 'Golgari', 'Boros', 'Simic'];
 const SHARDS_AND_WEDGES = ['Bant', 'Esper', 'Grixis', 'Jund', 'Naya', 'Mardu', 'Temur', 'Abzan', 'Jeskai', 'Sultai'];


### PR DESCRIPTION
This small PR aims to unify util/Sort.js to prepare it for custom user packages as mentioned in these issues:

User defined sort #509

Easy Add Cycles #213

Modules/Packages (like cycles but broader) #310

Summary:
* Does not change functionality
* Adds `CARD_TYPES` constant in `util/Sort.js`
* Modifies two sorts to use new constant

I ran `npm run test` but I am unfamiliar with how the tests are laid out. I visually inspected localhost:8080 and did not detect a difference in the error messages there.

My Next Steps:
* Define 'Land' category to have single color identity lands separate from colorless or multicolor gold lands

Future work:
* Add custom user labels and add admin-approved packages