### PR TITLE
Issue 196

### DIFF
--- a/serverjs/cards.js
+++ b/serverjs/cards.js
@@ -158,6 +158,15 @@ function reasonableId(id) {
 }
 
 function getIdsFromName(name) {
+  // this is a fully-spcecified card name
+  if (name.includes('[') && name.includes(']')) {
+    const split = name.toLowerCase().split('[');
+    return getIdsFromName(split[0])
+      .map((id) => cardFromId(id))
+      .filter((card) => split[1].includes(card.set))
+      .map((card) => card._id);
+  }
+
   return data.nameToId[
     name
       .trim()

--- a/src/components/AutocompleteInput.js
+++ b/src/components/AutocompleteInput.js
@@ -1,6 +1,9 @@
 import React, { forwardRef, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Input } from 'reactstrap';
+import withAutocard from 'components/WithAutocard';
+
+const AutocardLi = withAutocard('li');
 
 function getAllMatches(names, current) {
   const posts = getPosts(names, current);
@@ -283,9 +286,9 @@ const AutocompleteInput = forwardRef(
         {showMatches && (
           <ul className="autocomplete-list">
             {matches.map((match, index) => (
-              <li key={index} onClick={handleClickSuggestion} className={index === position ? 'active' : undefined}>
+              <AutocardLi front={`/tool/cardimage/${match}`} key={index} onClick={handleClickSuggestion} className={index === position ? 'active' : undefined}>
                 {match}
-              </li>
+              </AutocardLi>
             ))}
           </ul>
         )}

--- a/src/components/AutocompleteInput.js
+++ b/src/components/AutocompleteInput.js
@@ -286,7 +286,12 @@ const AutocompleteInput = forwardRef(
         {showMatches && (
           <ul className="autocomplete-list">
             {matches.map((match, index) => (
-              <AutocardLi front={cubeId ? `/tool/cardimageforcube/${match}/${cubeId}` : `/tool/cardimage/${match}`} key={index} onClick={handleClickSuggestion} className={index === position ? 'active' : undefined}>
+              <AutocardLi
+                front={cubeId ? `/tool/cardimageforcube/${match}/${cubeId}` : `/tool/cardimage/${match}`}
+                key={index}
+                onClick={handleClickSuggestion}
+                className={index === position ? 'active' : undefined}
+              >
                 {match}
               </AutocardLi>
             ))}

--- a/src/components/AutocompleteInput.js
+++ b/src/components/AutocompleteInput.js
@@ -187,7 +187,7 @@ const fetchTree = async (treeUrl, treePath) => {
 };
 
 const AutocompleteInput = forwardRef(
-  ({ treeUrl, treePath, defaultValue, value, onChange, onSubmit, wrapperClassName, ...props }, ref) => {
+  ({ treeUrl, treePath, defaultValue, value, onChange, onSubmit, wrapperClassName, cubeId, ...props }, ref) => {
     const [tree, setTree] = useState({});
     const [position, setPosition] = useState(-1);
     const [visible, setVisible] = useState(false);
@@ -286,7 +286,7 @@ const AutocompleteInput = forwardRef(
         {showMatches && (
           <ul className="autocomplete-list">
             {matches.map((match, index) => (
-              <AutocardLi front={`/tool/cardimage/${match}`} key={index} onClick={handleClickSuggestion} className={index === position ? 'active' : undefined}>
+              <AutocardLi front={cubeId ? `/tool/cardimageforcube/${match}/${cubeId}` : `/tool/cardimage/${match}`} key={index} onClick={handleClickSuggestion} className={index === position ? 'active' : undefined}>
                 {match}
               </AutocardLi>
             ))}

--- a/src/components/CubeOverviewModal.js
+++ b/src/components/CubeOverviewModal.js
@@ -327,7 +327,7 @@ class CubeOverviewModal extends Component {
                 </Row>
                 <br />
                 <AutocompleteInput
-                  treeUrl={'/cube/api/fullnames'}
+                  treeUrl="/cube/api/fullnames"
                   treePath="cardnames"
                   type="text"
                   className="mr-2"

--- a/src/components/CubeOverviewModal.js
+++ b/src/components/CubeOverviewModal.js
@@ -342,7 +342,12 @@ class CubeOverviewModal extends Component {
                 <br />
 
                 <h6>Description</h6>
-                <TextEntry name="blog" value={pickDescriptionFromCube(cube)} onChange={this.handleDescriptionChange} maxLength={100000}/>
+                <TextEntry
+                  name="blog"
+                  value={pickDescriptionFromCube(cube)}
+                  onChange={this.handleDescriptionChange}
+                  maxLength={100000}
+                />
                 <FormText>
                   Having trouble formatting your posts? Check out the{' '}
                   <a href="/markdown" target="_blank">

--- a/src/components/EditCollapse.js
+++ b/src/components/EditCollapse.js
@@ -14,6 +14,7 @@ import {
   Input,
   Card,
   FormText,
+  InputGroupText,
 } from 'reactstrap';
 
 import { encodeName } from 'utils/Card';
@@ -61,6 +62,7 @@ const EditCollapse = ({ ...props }) => {
   const [alerts, setAlerts] = useState([]);
   const [postContent, setPostContent] = useState('');
   const [mentions, setMentions] = useState('');
+  const [specifyEdition, setSpecifyEdition] = useState(false);
 
   const {
     changes,
@@ -173,7 +175,7 @@ const EditCollapse = ({ ...props }) => {
           <Form inline className="mb-2 mr-2" onSubmit={handleAdd}>
             <InputGroup className="flex-nowrap">
               <AutocompleteInput
-                treeUrl="/cube/api/cardnames"
+                treeUrl={specifyEdition ? '/cube/api/fullnames' : '/cube/api/cardnames'}
                 treePath="cardnames"
                 type="text"
                 innerRef={addInputRef}
@@ -214,6 +216,22 @@ const EditCollapse = ({ ...props }) => {
                   Remove/Replace
                 </Button>
               </InputGroupAddon>
+            </InputGroup>
+          </Form>
+          <Form inline className="mb-2 mr-2">
+            <InputGroup>
+              <InputGroupAddon addonType="prepend">
+                <InputGroupText>
+                  <Input
+                    addon
+                    type="checkbox"
+                    aria-label="Checkbox for following text input"
+                    checked={specifyEdition}
+                    onChange={() => setSpecifyEdition(!specifyEdition)}
+                  />
+                </InputGroupText>
+              </InputGroupAddon>
+              <Input disabled value="Specify Versions" />
             </InputGroup>
           </Form>
         </Row>

--- a/src/components/EditCollapse.js
+++ b/src/components/EditCollapse.js
@@ -198,6 +198,7 @@ const EditCollapse = ({ ...props }) => {
           <Form inline className="mb-2 mr-2" onSubmit={handleRemoveReplace}>
             <InputGroup className="flex-nowrap">
               <AutocompleteInput
+                cubeId={cube._id}
                 treeUrl={`/cube/api/cubecardnames/${cubeID}`}
                 treePath="cardnames"
                 type="text"


### PR DESCRIPTION
Fixes #196 

For a _long_ time, we actually had autocard not working on the drop down select here - this adds it back as well.

This also adds a checkbox to enable specifying card versions by set code and collector's id, turned off by default.

Showing correct version:
![image](https://user-images.githubusercontent.com/28238025/113631561-a1fcd080-9637-11eb-9921-42d3b8473f35.png)

With checkbox off (default, same as old behavior, except with autocard now):
![image](https://user-images.githubusercontent.com/28238025/113631649-c0fb6280-9637-11eb-808d-3768fe5d9f59.png)

With checkbox on:
![image](https://user-images.githubusercontent.com/28238025/113631678-cbb5f780-9637-11eb-9f1c-676389ddfc4c.png)

