### PR TITLE
Add mouseover text to cube preview cards

### DIFF
--- a/src/components/CubeOverviewModal.js
+++ b/src/components/CubeOverviewModal.js
@@ -342,7 +342,12 @@ class CubeOverviewModal extends Component {
                 <br />
 
                 <h6>Description</h6>
-                <TextEntry name="blog" value={pickDescriptionFromCube(cube)} onChange={this.handleDescriptionChange} maxLength={100000}/>
+                <TextEntry
+                  name="blog"
+                  value={pickDescriptionFromCube(cube)}
+                  onChange={this.handleDescriptionChange}
+                  maxLength={100000}
+                />
                 <FormText>
                   Having trouble formatting your posts? Check out the{' '}
                   <a href="/markdown" target="_blank">

--- a/src/components/CubePreview.js
+++ b/src/components/CubePreview.js
@@ -35,7 +35,9 @@ const CubePreview = ({ cube }) => {
         <em className="cube-preview-artist">Art by {cube.image_artist}</em>
       </AspectRatioBox>
       <div className="w-100 py-1 px-2">
-        <h5 className="text-muted text-ellipsis my-0">{cube.name}</h5>
+        <h5 className="text-muted text-ellipsis my-0" title={cube.name}>
+          {cube.name}
+        </h5>
         <div className="text-muted text-ellipsis">{getCubeDescription(cube)}</div>
         <em className="text-muted text-ellipsis">
           Designed by{' '}


### PR DESCRIPTION
Small change that closes #1784.

Shows the full name of a cube in a tooltip / mouseover text when a user hovers their mouse over the cube's name in the preview card.