### PR TITLE
Added "Tags Full" sort

### DIFF
--- a/src/utils/Sort.js
+++ b/src/utils/Sort.js
@@ -284,7 +284,8 @@ function getLabelsRaw(cube, sort) {
     return tags.sort();
   }
   if (sort === 'Tags Full') {
-    return [...getLabelsRaw(cube, 'Tags'), ''];
+    // whitespace around ' Untagged ' to prevent collisions
+    return [...getLabelsRaw(cube, 'Tags'), ' Untagged '];
   }
   if (sort === 'Date Added') {
     const dates = cube.map((card) => card.addedTmsp).sort((a, b) => a - b);
@@ -554,7 +555,8 @@ export function cardGetLabels(card, sort) {
     return card.tags;
   }
   if (sort === 'Tags Full') {
-    return card.tags.length === 0 ? [''] : card.tags;
+    // whitespace around ' Untagged ' to prevent collisions
+    return card.tags.length === 0 ? [' Untagged '] : card.tags;
   }
   if (sort === 'Status') {
     return [card.status];

--- a/src/utils/Sort.js
+++ b/src/utils/Sort.js
@@ -174,6 +174,7 @@ export const SORTS = [
   'Subtype',
   'Supertype',
   'Tags',
+  'Tags Full',
   'Toughness',
   'Type',
   'Types-Multicolor',
@@ -281,6 +282,9 @@ function getLabelsRaw(cube, sort) {
       }
     }
     return tags.sort();
+  }
+  if (sort === 'Tags Full') {
+    return [...getLabelsRaw(cube, 'Tags'), ''];
   }
   if (sort === 'Date Added') {
     const dates = cube.map((card) => card.addedTmsp).sort((a, b) => a - b);
@@ -548,6 +552,9 @@ export function cardGetLabels(card, sort) {
   }
   if (sort === 'Tags') {
     return card.tags;
+  }
+  if (sort === 'Tags Full') {
+    return card.tags.length === 0 ? [''] : card.tags;
   }
   if (sort === 'Status') {
     return [card.status];


### PR DESCRIPTION
The "Tags Full" sort functions the same way as the "Tags" sort, except it adds an "Untagged" column at the end representing cards without a tag. The label has spaces around it so that it won't collide with a user-supplied tag - the tag input field strips leading/trailing whitespace.