### PR TITLE
Fixed 4c cards not showing in sorts

### DIFF
--- a/src/utils/Sort.js
+++ b/src/utils/Sort.js
@@ -45,11 +45,11 @@ const SHARD_AND_WEDGE_MAP = {
 };
 
 const FOUR_COLOR_MAP = {
-  UBRG: 'Not-White',
-  WBRG: 'Not-Blue',
-  WURG: 'Not-Black',
-  WUBG: 'Not-Red',
-  WUBR: 'Not-Green',
+  UBRG: 'Non-White',
+  WBRG: 'Non-Blue',
+  WURG: 'Non-Black',
+  WUBG: 'Non-Red',
+  WUBR: 'Non-Green',
 };
 
 const ALL_CMCS = Array.from(Array(33).keys())
@@ -75,7 +75,7 @@ const CARD_TYPES = [
 const SINGLE_COLOR = ['White', 'Blue', 'Black', 'Red', 'Green'];
 const GUILDS = ['Azorius', 'Dimir', 'Rakdos', 'Gruul', 'Selesnya', 'Orzhov', 'Izzet', 'Golgari', 'Boros', 'Simic'];
 const SHARDS_AND_WEDGES = ['Bant', 'Esper', 'Grixis', 'Jund', 'Naya', 'Mardu', 'Temur', 'Abzan', 'Jeskai', 'Sultai'];
-const FOUR_AND_FIVE_COLOR = ['Not-White', 'Not-Blue', 'Not-Black', 'Not-Red', 'Not-Green', 'Five Color'];
+const FOUR_AND_FIVE_COLOR = ['Non-White', 'Non-Blue', 'Non-Black', 'Non-Red', 'Non-Green', 'Five Color'];
 
 const ELO_DEFAULT = 1200;
 


### PR DESCRIPTION
Fixes #1849.

The bucket labels for 4c were written as `Not-X`, but the function assigning labels to cards wrote them as `Non-X`, meaning that 4C cards could never get any appropriate label. This PR unifies the wording to remedy this.