### PR TITLE
[styling] - Remove scrolling on direct blog posts

### DIFF
--- a/src/components/BlogPost.js
+++ b/src/components/BlogPost.js
@@ -54,10 +54,12 @@ class BlogPost extends React.Component {
   }
 
   render() {
-    const { post, onEdit } = this.props;
+    const { post, onEdit, noScroll } = this.props;
     if (post.html == 'undefined') {
       post.html = null;
     }
+    let scrollStyle = noScroll ? {} : { overflow: 'auto', maxHeight: '50vh' };
+
     return (
       <Card className="shadowed rounded-0 mb-3">
         <CardHeader className="pl-4 pr-0 pt-2 pb-0">
@@ -81,7 +83,7 @@ class BlogPost extends React.Component {
             <TimeAgo date={post.date} />
           </h6>
         </CardHeader>
-        <div style={{ overflow: 'auto', maxHeight: '50vh' }}>
+        <div style={scrollStyle}>
           {post.changelist && (post.html || post.markdown) ? (
             <Row className="no-gutters">
               <Col className="col-12 col-l-5 col-md-4 col-sm-12 blog-post-border">

--- a/src/pages/BlogPostPage.js
+++ b/src/pages/BlogPostPage.js
@@ -12,7 +12,7 @@ const BlogPostPage = ({ post, user, loginCallback }) => (
   <MainLayout loginCallback={loginCallback} user={user}>
     <Advertisement />
     <DynamicFlash />
-    <BlogPost key={post._id} post={post} canEdit={false} userid={user ? user.id : null} loggedIn={user !== null} />
+    <BlogPost key={post._id} post={post} canEdit={false} noScroll userid={user ? user.id : null} loggedIn={user !== null} />
   </MainLayout>
 );
 

--- a/src/pages/BlogPostPage.js
+++ b/src/pages/BlogPostPage.js
@@ -12,7 +12,14 @@ const BlogPostPage = ({ post, user, loginCallback }) => (
   <MainLayout loginCallback={loginCallback} user={user}>
     <Advertisement />
     <DynamicFlash />
-    <BlogPost key={post._id} post={post} canEdit={false} noScroll userid={user ? user.id : null} loggedIn={user !== null} />
+    <BlogPost
+      key={post._id}
+      post={post}
+      canEdit={false}
+      noScroll
+      userid={user ? user.id : null}
+      loggedIn={user !== null}
+    />
   </MainLayout>
 );
 


### PR DESCRIPTION
Before: 
https://www.loom.com/share/e6b07059a92e44adb656838fac1edb50

After: 
https://www.loom.com/share/e6b07059a92e44adb656838fac1edb50

* Only prohibits scrolling on permalink pages. The cube blog index page is still set to 50vh max
* `noScroll` doesn't seem like a great flag name for me. Let me know if you have a better suggestion.
* the `div` style was set right on the page. I wanted to make minimal changes but I assume this is not best practice. Let me know if this is best practice. I am unsure where all the css files are.
