### PR TITLE
Added optional 'Other' column to sorts

### DIFF
--- a/models/cube.js
+++ b/models/cube.js
@@ -117,6 +117,7 @@ const cubeSchema = mongoose.Schema({
   date_updated: Date,
   updated_string: String,
   default_sorts: [String],
+  default_show_unsorted: Boolean,
   card_count: Number,
   type: String,
   draft_formats: {

--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -690,7 +690,7 @@ router.get('/compare/:idA/to/:idB', async (req, res) => {
 router.get('/list/:id', async (req, res) => {
   try {
     const fields =
-      'cards maybe name owner card_count type tag_colors default_sorts overrideCategory categoryOverride categoryPrefixes image_uri urlAlias';
+      'cards maybe name owner card_count type tag_colors default_sorts default_show_unsorted overrideCategory categoryOverride categoryPrefixes image_uri urlAlias';
     const cube = await Cube.findOne(buildIdQuery(req.params.id), fields).lean();
     if (!cube) {
       req.flash('danger', 'Cube not found');
@@ -722,6 +722,9 @@ router.get('/list/:id', async (req, res) => {
         defaultView: req.query.view || 'table',
         defaultPrimarySort: req.query.s1 || '',
         defaultSecondarySort: req.query.s2 || '',
+        defaultTertiarySort: req.query.s3 || '',
+        defaultQuaternarySort: req.query.s4 || '',
+        defaultShowUnsorted: req.query.so || '',
         defaultFilterText: req.query.f || '',
         defaultTagColors: cube.tag_colors || [],
         defaultShowTagColors: !req.user || !req.user.hide_tag_colors,
@@ -4111,6 +4114,7 @@ router.post(
     }
 
     cube.default_sorts = req.body.sorts;
+    cube.default_show_unsorted = !!req.body.showOther;
     await cube.save();
     return res.status(200).send({
       success: 'true',

--- a/src/analytics/AnalyticTable.js
+++ b/src/analytics/AnalyticTable.js
@@ -12,8 +12,8 @@ import CubePropType from 'proptypes/CubePropType';
 import { SORTS, cardCanBeSorted, sortGroupsOrdered } from 'utils/Sort';
 import { fromEntries } from 'utils/Util';
 
-const sortWithTotal = (pool, sort) =>
-  [...sortGroupsOrdered(pool, sort), ['Total', pool]].map(([label, cards]) => [
+const sortWithTotal = (pool, sort, showOther) =>
+  [...sortGroupsOrdered(pool, sort, showOther), ['Total', pool]].map(([label, cards]) => [
     label,
     cards.reduce((acc, card) => acc + card.asfan, 0),
   ]);
@@ -30,13 +30,13 @@ const AnalyticTable = ({ cards: allCards, cube, defaultFormatId, setAsfans }) =>
     row,
   ]);
   const [columnCounts, columnLabels] = useMemo(() => {
-    const counts = sortWithTotal(cards, column).filter(([label, count]) => label === 'Total' || count > 0);
+    const counts = sortWithTotal(cards, column, showOther).filter(([label, count]) => label === 'Total' || count > 0);
     return [fromEntries(counts), counts.map(([label]) => label)];
   }, [cards, column]);
   const rows = useMemo(
     () =>
-      [...sortGroupsOrdered(cards, row), ['Total', cards]]
-        .map(([label, groupCards]) => [label, fromEntries(sortWithTotal(groupCards, column))])
+      [...sortGroupsOrdered(cards, row, showOther), ['Total', cards]]
+        .map(([label, groupCards]) => [label, fromEntries(sortWithTotal(groupCards, column, showOther))])
         .map(([rowLabel, columnValues]) => ({
           rowLabel,
           ...fromEntries(columnLabels.map((label) => [label, columnValues[label] ?? 0])),

--- a/src/analytics/AnalyticTable.js
+++ b/src/analytics/AnalyticTable.js
@@ -12,8 +12,8 @@ import CubePropType from 'proptypes/CubePropType';
 import { SORTS, cardCanBeSorted, sortGroupsOrdered } from 'utils/Sort';
 import { fromEntries } from 'utils/Util';
 
-const sortWithTotal = (pool, sort, showOther) =>
-  [...sortGroupsOrdered(pool, sort, showOther), ['Total', pool]].map(([label, cards]) => [
+const sortWithTotal = (pool, sort) =>
+  [...sortGroupsOrdered(pool, sort), ['Total', pool]].map(([label, cards]) => [
     label,
     cards.reduce((acc, card) => acc + card.asfan, 0),
   ]);
@@ -30,13 +30,13 @@ const AnalyticTable = ({ cards: allCards, cube, defaultFormatId, setAsfans }) =>
     row,
   ]);
   const [columnCounts, columnLabels] = useMemo(() => {
-    const counts = sortWithTotal(cards, column, showOther).filter(([label, count]) => label === 'Total' || count > 0);
+    const counts = sortWithTotal(cards, column).filter(([label, count]) => label === 'Total' || count > 0);
     return [fromEntries(counts), counts.map(([label]) => label)];
   }, [cards, column]);
   const rows = useMemo(
     () =>
-      [...sortGroupsOrdered(cards, row, showOther), ['Total', cards]]
-        .map(([label, groupCards]) => [label, fromEntries(sortWithTotal(groupCards, column, showOther))])
+      [...sortGroupsOrdered(cards, row), ['Total', cards]]
+        .map(([label, groupCards]) => [label, fromEntries(sortWithTotal(groupCards, column))])
         .map(([rowLabel, columnValues]) => ({
           rowLabel,
           ...fromEntries(columnLabels.map((label) => [label, columnValues[label] ?? 0])),

--- a/src/components/AutocardListGroup.js
+++ b/src/components/AutocardListGroup.js
@@ -10,9 +10,9 @@ import AutocardListItem from 'components/AutocardListItem';
 import CubeContext from 'contexts/CubeContext';
 import GroupModalContext from 'contexts/GroupModalContext';
 
-const AutocardListGroup = ({ cards, heading, sort, orderedSort, rowTag, noGroupModal }) => {
+const AutocardListGroup = ({ cards, heading, sort, orderedSort, showOther, rowTag, noGroupModal }) => {
   const RowTag = rowTag;
-  const sorted = sortDeep(cards, orderedSort, sort);
+  const sorted = sortDeep(cards, showOther, orderedSort, sort);
   const { canEdit } = useContext(CubeContext);
   const { openGroupModal, setGroupModalCards } = useContext(GroupModalContext);
   const canGroupModal = !noGroupModal && canEdit;

--- a/src/components/AutocardListGroup.js
+++ b/src/components/AutocardListGroup.js
@@ -53,6 +53,7 @@ AutocardListGroup.propTypes = {
   heading: PropTypes.node.isRequired,
   sort: PropTypes.string,
   orderedSort: PropTypes.string,
+  showOther: PropTypes.bool,
 };
 
 AutocardListGroup.defaultProps = {
@@ -60,6 +61,7 @@ AutocardListGroup.defaultProps = {
   noGroupModal: false,
   sort: 'CMC-Full',
   orderedSort: 'Alphabetical',
+  showOther: false,
 };
 
 export default AutocardListGroup;

--- a/src/components/CompareView.js
+++ b/src/components/CompareView.js
@@ -44,7 +44,7 @@ const CompareGroup = ({ heading, both, onlyA, onlyB }) => {
 };
 
 const CompareViewRaw = ({ cards, primary, secondary, showOther, both, onlyA, onlyB, ...props }) => {
-  let columns = sortIntoGroups(cards, primary);
+  let columns = sortIntoGroups(cards, primary, showOther);
   let columnCounts = {};
   let bothCounts = { total: 0 };
   let onlyACounts = { total: 0 };
@@ -78,7 +78,7 @@ const CompareViewRaw = ({ cards, primary, secondary, showOther, both, onlyA, onl
     onlyACounts['total'] += onlyACount;
     onlyBCounts[columnLabel] = onlyBCount;
     onlyBCounts['total'] += onlyBCount;
-    columns[columnLabel] = sortIntoGroups(columns[columnLabel], secondary);
+    columns[columnLabel] = sortIntoGroups(columns[columnLabel], secondary, showOther);
   }
   const bothCopy = both.slice(0);
   const onlyACopy = onlyA.slice(0);

--- a/src/components/CompareView.js
+++ b/src/components/CompareView.js
@@ -43,7 +43,7 @@ const CompareGroup = ({ heading, both, onlyA, onlyB }) => {
   );
 };
 
-const CompareViewRaw = ({ cards, primary, secondary, both, onlyA, onlyB, ...props }) => {
+const CompareViewRaw = ({ cards, primary, secondary, showOther, both, onlyA, onlyB, ...props }) => {
   let columns = sortIntoGroups(cards, primary);
   let columnCounts = {};
   let bothCounts = { total: 0 };
@@ -115,7 +115,7 @@ const CompareViewRaw = ({ cards, primary, secondary, both, onlyA, onlyB, ...prop
           </Row>
         </div>
       }
-      {getLabels(cards, primary)
+      {getLabels(cards, primary, showOther)
         .filter((columnLabel) => columns[columnLabel])
         .map((columnLabel) => {
           let column = columns[columnLabel];
@@ -149,7 +149,7 @@ const CompareViewRaw = ({ cards, primary, secondary, both, onlyA, onlyB, ...prop
                     </Col>
                   </Row>
                 </div>
-                {getLabels(column, secondary)
+                {getLabels(column, secondary, showOther)
                   .filter((label) => column[label])
                   .map((label) => {
                     let group = column[label];
@@ -190,7 +190,8 @@ const CompareViewRaw = ({ cards, primary, secondary, both, onlyA, onlyB, ...prop
 
 const CompareView = (props) => (
   <SortContext.Consumer>
-    {({ primary, secondary }) => <CompareViewRaw primary={primary} secondary={secondary} {...props} />}
+    {({ primary, secondary, showOther }) =>
+      <CompareViewRaw primary={primary} secondary={secondary} showOther={showOther} {...props} />}
   </SortContext.Consumer>
 );
 

--- a/src/components/CompareView.js
+++ b/src/components/CompareView.js
@@ -190,8 +190,9 @@ const CompareViewRaw = ({ cards, primary, secondary, showOther, both, onlyA, onl
 
 const CompareView = (props) => (
   <SortContext.Consumer>
-    {({ primary, secondary, showOther }) =>
-      <CompareViewRaw primary={primary} secondary={secondary} showOther={showOther} {...props} />}
+    {({ primary, secondary, showOther }) => (
+      <CompareViewRaw primary={primary} secondary={secondary} showOther={showOther} {...props} />
+    )}
   </SortContext.Consumer>
 );
 

--- a/src/components/CubeListNavbar.js
+++ b/src/components/CubeListNavbar.js
@@ -270,9 +270,13 @@ const CubeListNavbar = ({
   setOpenCollapse,
   defaultPrimarySort,
   defaultSecondarySort,
+  defaultTertiarySort,
+  defaultQuaternarySort,
+  defaultShowUnsorted,
   sorts,
   setSorts,
   defaultSorts,
+  cubeDefaultShowUnsorted,
   defaultFilterText,
   filter,
   setFilter,
@@ -452,9 +456,13 @@ const CubeListNavbar = ({
       <SortCollapse
         defaultPrimarySort={defaultPrimarySort}
         defaultSecondarySort={defaultSecondarySort}
+        defaultTertiarySort={defaultTertiarySort}
+        defaultQuaternarySort={defaultQuaternarySort}
+        defaultShowUnsorted={defaultShowUnsorted}
         sorts={sorts}
         setSorts={setSorts}
         defaultSorts={defaultSorts}
+        cubeDefaultShowUnsorted={cubeDefaultShowUnsorted}
         isOpen={openCollapse === 'sort'}
       />
       <FilterCollapse
@@ -479,9 +487,13 @@ CubeListNavbar.propTypes = {
   setOpenCollapse: PropTypes.func.isRequired,
   defaultPrimarySort: PropTypes.string.isRequired,
   defaultSecondarySort: PropTypes.string.isRequired,
+  defaultTertiarySort: PropTypes.string.isRequired,
+  defaultQuaternarySort: PropTypes.string.isRequired,
+  defaultShowUnsorted: PropTypes.string.isRequired,
   sorts: PropTypes.arrayOf(PropTypes.string),
   setSorts: PropTypes.func.isRequired,
   defaultSorts: PropTypes.arrayOf(PropTypes.string).isRequired,
+  cubeDefaultShowUnsorted: PropTypes.bool.isRequired,
   defaultFilterText: PropTypes.string.isRequired,
   filter: PropTypes.func,
   setFilter: PropTypes.func.isRequired,

--- a/src/components/CurveView.js
+++ b/src/components/CurveView.js
@@ -12,7 +12,7 @@ import SortContext from 'contexts/SortContext';
 const cmc2Labels = getLabels(null, 'CMC2');
 
 const TypeRow = ({ cardType, group }) => {
-  const sorted = fromEntries(sortDeep(group, 'Alphabetical', 'CMC2'));
+  const sorted = fromEntries(sortDeep(group, false, 'Alphabetical', 'CMC2'));
   return (
     <>
       <h6>
@@ -46,7 +46,7 @@ const ColorCard = ({ color, group }) => (
       </h5>
     </CardHeader>
     <CardBody>
-      {sortDeep(group, 'Alphabetical', 'Creature/Non-Creature').map(([label, cncGroup]) => (
+      {sortDeep(group, false, 'Alphabetical', 'Creature/Non-Creature').map(([label, cncGroup]) => (
         <TypeRow key={label} cardType={label} group={cncGroup} />
       ))}
     </CardBody>
@@ -59,13 +59,13 @@ ColorCard.propTypes = {
 };
 
 const CurveView = ({ cards, ...props }) => {
-  const { primary } = useContext(SortContext);
+  const { primary, showOther } = useContext(SortContext);
 
   // We call the groups color and type even though they might be other sorts.
   return (
     <Row {...props}>
       <Col>
-        {sortDeep(cards, 'Alphabetical', primary).map(([color, group]) => (
+        {sortDeep(cards, showOther, 'Alphabetical', primary).map(([color, group]) => (
           <ColorCard key={color} color={color} group={group} />
         ))}
       </Col>

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -339,7 +339,7 @@ const ListView = ({ cards }) => {
 
   const { cube } = useContext(CubeContext);
   const { setGroupModalCards } = useContext(GroupModalContext);
-  const { primary, secondary, tertiary, quaternary } = useContext(SortContext);
+  const { primary, secondary, tertiary, quaternary, showOther } = useContext(SortContext);
 
   const { addAlert, alerts } = useAlerts();
 
@@ -403,7 +403,7 @@ const ListView = ({ cards }) => {
     [checked, cards, setGroupModalCards],
   );
 
-  const sorted = sortDeep(cards, quaternary, primary, secondary, tertiary);
+  const sorted = sortDeep(cards, showOther, quaternary, primary, secondary, tertiary);
 
   const rows = sorted.map(([, group1]) =>
     group1.map(([, group2]) =>

--- a/src/components/SortCollapse.js
+++ b/src/components/SortCollapse.js
@@ -20,7 +20,7 @@ const SortCollapse = ({
 }) => {
   const [alerts, setAlerts] = useState([]);
   const { canEdit, cubeID } = useContext(CubeContext);
-  const { primary, secondary, tertiary, quaternary, changeSort } = useContext(SortContext);
+  const { primary, secondary, tertiary, quaternary, showOther, changeSort } = useContext(SortContext);
 
   const formSorts = (src) => {
     return [src[0] || 'Color Category', src[1] || 'Types-Multicolor', src[2] || 'CMC', src[3] || 'Alphabetical'];
@@ -235,6 +235,13 @@ const SortCollapse = ({
                 Save as Default Sort
               </Button>
             )}
+            <Button
+              color={showOther ? 'danger' : 'success'}
+              className="mr-sm-2 mb-3"
+              onClick={() => changeSort({ showOther: !showOther })}
+            >
+              {showOther ? 'Hide' : 'Show'} Unsorted Cards
+            </Button>
           </Col>
         </Row>
       </Container>

--- a/src/components/SortCollapse.js
+++ b/src/components/SortCollapse.js
@@ -8,6 +8,7 @@ import { SORTS, ORDERED_SORTS } from 'utils/Sort';
 import CubeContext from 'contexts/CubeContext';
 import SortContext from 'contexts/SortContext';
 import Query from 'utils/Query';
+import Tooltip from 'components/Tooltip';
 
 const SortCollapse = ({
   defaultPrimarySort,
@@ -268,7 +269,9 @@ const SortCollapse = ({
                 changeSort({ showOther: newShowOther });
               }}
             >
-              {showOther ? 'Hide' : 'Show'} Unsorted Cards
+              <Tooltip text="Creates a separate column for cards that would be hidden otherwise.">
+                {showOther ? 'Hide' : 'Show'} Unsorted Cards
+              </Tooltip>
             </Button>
           </Col>
         </Row>

--- a/src/components/TableView.js
+++ b/src/components/TableView.js
@@ -43,6 +43,7 @@ const TableView = ({ cards, rowTag, noGroupModal, className, ...props }) => {
                 noGroupModal={noGroupModal}
                 sort={tertiary}
                 orderedSort={quaternary}
+                showOther={showOther}
               />
             ))}
           </Col>

--- a/src/components/TableView.js
+++ b/src/components/TableView.js
@@ -12,10 +12,10 @@ import DisplayContext from 'contexts/DisplayContext';
 import SortContext from 'contexts/SortContext';
 
 const TableView = ({ cards, rowTag, noGroupModal, className, ...props }) => {
-  const { primary, secondary, tertiary, quaternary } = useContext(SortContext);
+  const { primary, secondary, tertiary, quaternary, showOther } = useContext(SortContext);
   const { compressedView } = useContext(DisplayContext);
 
-  const sorted = sortDeep(cards, quaternary, primary, secondary);
+  const sorted = sortDeep(cards, showOther, quaternary, primary, secondary);
 
   return (
     <div className={`table-view-container${className ? ` ${className}` : ''}`}>

--- a/src/components/VisualSpoiler.js
+++ b/src/components/VisualSpoiler.js
@@ -12,8 +12,8 @@ import CardGrid from 'components/CardGrid';
 const VisualSpoiler = ({ cards }) => {
   const [scale, setScale] = useState('medium');
 
-  const { primary, secondary, tertiary, quaternary } = useContext(SortContext);
-  const sorted = sortDeep(cards, quaternary, primary, secondary, tertiary);
+  const { primary, secondary, tertiary, quaternary, showOther } = useContext(SortContext);
+  const sorted = sortDeep(cards, showOther, quaternary, primary, secondary, tertiary);
   const cardList = sorted
     .map((tuple1) => tuple1[1].map((tuple2) => tuple2[1].map((tuple3) => tuple3[1].map((card) => card))))
     .flat(4);

--- a/src/contexts/SortContext.js
+++ b/src/contexts/SortContext.js
@@ -6,6 +6,7 @@ const SortContext = React.createContext({
   secondary: 'Types-Multicolor',
   tertiary: 'CMC',
   quaternary: 'Alphabetical',
+  showOther: false,
 });
 
 export class SortContextProvider extends React.Component {
@@ -18,6 +19,7 @@ export class SortContextProvider extends React.Component {
         tertiary = 'CMC',
         quaternary = 'Alphabetical',
       ],
+      showOther = false,
     } = this.props;
 
     this.state = {
@@ -25,6 +27,7 @@ export class SortContextProvider extends React.Component {
       secondary,
       tertiary,
       quaternary,
+      showOther,
     };
 
     this.changeSort = this.changeSort.bind(this);
@@ -58,6 +61,7 @@ export class SortContextProvider extends React.Component {
 
 SortContextProvider.propTypes = {
   defaultSorts: PropTypes.arrayOf(PropTypes.string).isRequired,
+  showOther: PropTypes.bool.isRequired,
 };
 
 SortContext.Wrapped = (Tag) => (props) => (

--- a/src/pages/CubeListPage.js
+++ b/src/pages/CubeListPage.js
@@ -33,6 +33,9 @@ const CubeListPageRaw = ({
   defaultShowTagColors,
   defaultPrimarySort,
   defaultSecondarySort,
+  defaultTertiarySort,
+  defaultQuaternarySort,
+  defaultShowUnsorted,
 }) => {
   const { cube, canEdit } = useContext(CubeContext);
 
@@ -66,7 +69,7 @@ const CubeListPageRaw = ({
   }, [filter, cube]);
 
   return (
-    <SortContextProvider defaultSorts={cube.default_sorts} showOther={false}>
+    <SortContextProvider defaultSorts={cube.default_sorts} showOther={!!cube.default_show_unsorted}>
       <DisplayContextProvider cubeID={cube._id}>
         <TagContextProvider
           cubeID={cube._id}
@@ -84,9 +87,13 @@ const CubeListPageRaw = ({
                   setOpenCollapse={setOpenCollapse}
                   defaultPrimarySort={defaultPrimarySort}
                   defaultSecondarySort={defaultSecondarySort}
+                  defaultTertiarySort={defaultTertiarySort}
+                  defaultQuaternarySort={defaultQuaternarySort}
+                  defaultShowUnsorted={defaultShowUnsorted}
                   sorts={sorts}
                   setSorts={setSorts}
                   defaultSorts={cube.default_sorts}
+                  cubeDefaultShowUnsorted={cube.default_show_unsorted}
                   defaultFilterText={defaultFilterText}
                   filter={filter}
                   setFilter={setFilter}
@@ -131,6 +138,9 @@ CubeListPageRaw.propTypes = {
   defaultView: PropTypes.string.isRequired,
   defaultPrimarySort: PropTypes.string.isRequired,
   defaultSecondarySort: PropTypes.string.isRequired,
+  defaultTertiarySort: PropTypes.string.isRequired,
+  defaultQuaternarySort: PropTypes.string.isRequired,
+  defaultShowUnsorted: PropTypes.bool.isRequired,
 };
 
 const CubeListPage = ({
@@ -141,6 +151,9 @@ const CubeListPage = ({
   defaultView,
   defaultPrimarySort,
   defaultSecondarySort,
+  defaultTertiarySort,
+  defaultQuaternarySort,
+  defaultShowUnsorted,
   loginCallback,
 }) => (
   <MainLayout loginCallback={loginCallback} user={user}>
@@ -151,6 +164,9 @@ const CubeListPage = ({
         defaultView={defaultView}
         defaultPrimarySort={defaultPrimarySort}
         defaultSecondarySort={defaultSecondarySort}
+        defaultTertiarySort={defaultTertiarySort}
+        defaultQuaternarySort={defaultQuaternarySort}
+        defaultShowUnsorted={defaultShowUnsorted}
       />
     </CubeLayout>
   </MainLayout>
@@ -173,6 +189,9 @@ CubeListPage.propTypes = {
   defaultView: PropTypes.string.isRequired,
   defaultPrimarySort: PropTypes.string.isRequired,
   defaultSecondarySort: PropTypes.string.isRequired,
+  defaultTertiarySort: PropTypes.string.isRequired,
+  defaultQuaternarySort: PropTypes.string.isRequired,
+  defaultShowUnsorted: PropTypes.bool.isRequired,
   user: UserPropType,
   loginCallback: PropTypes.string,
 };

--- a/src/pages/CubeListPage.js
+++ b/src/pages/CubeListPage.js
@@ -66,7 +66,7 @@ const CubeListPageRaw = ({
   }, [filter, cube]);
 
   return (
-    <SortContextProvider defaultSorts={cube.default_sorts}>
+    <SortContextProvider defaultSorts={cube.default_sorts} showOther={false}>
       <DisplayContextProvider cubeID={cube._id}>
         <TagContextProvider
           cubeID={cube._id}

--- a/src/utils/Sort.js
+++ b/src/utils/Sort.js
@@ -175,7 +175,6 @@ export const SORTS = [
   'Subtype',
   'Supertype',
   'Tags',
-  'Tags Full',
   'Toughness',
   'Type',
   'Types-Multicolor',
@@ -275,10 +274,6 @@ function getLabelsRaw(cube, sort, showOther) {
       }
     }
     ret = tags.sort();
-  } else if (sort === 'Tags Full') {
-    // TODO remove
-    // whitespace around ' Untagged ' to prevent collisions
-    ret = [...getLabelsRaw(cube, 'Tags'), ' Untagged '];
   } else if (sort === 'Date Added') {
     const dates = cube.map((card) => card.addedTmsp).sort((a, b) => a - b);
     const days = dates.map((date) => ISODateToYYYYMMDD(date));
@@ -421,6 +416,7 @@ function getLabelsRaw(cube, sort, showOther) {
   }
   /* End of sort options */
 
+  // whitespace around 'Other' to prevent collisions
   return showOther ? [...ret, ' Other '] : ret;
 }
 
@@ -510,9 +506,6 @@ export function cardGetLabels(card, sort, showOther) {
     }
   } else if (sort === 'Tags') {
     ret = card.tags;
-  } else if (sort === 'Tags Full') {
-    // whitespace around ' Untagged ' to prevent collisions
-    ret = card.tags.length === 0 ? [' Untagged '] : card.tags;
   } else if (sort === 'Status') {
     ret = [card.status];
   } else if (sort === 'Finish') {
@@ -655,6 +648,7 @@ export function cardGetLabels(card, sort, showOther) {
   /* End of sort options */
 
   if (showOther && ret.length === 0) {
+    // whitespace around 'Other' to prevent collisions
     ret = [' Other '];
   }
   return ret;

--- a/src/utils/Sort.js
+++ b/src/utils/Sort.js
@@ -233,44 +233,45 @@ function getEloBucket(elo) {
   return `${bucketFloor}-${bucketFloor + 49}`;
 }
 
-function getLabelsRaw(cube, sort) {
+function getLabelsRaw(cube, sort, showOther) {
+  let ret = [];
   if (sort === 'Color Category') {
-    return ['White', 'Blue', 'Black', 'Red', 'Green', 'Hybrid', 'Multicolored', 'Colorless', 'Lands'];
+    ret = ['White', 'Blue', 'Black', 'Red', 'Green', 'Hybrid', 'Multicolored', 'Colorless', 'Lands'];
   }
   if (sort === 'Color Category Full') {
-    return SINGLE_COLOR.concat(['Colorless'])
+    ret = SINGLE_COLOR.concat(['Colorless'])
       .concat(GUILDS)
       .concat(SHARDS_AND_WEDGES)
       .concat(FOUR_AND_FIVE_COLOR)
       .concat(['Lands']);
   }
   if (sort === 'Color Identity') {
-    return ['White', 'Blue', 'Black', 'Red', 'Green', 'Multicolored', 'Colorless'];
+    ret = ['White', 'Blue', 'Black', 'Red', 'Green', 'Multicolored', 'Colorless'];
   }
   if (sort === 'Color Identity Full') {
-    return SINGLE_COLOR.concat(['Colorless']).concat(GUILDS).concat(SHARDS_AND_WEDGES).concat(FOUR_AND_FIVE_COLOR);
+    ret = SINGLE_COLOR.concat(['Colorless']).concat(GUILDS).concat(SHARDS_AND_WEDGES).concat(FOUR_AND_FIVE_COLOR);
   }
   if (sort === 'Color Combination Includes' || sort === 'Includes Color Combination') {
-    return ['Colorless'].concat(SINGLE_COLOR).concat(GUILDS).concat(SHARDS_AND_WEDGES).concat(FOUR_AND_FIVE_COLOR);
+    ret = ['Colorless'].concat(SINGLE_COLOR).concat(GUILDS).concat(SHARDS_AND_WEDGES).concat(FOUR_AND_FIVE_COLOR);
   }
   if (sort === 'CMC') {
-    return ['0', '1', '2', '3', '4', '5', '6', '7', '8+'];
+    ret = ['0', '1', '2', '3', '4', '5', '6', '7', '8+'];
   }
   if (sort === 'CMC2') {
-    return ['0-1', '2', '3', '4', '5', '6', '7+'];
+    ret = ['0-1', '2', '3', '4', '5', '6', '7+'];
   }
   if (sort === 'CMC-Full') {
     // All CMCs from 0-16, with halves included, plus Gleemax at 1,000,000.
-    return ALL_CMCS;
+    ret = ALL_CMCS;
   }
   if (sort === 'Color') {
-    return ['White', 'Blue', 'Black', 'Red', 'Green', 'Colorless'];
+    ret = ['White', 'Blue', 'Black', 'Red', 'Green', 'Colorless'];
   }
   if (sort === 'Type') {
-    return CARD_TYPES.concat(['Other']);
+    ret = CARD_TYPES.concat(['Other']);
   }
   if (sort === 'Supertype') {
-    return ['Snow', 'Legendary', 'Tribal', 'Basic', 'Elite', 'Host', 'Ongoing', 'World'];
+    ret = ['Snow', 'Legendary', 'Tribal', 'Basic', 'Elite', 'Host', 'Ongoing', 'World'];
   }
   if (sort === 'Tags') {
     const tags = [];
@@ -281,31 +282,31 @@ function getLabelsRaw(cube, sort) {
         }
       }
     }
-    return tags.sort();
+    ret = tags.sort();
   }
   if (sort === 'Tags Full') {
     // whitespace around ' Untagged ' to prevent collisions
-    return [...getLabelsRaw(cube, 'Tags'), ' Untagged '];
+    ret = [...getLabelsRaw(cube, 'Tags'), ' Untagged '];
   }
   if (sort === 'Date Added') {
     const dates = cube.map((card) => card.addedTmsp).sort((a, b) => a - b);
     const days = dates.map((date) => ISODateToYYYYMMDD(date));
-    return removeAdjacentDuplicates(days);
+    ret = removeAdjacentDuplicates(days);
   }
   if (sort === 'Status') {
-    return ['Not Owned', 'Ordered', 'Owned', 'Premium Owned', 'Proxied'];
+    ret = ['Not Owned', 'Ordered', 'Owned', 'Premium Owned', 'Proxied'];
   }
   if (sort === 'Finish') {
-    return ['Non-foil', 'Foil'];
+    ret = ['Non-foil', 'Foil'];
   }
   if (sort === 'Guilds') {
-    return GUILDS;
+    ret = GUILDS;
   }
   if (sort === 'Shards / Wedges') {
-    return SHARDS_AND_WEDGES;
+    ret = SHARDS_AND_WEDGES;
   }
   if (sort === 'Color Count') {
-    return ['0', '1', '2', '3', '4', '5'];
+    ret = ['0', '1', '2', '3', '4', '5'];
   }
   if (sort === 'Set') {
     const sets = [];
@@ -314,7 +315,7 @@ function getLabelsRaw(cube, sort) {
         sets.push(card.details.set.toUpperCase());
       }
     }
-    return sets.sort();
+    ret = sets.sort();
   }
   if (sort === 'Artist') {
     const artists = [];
@@ -323,13 +324,13 @@ function getLabelsRaw(cube, sort) {
         artists.push(card.details.artist);
       }
     }
-    return artists.sort();
+    ret = artists.sort();
   }
   if (sort === 'Rarity') {
-    return ['Common', 'Uncommon', 'Rare', 'Mythic', 'Special'];
+    ret = ['Common', 'Uncommon', 'Rare', 'Mythic', 'Special'];
   }
   if (sort === 'Unsorted') {
-    return ['All'];
+    ret = ['All'];
   }
   if (sort === 'Subtype') {
     const types = new Set();
@@ -343,17 +344,17 @@ function getLabelsRaw(cube, sort) {
         }
       }
     }
-    return [...types];
+    ret = [...types];
   }
   if (sort === 'Types-Multicolor') {
-    return CARD_TYPES.slice(0, -1)
+    ret = CARD_TYPES.slice(0, -1)
       .concat(GUILDS)
       .concat(SHARDS_AND_WEDGES)
       .concat(FOUR_AND_FIVE_COLOR)
       .concat(['Land', 'Other']);
   }
   if (sort === 'Legality') {
-    return ['Standard', 'Modern', 'Legacy', 'Vintage', 'Pioneer', 'Brawl', 'Historic', 'Pauper', 'Penny', 'Commander'];
+    ret = ['Standard', 'Modern', 'Legacy', 'Vintage', 'Pioneer', 'Brawl', 'Historic', 'Pauper', 'Penny', 'Commander'];
   }
   if (sort === 'Power') {
     const items = [];
@@ -364,7 +365,7 @@ function getLabelsRaw(cube, sort) {
         }
       }
     }
-    return items.sort(defaultSort);
+    ret = items.sort(defaultSort);
   }
   if (sort === 'Toughness') {
     const items = [];
@@ -375,7 +376,7 @@ function getLabelsRaw(cube, sort) {
         }
       }
     }
-    return items.sort(defaultSort);
+    ret = items.sort(defaultSort);
   }
   if (sort === 'Loyalty') {
     const items = [];
@@ -386,13 +387,13 @@ function getLabelsRaw(cube, sort) {
         }
       }
     }
-    return items.sort(defaultSort);
+    ret = items.sort(defaultSort);
   }
   if (sort === 'Manacost Type') {
-    return ['Gold', 'Hybrid', 'Phyrexian'];
+    ret = ['Gold', 'Hybrid', 'Phyrexian'];
   }
   if (sort === 'Creature/Non-Creature') {
-    return ['Creature', 'Non-Creature'];
+    ret = ['Creature', 'Non-Creature'];
   }
   if (['Price', 'Price USD', 'Price Foil', 'Price USD Foil'].includes(sort)) {
     const labels = [];
@@ -400,7 +401,7 @@ function getLabelsRaw(cube, sort) {
       labels.push(priceBucketLabel(i, '$'));
     }
     labels.push('No Price Available');
-    return labels;
+    ret = labels;
   }
   if (sort === 'Price EUR') {
     const labels = [];
@@ -408,7 +409,7 @@ function getLabelsRaw(cube, sort) {
       labels.push(priceBucketLabel(i, '€'));
     }
     labels.push('No Price Available');
-    return labels;
+    ret = labels;
   }
   if (sort === 'MTGO TIX') {
     const labels = [];
@@ -416,25 +417,25 @@ function getLabelsRaw(cube, sort) {
       labels.push(priceBucketLabel(i, ''));
     }
     labels.push('No Price Available');
-    return labels;
+    ret = labels;
   }
   if (sort === 'Devotion to White') {
-    return allDevotions(cube, 'W');
+    ret = allDevotions(cube, 'W');
   }
   if (sort === 'Devotion to Blue') {
-    return allDevotions(cube, 'U');
+    ret = allDevotions(cube, 'U');
   }
   if (sort === 'Devotion to Black') {
-    return allDevotions(cube, 'B');
+    ret = allDevotions(cube, 'B');
   }
   if (sort === 'Devotion to Red') {
-    return allDevotions(cube, 'R');
+    ret = allDevotions(cube, 'R');
   }
   if (sort === 'Devotion to Green') {
-    return allDevotions(cube, 'G');
+    ret = allDevotions(cube, 'G');
   }
   if (sort === 'Unsorted') {
-    return ['All'];
+    ret = ['All'];
   }
   if (sort === 'Elo') {
     let elos = [];
@@ -452,10 +453,14 @@ function getLabelsRaw(cube, sort) {
         res.push(bucket);
       }
     }
-    return res;
+    ret = res;
   }
-  // Unrecognized sort
-  return [];
+
+  if (showOther) {
+    ret.push(' Other ');
+  }
+
+  return ret;
 }
 
 function cmcToNumber(card) {
@@ -466,65 +471,66 @@ function cmcToNumber(card) {
   return cmc;
 }
 
-export function cardGetLabels(card, sort) {
+export function cardGetLabels(card, sort, showOther) {
+  let ret = [];
   if (sort === 'Color Category') {
-    return [card.colorCategory ?? GetColorCategory(cardType(card), cardColorIdentity(card))];
+    ret = [card.colorCategory ?? GetColorCategory(cardType(card), cardColorIdentity(card))];
   }
   if (sort === 'Color Category Full') {
     const colorCategory = card.colorCategory ?? GetColorCategory(cardType(card), cardColorIdentity(card));
     if (colorCategory === 'Multicolored') {
-      return [getColorCombination(cardColorIdentity(card))];
+      ret = [getColorCombination(cardColorIdentity(card))];
     }
-    return [colorCategory];
+    ret = [colorCategory];
   }
   if (sort === 'Color Identity') {
-    return [GetColorIdentity(cardColorIdentity(card))];
+    ret = [GetColorIdentity(cardColorIdentity(card))];
   }
   if (sort === 'Color Identity Full') {
-    return [getColorCombination(cardColorIdentity(card))];
+    ret = [getColorCombination(cardColorIdentity(card))];
   }
   if (sort === 'Color Combination Includes') {
-    return COLOR_COMBINATIONS.filter((comb) => arrayIsSubset(cardColorIdentity(card), comb)).map(getColorCombination);
+    ret = COLOR_COMBINATIONS.filter((comb) => arrayIsSubset(cardColorIdentity(card), comb)).map(getColorCombination);
   }
   if (sort === 'Includes Color Combination') {
-    return COLOR_COMBINATIONS.filter((comb) => arrayIsSubset(comb, cardColorIdentity(card))).map(getColorCombination);
+    ret = COLOR_COMBINATIONS.filter((comb) => arrayIsSubset(comb, cardColorIdentity(card))).map(getColorCombination);
   }
   if (sort === 'Color') {
     if (card.details.colors.length === 0) {
-      return ['Colorless'];
+      ret = ['Colorless'];
     }
-    return card.details.colors.map((c) => COLOR_MAP[c]).filter((c) => c);
+    ret = card.details.colors.map((c) => COLOR_MAP[c]).filter((c) => c);
   }
   if (sort === '4+ Color') {
     if (cardColorIdentity(card).length < 4) {
-      return [];
+      ret = [];
     }
     if (cardColorIdentity(card).length === 5) {
-      return ['Five Color'];
+      ret = ['Five Color'];
     }
-    return [...'WUBRG'].filter((c) => !cardColorIdentity(card).includes(c)).map((c) => `Non-${COLOR_MAP[c]}`);
+    ret = [...'WUBRG'].filter((c) => !cardColorIdentity(card).includes(c)).map((c) => `Non-${COLOR_MAP[c]}`);
   }
   if (sort === 'CMC') {
     // Sort by CMC, but collapse all >= 8 into '8+' category.
     const cmc = Math.round(cmcToNumber(card));
     if (cmc >= 8) {
-      return ['8+'];
+      ret = ['8+'];
     }
-    return [cmc.toString()];
+    ret = [cmc.toString()];
   }
   if (sort === 'CMC2') {
     const cmc = Math.round(cmcToNumber(card));
     if (cmc >= 7) {
-      return ['7+'];
+      ret = ['7+'];
     }
     if (cmc <= 1) {
-      return ['0-1'];
+      ret = ['0-1'];
     }
-    return [cmc.toString()];
+    ret = [cmc.toString()];
   }
   if (sort === 'CMC-Full') {
     // Round to half-integer.
-    return [(Math.round(cmcToNumber(card) * 2) / 2).toString()];
+    ret = [(Math.round(cmcToNumber(card) * 2) / 2).toString()];
   }
   if (sort === 'Supertype' || sort === 'Type') {
     const split = cardType(card).split(/[-–—]/);
@@ -543,62 +549,62 @@ export function cardGetLabels(card, sort) {
         .filter((x) => x);
     }
     if (types.includes('Contraption')) {
-      return ['Contraption'];
+      ret = ['Contraption'];
     }
     if (types.includes('Plane')) {
-      return ['Plane'];
+      ret = ['Plane'];
     }
     const labels = getLabelsRaw(null, sort);
-    return types.filter((t) => labels.includes(t));
+    ret = types.filter((t) => labels.includes(t));
   }
   if (sort === 'Tags') {
-    return card.tags;
+    ret = card.tags;
   }
   if (sort === 'Tags Full') {
     // whitespace around ' Untagged ' to prevent collisions
-    return card.tags.length === 0 ? [' Untagged '] : card.tags;
+    ret = card.tags.length === 0 ? [' Untagged '] : card.tags;
   }
   if (sort === 'Status') {
-    return [card.status];
+    ret = [card.status];
   }
   if (sort === 'Finish') {
-    return [card.finish];
+    ret = [card.finish];
   }
   if (sort === 'Date Added') {
-    return [ISODateToYYYYMMDD(card.addedTmsp)];
+    ret = [ISODateToYYYYMMDD(card.addedTmsp)];
   }
   if (sort === 'Guilds') {
     if (cardColorIdentity(card).length !== 2) {
-      return [];
+      ret = [];
     }
     const ordered = [...'WUBRG'].filter((c) => cardColorIdentity(card).includes(c)).join('');
-    return [GUILD_MAP[ordered]];
+    ret = [GUILD_MAP[ordered]];
   }
   if (sort === 'Shards / Wedges') {
     if (cardColorIdentity(card).length !== 3) {
-      return [];
+      ret = [];
     }
     const ordered = [...'WUBRG'].filter((c) => cardColorIdentity(card).includes(c)).join('');
-    return [SHARD_AND_WEDGE_MAP[ordered]];
+    ret = [SHARD_AND_WEDGE_MAP[ordered]];
   }
   if (sort === 'Color Count') {
-    return [cardColorIdentity(card).length];
+    ret = [cardColorIdentity(card).length];
   }
   if (sort === 'Set') {
-    return [card.details.set.toUpperCase()];
+    ret = [card.details.set.toUpperCase()];
   }
   if (sort === 'Rarity') {
     let { rarity } = card.details;
     if (card.rarity) rarity = card.rarity;
-    return [rarity[0].toUpperCase() + rarity.slice(1)];
+    ret = [rarity[0].toUpperCase() + rarity.slice(1)];
   }
   if (sort === 'Subtype') {
     const split = cardType(card).split(/[-–—]/);
     if (split.length > 1) {
       const subtypes = split[1].trim().split(' ');
-      return subtypes.map((subtype) => subtype.trim()).filter((x) => x);
+      ret = subtypes.map((subtype) => subtype.trim()).filter((x) => x);
     }
-    return [];
+    ret = [];
   }
   if (sort === 'Types-Multicolor') {
     if (cardColorIdentity(card).length <= 1) {
@@ -623,114 +629,115 @@ export function cardGetLabels(card, sort) {
           'Land',
         ].includes(type)
       ) {
-        return ['Other'];
+        ret = ['Other'];
       }
-      return [type];
+      ret = [type];
     }
     if (cardColorIdentity(card).length === 5) {
-      return ['Five Color'];
+      ret = ['Five Color'];
     }
-    return [
+    ret = [
       ...cardGetLabels(card, 'Guilds'),
       ...cardGetLabels(card, 'Shards / Wedges'),
       ...cardGetLabels(card, '4+ Color'),
     ];
   }
   if (sort === 'Artist') {
-    return [card.details.artist];
+    ret = [card.details.artist];
   }
   if (sort === 'Legality') {
-    return Object.entries(card.details.legalities)
+    ret = Object.entries(card.details.legalities)
       .filter(([, v]) => ['legal', 'banned'].includes(v)) // eslint-disable-line no-unused-vars
       .map(([k]) => k); // eslint-disable-line no-unused-vars
   }
   if (sort === 'Power') {
     if (card.details.power) {
-      return [card.details.power];
+      ret = [card.details.power];
     }
-    return [];
+    ret = [];
   }
   if (sort === 'Toughness') {
     if (card.details.toughness) {
-      return [card.details.toughness];
+      ret = [card.details.toughness];
     }
-    return [];
+    ret = [];
   }
   if (sort === 'Loyalty') {
     if (card.details.loyalty) {
-      return [parseInt(card.details.loyalty, 10)];
+      ret = [parseInt(card.details.loyalty, 10)];
     }
-    return [];
+    ret = [];
   }
   if (sort === 'Manacost Type') {
     if (card.details.colors.length > 1 && card.details.parsed_cost.every((symbol) => !symbol.includes('-'))) {
-      return ['Gold'];
+      ret = ['Gold'];
     }
     if (
       card.details.colors.length > 1 &&
       card.details.parsed_cost.some((symbol) => symbol.includes('-') && !symbol.includes('-p'))
     ) {
-      return ['Hybrid'];
+      ret = ['Hybrid'];
     }
     if (card.details.parsed_cost.some((symbol) => symbol.includes('-p'))) {
-      return ['Phyrexian'];
+      ret = ['Phyrexian'];
     }
-    return [];
+    ret = [];
   }
   if (sort === 'Creature/Non-Creature') {
-    return cardType(card).toLowerCase().includes('creature') ? ['Creature'] : ['Non-Creature'];
+    ret = cardType(card).toLowerCase().includes('creature') ? ['Creature'] : ['Non-Creature'];
   }
   if (sort === 'Price USD' || sort === 'Price') {
     const price = card.details.prices.usd ?? card.details.prices.usd_foil;
     if (price) {
-      return [getPriceBucket(price, '$')];
+      ret = [getPriceBucket(price, '$')];
     }
-    return ['No Price Available'];
+    ret = ['No Price Available'];
   }
   if (sort === 'Price USD Foil') {
     const price = card.details.prices.usd_foil;
     if (price) {
-      return [getPriceBucket(price, '$')];
+      ret = [getPriceBucket(price, '$')];
     }
-    return ['No Price Available'];
+    ret = ['No Price Available'];
   }
   if (sort === 'Price EUR') {
     const price = cardPriceEur(card);
     if (price) {
-      return [getPriceBucket(price, '€')];
+      ret = [getPriceBucket(price, '€')];
     }
-    return ['No Price Available'];
+    ret = ['No Price Available'];
   }
   if (sort === 'MTGO TIX') {
     const price = cardTix(card);
     if (price) {
-      return [getPriceBucket(price, '')];
+      ret = [getPriceBucket(price, '')];
     }
-    return ['No Price Available'];
+    ret = ['No Price Available'];
   }
   if (sort === 'Devotion to White') {
-    return [cardDevotion(card, 'w').toString()];
+    ret = [cardDevotion(card, 'w').toString()];
   }
   if (sort === 'Devotion to Blue') {
-    return [cardDevotion(card, 'u').toString()];
+    ret = [cardDevotion(card, 'u').toString()];
   }
   if (sort === 'Devotion to Black') {
-    return [cardDevotion(card, 'b').toString()];
+    ret = [cardDevotion(card, 'b').toString()];
   }
   if (sort === 'Devotion to Red') {
-    return [cardDevotion(card, 'r').toString()];
+    ret = [cardDevotion(card, 'r').toString()];
   }
   if (sort === 'Devotion to Green') {
-    return [cardDevotion(card, 'g').toString()];
+    ret = [cardDevotion(card, 'g').toString()];
   }
   if (sort === 'Unsorted') {
-    return ['All'];
+    ret = ['All'];
   }
   if (sort === 'Elo') {
-    return [getEloBucket(card.details.elo ?? ELO_DEFAULT)];
+    ret = [getEloBucket(card.details.elo ?? ELO_DEFAULT)];
   }
-  // Unrecognized sort
-  return [];
+
+  if (showOther && ret === []) ret = [' Other '];
+  return ret;
 }
 
 export function cardCanBeSorted(card, sort) {
@@ -752,13 +759,13 @@ export function formatLabel(label) {
 }
 
 // Get labels in string form.
-export function getLabels(cube, sort) {
-  return getLabelsRaw(cube, sort).map(formatLabel);
+export function getLabels(cube, sort, showOther) {
+  return getLabelsRaw(cube, sort, showOther).map(formatLabel);
 }
 
-export function sortGroupsOrdered(cards, sort) {
-  const labels = getLabelsRaw(cards, sort);
-  const allCardLabels = cards.map((card) => [card, cardGetLabels(card, sort)]);
+export function sortGroupsOrdered(cards, sort, showOther) {
+  const labels = getLabelsRaw(cards, sort, showOther);
+  const allCardLabels = cards.map((card) => [card, cardGetLabels(card, sort, showOther)]);
   const compare = (x, y) => labels.indexOf(x) - labels.indexOf(y);
   const byLabel = {};
   for (const [card, cardLabels] of allCardLabels) {
@@ -785,15 +792,15 @@ const OrderSortMap = {
   Price: (a, b) => cardPrice(a) - cardPrice(b),
 };
 
-export function sortDeep(cards, last, ...sorts) {
+export function sortDeep(cards, showOther, last, ...sorts) {
   if (sorts.length === 0) {
     return [...cards].sort(OrderSortMap[last]);
   }
   const [first, ...rest] = sorts;
-  const result = sortGroupsOrdered(cards, first ?? 'Unsorted');
+  const result = sortGroupsOrdered(cards, first ?? 'Unsorted', showOther);
   for (const labelGroup of result) {
     if (rest.length > 0) {
-      labelGroup[1] = sortDeep(labelGroup[1], last, ...rest);
+      labelGroup[1] = sortDeep(labelGroup[1], showOther, last, ...rest);
     } else {
       labelGroup[1].sort(OrderSortMap[last]);
     }
@@ -815,9 +822,10 @@ export function sortForCSVDownload(
   secondary = 'Types-Multicolor',
   tertiary = 'CMC',
   quaternary = 'Alphabetical',
+  showOther = false,
 ) {
   const exportCards = [];
-  cards = sortDeep(cards, quaternary, primary, secondary, tertiary);
+  cards = sortDeep(cards, showOther, quaternary, primary, secondary, tertiary);
   for (const firstGroup of cards) {
     for (const secondGroup of firstGroup[1]) {
       for (const thirdGroup of secondGroup[1]) {

--- a/src/utils/Sort.js
+++ b/src/utils/Sort.js
@@ -288,6 +288,7 @@ function getLabelsRaw(cube, sort, showOther) {
     ret = tags.sort();
   }
   if (sort === 'Tags Full') {
+    // TODO remove
     // whitespace around ' Untagged ' to prevent collisions
     ret = [...getLabelsRaw(cube, 'Tags'), ' Untagged '];
   }

--- a/src/utils/Sort.js
+++ b/src/utils/Sort.js
@@ -240,43 +240,32 @@ function getLabelsRaw(cube, sort, showOther) {
   /* Start of sort Options */
   if (sort === 'Color Category') {
     ret = ['White', 'Blue', 'Black', 'Red', 'Green', 'Hybrid', 'Multicolored', 'Colorless', 'Lands'];
-  }
-  if (sort === 'Color Category Full') {
+  } else if (sort === 'Color Category Full') {
     ret = SINGLE_COLOR.concat(['Colorless'])
       .concat(GUILDS)
       .concat(SHARDS_AND_WEDGES)
       .concat(FOUR_AND_FIVE_COLOR)
       .concat(['Lands']);
-  }
-  if (sort === 'Color Identity') {
+  } else if (sort === 'Color Identity') {
     ret = ['White', 'Blue', 'Black', 'Red', 'Green', 'Multicolored', 'Colorless'];
-  }
-  if (sort === 'Color Identity Full') {
+  } else if (sort === 'Color Identity Full') {
     ret = SINGLE_COLOR.concat(['Colorless']).concat(GUILDS).concat(SHARDS_AND_WEDGES).concat(FOUR_AND_FIVE_COLOR);
-  }
-  if (sort === 'Color Combination Includes' || sort === 'Includes Color Combination') {
+  } else if (sort === 'Color Combination Includes' || sort === 'Includes Color Combination') {
     ret = ['Colorless'].concat(SINGLE_COLOR).concat(GUILDS).concat(SHARDS_AND_WEDGES).concat(FOUR_AND_FIVE_COLOR);
-  }
-  if (sort === 'CMC') {
+  } else if (sort === 'CMC') {
     ret = ['0', '1', '2', '3', '4', '5', '6', '7', '8+'];
-  }
-  if (sort === 'CMC2') {
+  } else if (sort === 'CMC2') {
     ret = ['0-1', '2', '3', '4', '5', '6', '7+'];
-  }
-  if (sort === 'CMC-Full') {
+  } else if (sort === 'CMC-Full') {
     // All CMCs from 0-16, with halves included, plus Gleemax at 1,000,000.
     ret = ALL_CMCS;
-  }
-  if (sort === 'Color') {
+  } else if (sort === 'Color') {
     ret = ['White', 'Blue', 'Black', 'Red', 'Green', 'Colorless'];
-  }
-  if (sort === 'Type') {
+  } else if (sort === 'Type') {
     ret = CARD_TYPES.concat(['Other']);
-  }
-  if (sort === 'Supertype') {
+  } else if (sort === 'Supertype') {
     ret = ['Snow', 'Legendary', 'Tribal', 'Basic', 'Elite', 'Host', 'Ongoing', 'World'];
-  }
-  if (sort === 'Tags') {
+  } else if (sort === 'Tags') {
     const tags = [];
     for (const card of cube) {
       for (const tag of card.tags) {
@@ -286,33 +275,25 @@ function getLabelsRaw(cube, sort, showOther) {
       }
     }
     ret = tags.sort();
-  }
-  if (sort === 'Tags Full') {
+  } else if (sort === 'Tags Full') {
     // TODO remove
     // whitespace around ' Untagged ' to prevent collisions
     ret = [...getLabelsRaw(cube, 'Tags'), ' Untagged '];
-  }
-  if (sort === 'Date Added') {
+  } else if (sort === 'Date Added') {
     const dates = cube.map((card) => card.addedTmsp).sort((a, b) => a - b);
     const days = dates.map((date) => ISODateToYYYYMMDD(date));
     ret = removeAdjacentDuplicates(days);
-  }
-  if (sort === 'Status') {
+  } else if (sort === 'Status') {
     ret = ['Not Owned', 'Ordered', 'Owned', 'Premium Owned', 'Proxied'];
-  }
-  if (sort === 'Finish') {
+  } else if (sort === 'Finish') {
     ret = ['Non-foil', 'Foil'];
-  }
-  if (sort === 'Guilds') {
+  } else if (sort === 'Guilds') {
     ret = GUILDS;
-  }
-  if (sort === 'Shards / Wedges') {
+  } else if (sort === 'Shards / Wedges') {
     ret = SHARDS_AND_WEDGES;
-  }
-  if (sort === 'Color Count') {
+  } else if (sort === 'Color Count') {
     ret = ['0', '1', '2', '3', '4', '5'];
-  }
-  if (sort === 'Set') {
+  } else if (sort === 'Set') {
     const sets = [];
     for (const card of cube) {
       if (!sets.includes(card.details.set.toUpperCase())) {
@@ -320,8 +301,7 @@ function getLabelsRaw(cube, sort, showOther) {
       }
     }
     ret = sets.sort();
-  }
-  if (sort === 'Artist') {
+  } else if (sort === 'Artist') {
     const artists = [];
     for (const card of cube) {
       if (!artists.includes(card.details.artist)) {
@@ -329,14 +309,11 @@ function getLabelsRaw(cube, sort, showOther) {
       }
     }
     ret = artists.sort();
-  }
-  if (sort === 'Rarity') {
+  } else if (sort === 'Rarity') {
     ret = ['Common', 'Uncommon', 'Rare', 'Mythic', 'Special'];
-  }
-  if (sort === 'Unsorted') {
+  } else if (sort === 'Unsorted') {
     ret = ['All'];
-  }
-  if (sort === 'Subtype') {
+  } else if (sort === 'Subtype') {
     const types = new Set();
     for (const card of cube) {
       const split = card.type_line.split(/[-–—]/);
@@ -349,18 +326,15 @@ function getLabelsRaw(cube, sort, showOther) {
       }
     }
     ret = [...types];
-  }
-  if (sort === 'Types-Multicolor') {
+  } else if (sort === 'Types-Multicolor') {
     ret = CARD_TYPES.slice(0, -1)
       .concat(GUILDS)
       .concat(SHARDS_AND_WEDGES)
       .concat(FOUR_AND_FIVE_COLOR)
       .concat(['Land', 'Other']);
-  }
-  if (sort === 'Legality') {
+  } else if (sort === 'Legality') {
     ret = ['Standard', 'Modern', 'Legacy', 'Vintage', 'Pioneer', 'Brawl', 'Historic', 'Pauper', 'Penny', 'Commander'];
-  }
-  if (sort === 'Power') {
+  } else if (sort === 'Power') {
     const items = [];
     for (const card of cube) {
       if (card.details.power) {
@@ -370,8 +344,7 @@ function getLabelsRaw(cube, sort, showOther) {
       }
     }
     ret = items.sort(defaultSort);
-  }
-  if (sort === 'Toughness') {
+  } else if (sort === 'Toughness') {
     const items = [];
     for (const card of cube) {
       if (card.details.toughness) {
@@ -381,8 +354,7 @@ function getLabelsRaw(cube, sort, showOther) {
       }
     }
     ret = items.sort(defaultSort);
-  }
-  if (sort === 'Loyalty') {
+  } else if (sort === 'Loyalty') {
     const items = [];
     for (const card of cube) {
       if (card.details.loyalty) {
@@ -392,56 +364,44 @@ function getLabelsRaw(cube, sort, showOther) {
       }
     }
     ret = items.sort(defaultSort);
-  }
-  if (sort === 'Manacost Type') {
+  } else if (sort === 'Manacost Type') {
     ret = ['Gold', 'Hybrid', 'Phyrexian'];
-  }
-  if (sort === 'Creature/Non-Creature') {
+  } else if (sort === 'Creature/Non-Creature') {
     ret = ['Creature', 'Non-Creature'];
-  }
-  if (['Price', 'Price USD', 'Price Foil', 'Price USD Foil'].includes(sort)) {
+  } else if (['Price', 'Price USD', 'Price Foil', 'Price USD Foil'].includes(sort)) {
     const labels = [];
     for (let i = 0; i <= priceBuckets.length; i++) {
       labels.push(priceBucketLabel(i, '$'));
     }
     labels.push('No Price Available');
     ret = labels;
-  }
-  if (sort === 'Price EUR') {
+  } else if (sort === 'Price EUR') {
     const labels = [];
     for (let i = 0; i <= priceBuckets.length; i++) {
       labels.push(priceBucketLabel(i, '€'));
     }
     labels.push('No Price Available');
     ret = labels;
-  }
-  if (sort === 'MTGO TIX') {
+  } else if (sort === 'MTGO TIX') {
     const labels = [];
     for (let i = 0; i <= priceBuckets.length; i++) {
       labels.push(priceBucketLabel(i, ''));
     }
     labels.push('No Price Available');
     ret = labels;
-  }
-  if (sort === 'Devotion to White') {
+  } else if (sort === 'Devotion to White') {
     ret = allDevotions(cube, 'W');
-  }
-  if (sort === 'Devotion to Blue') {
+  } else if (sort === 'Devotion to Blue') {
     ret = allDevotions(cube, 'U');
-  }
-  if (sort === 'Devotion to Black') {
+  } else if (sort === 'Devotion to Black') {
     ret = allDevotions(cube, 'B');
-  }
-  if (sort === 'Devotion to Red') {
+  } else if (sort === 'Devotion to Red') {
     ret = allDevotions(cube, 'R');
-  }
-  if (sort === 'Devotion to Green') {
+  } else if (sort === 'Devotion to Green') {
     ret = allDevotions(cube, 'G');
-  }
-  if (sort === 'Unsorted') {
+  } else if (sort === 'Unsorted') {
     ret = ['All'];
-  }
-  if (sort === 'Elo') {
+  } else if (sort === 'Elo') {
     let elos = [];
     for (const card of cube) {
       const elo = card.details.elo ?? ELO_DEFAULT;
@@ -477,42 +437,34 @@ export function cardGetLabels(card, sort, showOther) {
   /* Start of sort options */
   if (sort === 'Color Category') {
     ret = [card.colorCategory ?? GetColorCategory(cardType(card), cardColorIdentity(card))];
-  }
-  if (sort === 'Color Category Full') {
+  } else if (sort === 'Color Category Full') {
     const colorCategory = card.colorCategory ?? GetColorCategory(cardType(card), cardColorIdentity(card));
     if (colorCategory === 'Multicolored') {
       ret = [getColorCombination(cardColorIdentity(card))];
     } else {
       ret = [colorCategory];
     }
-  }
-  if (sort === 'Color Identity') {
+  } else if (sort === 'Color Identity') {
     ret = [GetColorIdentity(cardColorIdentity(card))];
-  }
-  if (sort === 'Color Identity Full') {
+  } else if (sort === 'Color Identity Full') {
     ret = [getColorCombination(cardColorIdentity(card))];
-  }
-  if (sort === 'Color Combination Includes') {
+  } else if (sort === 'Color Combination Includes') {
     ret = COLOR_COMBINATIONS.filter((comb) => arrayIsSubset(cardColorIdentity(card), comb)).map(getColorCombination);
-  }
-  if (sort === 'Includes Color Combination') {
+  } else if (sort === 'Includes Color Combination') {
     ret = COLOR_COMBINATIONS.filter((comb) => arrayIsSubset(comb, cardColorIdentity(card))).map(getColorCombination);
-  }
-  if (sort === 'Color') {
+  } else if (sort === 'Color') {
     if (card.details.colors.length === 0) {
       ret = ['Colorless'];
     } else {
       ret = card.details.colors.map((c) => COLOR_MAP[c]).filter((c) => c);
     }
-  }
-  if (sort === '4+ Color') {
+  } else if (sort === '4+ Color') {
     if (cardColorIdentity(card).length === 5) {
       ret = ['Five Color'];
     } else if (cardColorIdentity(card).length === 4) {
       ret = [...'WUBRG'].filter((c) => !cardColorIdentity(card).includes(c)).map((c) => `Non-${COLOR_MAP[c]}`);
     }
-  }
-  if (sort === 'CMC') {
+  } else if (sort === 'CMC') {
     // Sort by CMC, but collapse all >= 8 into '8+' category.
     const cmc = Math.round(cmcToNumber(card));
     if (cmc >= 8) {
@@ -520,8 +472,7 @@ export function cardGetLabels(card, sort, showOther) {
     } else {
       ret = [cmc.toString()];
     }
-  }
-  if (sort === 'CMC2') {
+  } else if (sort === 'CMC2') {
     const cmc = Math.round(cmcToNumber(card));
     if (cmc >= 7) {
       ret = ['7+'];
@@ -530,12 +481,10 @@ export function cardGetLabels(card, sort, showOther) {
     } else {
       ret = [cmc.toString()];
     }
-  }
-  if (sort === 'CMC-Full') {
+  } else if (sort === 'CMC-Full') {
     // Round to half-integer.
     ret = [(Math.round(cmcToNumber(card) * 2) / 2).toString()];
-  }
-  if (sort === 'Supertype' || sort === 'Type') {
+  } else if (sort === 'Supertype' || sort === 'Type') {
     const split = cardType(card).split(/[-–—]/);
     let types;
     if (split.length > 1) {
@@ -559,53 +508,41 @@ export function cardGetLabels(card, sort, showOther) {
       const labels = getLabelsRaw(null, sort, showOther);
       ret = types.filter((t) => labels.includes(t));
     }
-  }
-  if (sort === 'Tags') {
+  } else if (sort === 'Tags') {
     ret = card.tags;
-  }
-  if (sort === 'Tags Full') {
+  } else if (sort === 'Tags Full') {
     // whitespace around ' Untagged ' to prevent collisions
     ret = card.tags.length === 0 ? [' Untagged '] : card.tags;
-  }
-  if (sort === 'Status') {
+  } else if (sort === 'Status') {
     ret = [card.status];
-  }
-  if (sort === 'Finish') {
+  } else if (sort === 'Finish') {
     ret = [card.finish];
-  }
-  if (sort === 'Date Added') {
+  } else if (sort === 'Date Added') {
     ret = [ISODateToYYYYMMDD(card.addedTmsp)];
-  }
-  if (sort === 'Guilds') {
+  } else if (sort === 'Guilds') {
     if (cardColorIdentity(card).length === 2) {
       const ordered = [...'WUBRG'].filter((c) => cardColorIdentity(card).includes(c)).join('');
       ret = [GUILD_MAP[ordered]];
     }
-  }
-  if (sort === 'Shards / Wedges') {
+  } else if (sort === 'Shards / Wedges') {
     if (cardColorIdentity(card).length === 3) {
       const ordered = [...'WUBRG'].filter((c) => cardColorIdentity(card).includes(c)).join('');
       ret = [SHARD_AND_WEDGE_MAP[ordered]];
     }
-  }
-  if (sort === 'Color Count') {
+  } else if (sort === 'Color Count') {
     ret = [cardColorIdentity(card).length];
-  }
-  if (sort === 'Set') {
+  } else if (sort === 'Set') {
     ret = [card.details.set.toUpperCase()];
-  }
-  if (sort === 'Rarity') {
+  } else if (sort === 'Rarity') {
     const rarity = cardRarity(card);
     ret = [rarity[0].toUpperCase() + rarity.slice(1)];
-  }
-  if (sort === 'Subtype') {
+  } else if (sort === 'Subtype') {
     const split = cardType(card).split(/[-–—]/);
     if (split.length > 1) {
       const subtypes = split[1].trim().split(' ');
       ret = subtypes.map((subtype) => subtype.trim()).filter((x) => x);
     }
-  }
-  if (sort === 'Types-Multicolor') {
+  } else if (sort === 'Types-Multicolor') {
     if (cardColorIdentity(card).length <= 1) {
       const split = cardType(card).split('—');
       const types = split[0].trim().split(' ');
@@ -641,31 +578,25 @@ export function cardGetLabels(card, sort, showOther) {
         ...cardGetLabels(card, '4+ Color'),
       ];
     }
-  }
-  if (sort === 'Artist') {
+  } else if (sort === 'Artist') {
     ret = [card.details.artist];
-  }
-  if (sort === 'Legality') {
+  } else if (sort === 'Legality') {
     ret = Object.entries(card.details.legalities)
       .filter(([, v]) => ['legal', 'banned'].includes(v)) // eslint-disable-line no-unused-vars
       .map(([k]) => k); // eslint-disable-line no-unused-vars
-  }
-  if (sort === 'Power') {
+  } else if (sort === 'Power') {
     if (card.details.power) {
       ret = [card.details.power];
     }
-  }
-  if (sort === 'Toughness') {
+  } else if (sort === 'Toughness') {
     if (card.details.toughness) {
       ret = [card.details.toughness];
     }
-  }
-  if (sort === 'Loyalty') {
+  } else if (sort === 'Loyalty') {
     if (card.details.loyalty) {
       ret = [parseInt(card.details.loyalty, 10)];
     }
-  }
-  if (sort === 'Manacost Type') {
+  } else if (sort === 'Manacost Type') {
     if (card.details.colors.length > 1 && card.details.parsed_cost.every((symbol) => !symbol.includes('-'))) {
       ret = ['Gold'];
     } else if (
@@ -676,61 +607,49 @@ export function cardGetLabels(card, sort, showOther) {
     } else if (card.details.parsed_cost.some((symbol) => symbol.includes('-p'))) {
       ret = ['Phyrexian'];
     }
-  }
-  if (sort === 'Creature/Non-Creature') {
+  } else if (sort === 'Creature/Non-Creature') {
     ret = cardType(card).toLowerCase().includes('creature') ? ['Creature'] : ['Non-Creature'];
-  }
-  if (sort === 'Price USD' || sort === 'Price') {
+  } else if (sort === 'Price USD' || sort === 'Price') {
     const price = card.details.prices.usd ?? card.details.prices.usd_foil;
     if (price) {
       ret = [getPriceBucket(price, '$')];
     } else {
       ret = ['No Price Available'];
     }
-  }
-  if (sort === 'Price USD Foil') {
+  } else if (sort === 'Price USD Foil') {
     const price = card.details.prices.usd_foil;
     if (price) {
       ret = [getPriceBucket(price, '$')];
     } else {
       ret = ['No Price Available'];
     }
-  }
-  if (sort === 'Price EUR') {
+  } else if (sort === 'Price EUR') {
     const price = cardPriceEur(card);
     if (price) {
       ret = [getPriceBucket(price, '€')];
     } else {
       ret = ['No Price Available'];
     }
-  }
-  if (sort === 'MTGO TIX') {
+  } else if (sort === 'MTGO TIX') {
     const price = cardTix(card);
     if (price) {
       ret = [getPriceBucket(price, '')];
     } else {
       ret = ['No Price Available'];
     }
-  }
-  if (sort === 'Devotion to White') {
+  } else if (sort === 'Devotion to White') {
     ret = [cardDevotion(card, 'w').toString()];
-  }
-  if (sort === 'Devotion to Blue') {
+  } else if (sort === 'Devotion to Blue') {
     ret = [cardDevotion(card, 'u').toString()];
-  }
-  if (sort === 'Devotion to Black') {
+  } else if (sort === 'Devotion to Black') {
     ret = [cardDevotion(card, 'b').toString()];
-  }
-  if (sort === 'Devotion to Red') {
+  } else if (sort === 'Devotion to Red') {
     ret = [cardDevotion(card, 'r').toString()];
-  }
-  if (sort === 'Devotion to Green') {
+  } else if (sort === 'Devotion to Green') {
     ret = [cardDevotion(card, 'g').toString()];
-  }
-  if (sort === 'Unsorted') {
+  } else if (sort === 'Unsorted') {
     ret = ['All'];
-  }
-  if (sort === 'Elo') {
+  } else if (sort === 'Elo') {
     ret = [getEloBucket(card.details.elo ?? ELO_DEFAULT)];
   }
   /* End of sort options */

--- a/src/utils/Sort.js
+++ b/src/utils/Sort.js
@@ -461,11 +461,7 @@ function getLabelsRaw(cube, sort, showOther) {
   }
   /* End of sort options */
 
-  if (showOther) {
-    ret.push(' Other ');
-  }
-
-  return ret;
+  return showOther ? [...ret, ' Other '] : ret;
 }
 
 function cmcToNumber(card) {
@@ -739,7 +735,7 @@ export function cardGetLabels(card, sort, showOther) {
   }
   /* End of sort options */
 
-  if (showOther && ret === []) {
+  if (showOther && ret.length === 0) {
     ret = [' Other '];
   }
   return ret;

--- a/src/utils/Sort.js
+++ b/src/utils/Sort.js
@@ -236,6 +236,8 @@ function getEloBucket(elo) {
 
 function getLabelsRaw(cube, sort, showOther) {
   let ret = [];
+
+  /* Start of sort Options */
   if (sort === 'Color Category') {
     ret = ['White', 'Blue', 'Black', 'Red', 'Green', 'Hybrid', 'Multicolored', 'Colorless', 'Lands'];
   }
@@ -456,6 +458,7 @@ function getLabelsRaw(cube, sort, showOther) {
     }
     ret = res;
   }
+  /* End of sort options */
 
   if (showOther) {
     ret.push(' Other ');
@@ -474,6 +477,7 @@ function cmcToNumber(card) {
 
 export function cardGetLabels(card, sort, showOther) {
   let ret = [];
+  /* Start of sort options */
   if (sort === 'Color Category') {
     ret = [card.colorCategory ?? GetColorCategory(cardType(card), cardColorIdentity(card))];
   }
@@ -732,6 +736,7 @@ export function cardGetLabels(card, sort, showOther) {
   if (sort === 'Elo') {
     ret = [getEloBucket(card.details.elo ?? ELO_DEFAULT)];
   }
+  /* End of sort options */
 
   if (showOther && ret === []) {
     ret = [' Other '];

--- a/src/utils/Sort.js
+++ b/src/utils/Sort.js
@@ -787,8 +787,8 @@ export function sortGroupsOrdered(cards, sort, showOther) {
   return labels.filter((label) => byLabel[label]).map((label) => [formatLabel(label), byLabel[label]]);
 }
 
-export function sortIntoGroups(cards, sort) {
-  return fromEntries(sortGroupsOrdered(cards, sort));
+export function sortIntoGroups(cards, sort, showOther) {
+  return fromEntries(sortGroupsOrdered(cards, sort, showOther));
 }
 
 const OrderSortMap = {


### PR DESCRIPTION
Users will now have a  'Show Unsorted Cards' option present in the sort modal. That option enables the creation of an `Other` column, which will be filled with cards that normally wouldn't appear in any columns. 

This feature is a superset of #1853 and thus this PR removes the `Tags Full` sort option.

This option isn't made available in the analytics pages, as they don't use the `SortCollapse` component and thus would each require a separate UI and logic for enabling it.

The PR also fixes an issue I found where query parameters for `s3` and `s4` weren't being respected by the List Page.

### Screenshots
![hide](https://user-images.githubusercontent.com/38463785/113048060-a20d5400-9191-11eb-81e6-673d5774a70a.png)
![show2](https://user-images.githubusercontent.com/38463785/113048066-a33e8100-9191-11eb-839d-f34033909df5.png)


