### PR TITLE
Adds Link to LP Cube Map

### DIFF
--- a/src/pages/CubeOverviewPage.js
+++ b/src/pages/CubeOverviewPage.js
@@ -20,6 +20,8 @@ import {
   UncontrolledCollapse,
 } from 'reactstrap';
 
+import { LinkExternalIcon } from '@primer/octicons-react';
+
 import { csrfFetch } from 'utils/CSRF';
 import { getCubeId, getCubeDescription } from 'utils/Util';
 
@@ -217,6 +219,11 @@ class CubeOverview extends Component {
                     </i>{' '}
                     • <a href={`/cube/rss/${cube._id}`}>RSS</a>
                   </h6>
+                  <p>
+                    <a href={`https://luckypaper.co/resources/cube-map/?cube=${cube.shortID}`}>
+                      View in Cube Map <LinkExternalIcon size={16} />
+                    </a>
+                  </p>
                   {!cube.privatePrices && (
                     <Row noGutters className="mb-1">
                       {Number.isFinite(priceOwned) && (


### PR DESCRIPTION
This came up in the discord. Adds links from cube overview pages to the [Cube Map](http://luckypaper.co/resources/cube-map/) highlighting the particular cube.

I wanted to open this up for discussion, but obviously I'm not sure about how the team feels about adding more complexity to the overview and linking out to other tools.

One issue worth noting is the Cube Map is not automatically updated, so the link will be broken for newly created cubes. I can improve this on the map end handling unknown ids and showing showing some useful information. Another layer could be to store the last update time somewhere globally and only show this link if the cube was created before the last update. In the little bit of poking around I've done so far I didn't see a created at date on the cube prop types.