### PR TITLE
Cache a promise for generating pack images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5027,6 +5027,11 @@
         "wordwrap": "0.0.2"
       }
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -14039,6 +14044,14 @@
             "isarray": "0.0.1"
           }
         }
+      }
+    },
+    "node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "requires": {
+        "clone": "2.x"
       }
     },
     "node-fetch": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "mongoose": "5.7.7",
     "mongoose-seed": "^0.6.0",
     "nearley": "^2.19.3",
+    "node-cache": "^5.1.2",
     "node-fetch": "^2.6.1",
     "node-schedule": "^1.3.2",
     "nodemailer": "^6.3.1",

--- a/serverjs/cubefn.js
+++ b/serverjs/cubefn.js
@@ -1,3 +1,4 @@
+const NodeCache = require('node-cache');
 const Papa = require('papaparse');
 const sanitizeHtml = require('sanitize-html');
 
@@ -454,6 +455,25 @@ const generateSamplepackImage = (sources = [], options = {}) =>
     );
   });
 
+// A cache for promises that are expensive to compute and will always produce
+// the same value, such as pack images. If a promise produces an error, it's
+// removed from the cache. Each promise lives five minutes by default.
+const promiseCache = new NodeCache({stdTTL: 60 * 5, useClones: false});
+
+/// Caches the result of the given callback in `promiseCache` with the given
+/// key.
+function cachePromise(key, callback) {
+  const existingPromise = promiseCache.get(key);
+  if (existingPromise) return existingPromise;
+
+  const newPromise = callback().catch(error => {
+    dromiseCache.del(key);
+    throw error;
+  });
+  imagePromiseCache.set(key, newPromise);
+  return newPromise;
+}
+
 const methods = {
   getBasics(carddb) {
     const names = ['Plains', 'Mountain', 'Forest', 'Swamp', 'Island'];
@@ -534,6 +554,7 @@ const methods = {
   CSVtoCards,
   compareCubes,
   generateSamplepackImage,
+  cachePromise,
 };
 
 module.exports = methods;


### PR DESCRIPTION
This means that when N requests for the same image come in quick
succession (for example, when a pack image is displayed on Discord),
the server doesn't need to render the image N times. Instead, it
renders it once, then sends the resulting data out N times,
substantially decreasing the server load and increasing
responsiveness.