### PR TITLE
Added is:tdfc

### DIFF
--- a/nearley/cardFilters.ne
+++ b/nearley/cardFilters.ne
@@ -172,7 +172,7 @@ notCondition -> "not"i isOpValue {% ([, valuePred]) => negated(genericCondition(
 isOpValue -> ":" isValue {% ([, category]) => CARD_CATEGORY_DETECTORS[category] %}
 
 isValue -> (
-    "gold"i | "twobrid"i | "hybrid"i | "phyrexian"i | "promo"i | "digital"i | "reasonable"i | "dfc"i | "mdfc"i
+    "gold"i | "twobrid"i | "hybrid"i | "phyrexian"i | "promo"i | "digital"i | "reasonable"i | "dfc"i | "mdfc"i |"tdfc"i
   | "meld"i | "transform"i | "split"i | "flip"i | "leveler"i | "commander"i | "spell"i | "permanent"i | "historic"i
   | "vanilla"i | "modal"i | "fullart"i | "foil"i | "nonfoil"i
   | "bikeland"i | "cycleland"i | "bicycleland"i | "bounceland"i | "karoo"i | "canopyland"i | "canland"i | "fetchland"i

--- a/src/utils/Card.js
+++ b/src/utils/Card.js
@@ -217,6 +217,7 @@ export const CARD_CATEGORY_DETECTORS = {
   dfc: (details) => ['transform', 'modal_dfc', 'meld', 'double_faced_token', 'double_sided'].includes(details.layout),
   mdfc: (details) => details.layout === 'modal_dfc',
   meld: (details) => details.layout === 'meld',
+  tdfc: (details) => details.layout === 'transform',
   transform: (details) => details.layout === 'transform',
   flip: (details) => details.layout === 'flip',
   split: (details) => details.layout === 'split',


### PR DESCRIPTION
As an alias for `is:transform` and a nice counterpart to `is:mdfc`, this PR adds the support for `is:tdfc` (which is also Scryfall-compatible).