### PR TITLE
CMC -> Mana Value

### DIFF
--- a/nearley/cardFilters.ne
+++ b/nearley/cardFilters.ne
@@ -105,7 +105,7 @@ const genericCondition = (propertyName, propertyAccessor, valuePred) => {
 %} # %}
 
 
-cmcCondition -> "cmc"i integerOpValue {% ([, valuePred]) => genericCondition('cmc', cardCmc, valuePred) %}
+cmcCondition -> ("mv"i | "cmc"i) integerOpValue {% ([, valuePred]) => genericCondition('cmc', cardCmc, valuePred) %}
 
 colorCondition -> ("c"i | "color"i | "colors"i) colorCombinationOpValue {% ([, valuePred]) => genericCondition('colors', cardColors, valuePred) %}
 

--- a/routes/cube_routes.js
+++ b/routes/cube_routes.js
@@ -3639,7 +3639,7 @@ router.post(
       !src ||
       (src && typeof src.index !== 'number') ||
       (updated.cardID && typeof updated.cardID !== 'string') ||
-      (updated.cmc && !['number', 'string'].includes(typeof updated.cmc)) ||
+      (updated.cmc && typeof updated.cmc !== 'number') ||
       (updated.status && typeof updated.status !== 'string') ||
       (updated.type_line && typeof updated.type_line !== 'string') ||
       (updated.colors && !Array.isArray(updated.colors)) ||

--- a/src/analytics/Averages.js
+++ b/src/analytics/Averages.js
@@ -13,7 +13,7 @@ import { sortIntoGroups, SORTS } from 'utils/Sort';
 
 const Averages = ({ cards, characteristics, defaultFormatId, cube, setAsfans }) => {
   const [sort, setSort] = useQueryParam('sort', 'Color');
-  const [characteristic, setCharacteristic] = useQueryParam('field', 'CMC');
+  const [characteristic, setCharacteristic] = useQueryParam('field', 'Mana Value');
 
   const groups = useMemo(() => sortIntoGroups(cards, sort), [cards, sort]);
 
@@ -23,7 +23,7 @@ const Averages = ({ cards, characteristics, defaultFormatId, cube, setAsfans }) 
         .map((tuple) => {
           const vals = tuple[1]
             .filter((card) => {
-              if (characteristic === 'CMC') {
+              if (characteristic === 'Mana Value') {
                 /* If we are calculating the average cmc, we don't want to include lands in the average.
                    We can't just filter out 0 cmc cards, so we need to check the type here. */
                 const type = cardType(card);

--- a/src/analytics/Chart.js
+++ b/src/analytics/Chart.js
@@ -11,7 +11,7 @@ import { sortIntoGroups, SORTS } from 'utils/Sort';
 
 const Chart = ({ cards, characteristics, setAsfans, cube, defaultFormatId }) => {
   const [sort, setSort] = useQueryParam('sort', 'Color Identity');
-  const [characteristic, setcharacteristic] = useQueryParam('field', 'CMC');
+  const [characteristic, setcharacteristic] = useQueryParam('field', 'Mana Value');
 
   const groups = sortIntoGroups(cards, sort);
 
@@ -95,7 +95,7 @@ const Chart = ({ cards, characteristics, setAsfans, cube, defaultFormatId }) => 
       <Row>
         <Col>
           <h4 className="d-lg-block d-none">Chart</h4>
-          <p>View the counts of a characteristic on a chart. For unstacked columns, used 'Unsorted'.</p>
+          <p>View the counts of a characteristic on a chart. For unstacked columns, use 'Unsorted'.</p>
           <InputGroup className="mb-3">
             <InputGroupAddon addonType="prepend">
               <InputGroupText>Group by: </InputGroupText>

--- a/src/components/AutocardListGroup.js
+++ b/src/components/AutocardListGroup.js
@@ -59,7 +59,7 @@ AutocardListGroup.propTypes = {
 AutocardListGroup.defaultProps = {
   rowTag: AutocardListItem,
   noGroupModal: false,
-  sort: 'CMC-Full',
+  sort: 'Mana Value Full',
   orderedSort: 'Alphabetical',
   showOther: false,
 };

--- a/src/components/CardModal.js
+++ b/src/components/CardModal.js
@@ -130,9 +130,9 @@ const CardModal = ({
               </InputGroup>
               <InputGroup className="mb-3">
                 <InputGroupAddon addonType="prepend">
-                  <InputGroupText>CMC</InputGroupText>
+                  <InputGroupText>Mana Value</InputGroupText>
                 </InputGroupAddon>
-                <Input type="text" name="cmc" value={values.cmc} onChange={onChange} />
+                <Input type="number" name="cmc" value={values.cmc} onChange={onChange} />
               </InputGroup>
               <InputGroup className="mb-3">
                 <InputGroupAddon addonType="prepend">

--- a/src/components/CardModal.js
+++ b/src/components/CardModal.js
@@ -132,7 +132,7 @@ const CardModal = ({
                 <InputGroupAddon addonType="prepend">
                   <InputGroupText>Mana Value</InputGroupText>
                 </InputGroupAddon>
-                <Input type="number" name="cmc" value={values.cmc} onChange={onChange} />
+                <Input type="text" name="cmc" value={values.cmc} onChange={onChange} />
               </InputGroup>
               <InputGroup className="mb-3">
                 <InputGroupAddon addonType="prepend">

--- a/src/components/CardModalForm.js
+++ b/src/components/CardModalForm.js
@@ -98,6 +98,10 @@ const CardModalForm = ({ children, ...props }) => {
     if (updated.colorCategory === cardGetLabels(card, 'Color Category')) {
       updated.colorCategory = null;
     }
+    updated.cmc = parseInt(updated.cmc, 10);
+    if (isNaN(updated.cmc)) {
+      updated.cmc = null;
+    }
     updated.cardID = updated.version;
     delete updated.version;
     updated.tags = updated.tags.map((tag) => tag.text);

--- a/src/components/CompareView.js
+++ b/src/components/CompareView.js
@@ -8,9 +8,9 @@ import AutocardListItem from './AutocardListItem';
 import SortContext from 'contexts/SortContext';
 
 const CompareGroup = ({ heading, both, onlyA, onlyB }) => {
-  let bothCmc = sortIntoGroups(both, 'CMC');
-  let onlyACmc = sortIntoGroups(onlyA, 'CMC');
-  let onlyBCmc = sortIntoGroups(onlyB, 'CMC');
+  let bothCmc = sortIntoGroups(both, 'Mana Value');
+  let onlyACmc = sortIntoGroups(onlyA, 'Mana Value');
+  let onlyBCmc = sortIntoGroups(onlyB, 'Mana Value');
 
   return (
     <ListGroup className="list-outline">
@@ -22,7 +22,7 @@ const CompareGroup = ({ heading, both, onlyA, onlyB }) => {
           <Col>({onlyB.length})</Col>
         </Row>
       </ListGroupItem>
-      {getLabels(null, 'CMC')
+      {getLabels(null, 'Mana Value')
         .filter((cmc) => onlyACmc[cmc] || bothCmc[cmc] || onlyBCmc[cmc])
         .map((cmc) => (
           <Row key={cmc} noGutters className="cmc-group">

--- a/src/components/CurveView.js
+++ b/src/components/CurveView.js
@@ -9,10 +9,10 @@ import { fromEntries } from 'utils/Util';
 import AutocardListGroup from 'components/AutocardListGroup';
 import SortContext from 'contexts/SortContext';
 
-const cmc2Labels = getLabels(null, 'CMC2');
+const cmc2Labels = getLabels(null, 'Mana Value 2');
 
 const TypeRow = ({ cardType, group }) => {
-  const sorted = fromEntries(sortDeep(group, false, 'Alphabetical', 'CMC2'));
+  const sorted = fromEntries(sortDeep(group, false, 'Alphabetical', 'Mana Value 2'));
   return (
     <>
       <h6>

--- a/src/components/FilterCollapse.js
+++ b/src/components/FilterCollapse.js
@@ -32,7 +32,7 @@ import CubeContext from 'contexts/CubeContext';
 const allFields = [
   'name',
   'oracle',
-  'cmc',
+  'mv',
   'mana',
   'type',
   'set',
@@ -53,7 +53,7 @@ const allFields = [
   'is',
 ];
 const numFields = [
-  'cmc',
+  'mv',
   'price',
   'priceFoil',
   'priceEur',
@@ -92,8 +92,8 @@ const AdvancedFilterModal = ({ isOpen, toggle, apply, values, onChange, ...props
           onChange={onChange}
         />
         <NumericField
-          name="cmc"
-          humanName="CMC"
+          name="mv"
+          humanName="Mana Value"
           placeholder={'Any value, e.g. "2"'}
           value={values.cmc}
           valueOp={values.cmcOp}
@@ -426,7 +426,7 @@ class FilterCollapse extends Component {
     }
 
     if (this.state.cmcQuick) {
-      tokens.push(`cmc${this.state.cmcQuickOp}${this.state.cmcQuick}`);
+      tokens.push(`mv${this.state.cmcQuickOp}${this.state.cmcQuick}`);
     }
 
     for (const name of ['type', 'text']) {
@@ -552,7 +552,7 @@ class FilterCollapse extends Component {
             <Col xs="auto" style={{ padding: '0 5px' }}>
               <InputGroup size="sm" className="mb-3">
                 <InputGroupAddon addonType="prepend">
-                  <InputGroupText htmlFor="cmcQuick">CMC</InputGroupText>
+                  <InputGroupText htmlFor="cmcQuick">Mana Value</InputGroupText>
                 </InputGroupAddon>
                 <CustomInput
                   id="cmcQickOp"

--- a/src/components/GroupModal.js
+++ b/src/components/GroupModal.js
@@ -310,7 +310,7 @@ const GroupModal = ({ cubeID, canEdit, children, ...props }) => {
                 <h5>Override Attribute on All</h5>
                 <InputGroup className="mb-2">
                   <InputGroupAddon addonType="prepend">
-                    <InputGroupText>CMC</InputGroupText>
+                    <InputGroupText>Mana Value</InputGroupText>
                   </InputGroupAddon>
                   <Input type="text" name="cmc" value={formValues.cmc} onChange={handleChange} />
                 </InputGroup>

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -440,7 +440,7 @@ const ListView = ({ cards }) => {
               <th>Type</th>
               <th>Status</th>
               <th>Finish</th>
-              <th>CMC</th>
+              <th>MV</th>
               <th>Color</th>
               <th>Tags</th>
             </tr>

--- a/src/components/SortCollapse.js
+++ b/src/components/SortCollapse.js
@@ -25,8 +25,18 @@ const SortCollapse = ({
   const { canEdit, cubeID } = useContext(CubeContext);
   const { primary, secondary, tertiary, quaternary, showOther, changeSort } = useContext(SortContext);
 
+  const normalizeSort = (sort) => {
+    if (sort === 'CMC') return 'Mana Value';
+    if (sort === 'CMC2') return 'Mana Value 2';
+    if (sort === 'CMC-Full') return 'Mana Value Full';
+    return sort;
+  };
   const formSorts = (src) => {
-    return [src[0] || 'Color Category', src[1] || 'Types-Multicolor', src[2] || 'Mana Value', src[3] || 'Alphabetical'];
+    const sorts = ['Color Category', 'Types-Multicolor', 'Mana Value', 'Alphabetical'];
+    for (let i = 0; i < 4; i++) {
+      if (src[i]) sorts[i] = normalizeSort(src[i]);
+    }
+    return sorts;
   };
 
   const [defSorts, setDefSorts] = useState(formSorts(defaultSorts));
@@ -35,10 +45,10 @@ const SortCollapse = ({
   const prevSorts = useRef(defSorts);
   const prevShow = useRef(defShow);
   useEffect(() => {
-    let currentPrimarySort = defaultPrimarySort ?? '';
-    let currentSecondarySort = defaultSecondarySort ?? '';
-    let currentTertiarySort = defaultTertiarySort ?? '';
-    let currentQuaternarySort = defaultQuaternarySort ?? '';
+    let currentPrimarySort = normalizeSort(defaultPrimarySort) ?? '';
+    let currentSecondarySort = normalizeSort(defaultSecondarySort) ?? '';
+    let currentTertiarySort = normalizeSort(defaultTertiarySort) ?? '';
+    let currentQuaternarySort = normalizeSort(defaultQuaternarySort) ?? '';
     let currentShowUnsorted = defaultShowUnsorted ?? '';
     if (!SORTS.includes(currentPrimarySort)) currentPrimarySort = '';
     if (!SORTS.includes(currentSecondarySort)) currentSecondarySort = '';

--- a/src/components/SortCollapse.js
+++ b/src/components/SortCollapse.js
@@ -26,7 +26,7 @@ const SortCollapse = ({
   const { primary, secondary, tertiary, quaternary, showOther, changeSort } = useContext(SortContext);
 
   const formSorts = (src) => {
-    return [src[0] || 'Color Category', src[1] || 'Types-Multicolor', src[2] || 'CMC', src[3] || 'Alphabetical'];
+    return [src[0] || 'Color Category', src[1] || 'Types-Multicolor', src[2] || 'Mana Value', src[3] || 'Alphabetical'];
   };
 
   const [defSorts, setDefSorts] = useState(formSorts(defaultSorts));
@@ -296,7 +296,7 @@ SortCollapse.defaultProps = {
   defaultTertiarySort: '',
   defaultQuaternarySort: '',
   defaultShowUnsorted: '',
-  defaultSorts: ['Color Category', 'Types-Multicolor', 'CMC', 'Alphabetical'],
+  defaultSorts: ['Color Category', 'Types-Multicolor', 'Mana Value', 'Alphabetical'],
   cubeDefaultShowUnsorted: false,
 };
 

--- a/src/contexts/SortContext.js
+++ b/src/contexts/SortContext.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 const SortContext = React.createContext({
   primary: 'Color Category',
   secondary: 'Types-Multicolor',
-  tertiary: 'CMC',
+  tertiary: 'Mana Value',
   quaternary: 'Alphabetical',
   showOther: false,
 });
@@ -16,7 +16,7 @@ export class SortContextProvider extends React.Component {
       defaultSorts: [
         primary = 'Color Category',
         secondary = 'Types-Multicolor',
-        tertiary = 'CMC',
+        tertiary = 'Mana Value',
         quaternary = 'Alphabetical',
       ],
       showOther = false,

--- a/src/pages/CubeAnalysisPage.js
+++ b/src/pages/CubeAnalysisPage.js
@@ -103,7 +103,7 @@ const CubeAnalysisPage = ({
       : null;
 
   const characteristics = {
-    CMC: convertToCharacteristic('CMC', cardCmc),
+    'Mana Value': convertToCharacteristic('Mana Value', cardCmc),
     Power: convertToCharacteristic('Power', (card) => parseInt(cardPower(card), 10)),
     Toughness: convertToCharacteristic('Toughness', (card) => parseInt(cardToughness(card), 10)),
     Elo: convertToCharacteristic('Elo', (card) => parseFloat(card.details.elo, 10)),

--- a/src/pages/FiltersPage.js
+++ b/src/pages/FiltersPage.js
@@ -313,9 +313,9 @@ const ContactPage = ({ user, loginCallback }) => (
           </tr>
         </table>
       </Accordion>
-      <Accordion title="Converted Mana Cost">
+      <Accordion title="Mana Value">
         <p>
-          You can use <code>cmc:</code> to search for specific converted mana costs.
+          You can use <code>mv:</code> to search for specific mana values.
         </p>
         <p>
           Operators supported: <code>:</code>, <code>=</code>, <code>{'<'}</code>, <code>{'>'}</code>,{' '}
@@ -328,15 +328,15 @@ const ContactPage = ({ user, loginCallback }) => (
           <tr>
             <td>
               {' '}
-              <code>{'cmc>5'}</code>{' '}
+              <code>{'mv>5'}</code>{' '}
             </td>
-            <td>Cards with converted mana cost greater than 5.</td>
+            <td>Cards with mana value greater than 5.</td>
           </tr>
           <tr>
             <td>
-              <code>cmc=3</code>{' '}
+              <code>mv=3</code>{' '}
             </td>
-            <td>Cards with converted mana cost of exactly 3.</td>
+            <td>Cards with mana value of exactly 3.</td>
           </tr>
         </table>
       </Accordion>

--- a/src/utils/Sort.js
+++ b/src/utils/Sort.js
@@ -145,8 +145,8 @@ export function GetColorCategory(type, colors) {
 
 export const SORTS = [
   'Artist',
-  'CMC',
-  'CMC2',
+  'Mana Value',
+  'Mana Value 2',
   'Color Category',
   'Color Category Full',
   'Color Count',
@@ -186,7 +186,7 @@ export const SORTS = [
   'Unsorted',
 ];
 
-export const ORDERED_SORTS = ['Alphabetical', 'CMC', 'Price'];
+export const ORDERED_SORTS = ['Alphabetical', 'Mana Value', 'Price'];
 
 const allDevotions = (cube, color) => {
   const counts = new Set();
@@ -251,11 +251,11 @@ function getLabelsRaw(cube, sort, showOther) {
     ret = SINGLE_COLOR.concat(['Colorless']).concat(GUILDS).concat(SHARDS_AND_WEDGES).concat(FOUR_AND_FIVE_COLOR);
   } else if (sort === 'Color Combination Includes' || sort === 'Includes Color Combination') {
     ret = ['Colorless'].concat(SINGLE_COLOR).concat(GUILDS).concat(SHARDS_AND_WEDGES).concat(FOUR_AND_FIVE_COLOR);
-  } else if (sort === 'CMC') {
+  } else if (sort === 'Mana Value') {
     ret = ['0', '1', '2', '3', '4', '5', '6', '7', '8+'];
-  } else if (sort === 'CMC2') {
+  } else if (sort === 'Mana Value 2') {
     ret = ['0-1', '2', '3', '4', '5', '6', '7+'];
-  } else if (sort === 'CMC-Full') {
+  } else if (sort === 'Mana Value Full') {
     // All CMCs from 0-16, with halves included, plus Gleemax at 1,000,000.
     ret = ALL_CMCS;
   } else if (sort === 'Color') {
@@ -460,7 +460,7 @@ export function cardGetLabels(card, sort, showOther) {
     } else if (cardColorIdentity(card).length === 4) {
       ret = [...'WUBRG'].filter((c) => !cardColorIdentity(card).includes(c)).map((c) => `Non-${COLOR_MAP[c]}`);
     }
-  } else if (sort === 'CMC') {
+  } else if (sort === 'Mana Value') {
     // Sort by CMC, but collapse all >= 8 into '8+' category.
     const cmc = Math.round(cmcToNumber(card));
     if (cmc >= 8) {
@@ -468,7 +468,7 @@ export function cardGetLabels(card, sort, showOther) {
     } else {
       ret = [cmc.toString()];
     }
-  } else if (sort === 'CMC2') {
+  } else if (sort === 'Mana Value 2') {
     const cmc = Math.round(cmcToNumber(card));
     if (cmc >= 7) {
       ret = ['7+'];
@@ -477,7 +477,7 @@ export function cardGetLabels(card, sort, showOther) {
     } else {
       ret = [cmc.toString()];
     }
-  } else if (sort === 'CMC-Full') {
+  } else if (sort === 'Mana Value Full') {
     // Round to half-integer.
     ret = [(Math.round(cmcToNumber(card) * 2) / 2).toString()];
   } else if (sort === 'Supertype' || sort === 'Type') {
@@ -702,7 +702,7 @@ export function sortIntoGroups(cards, sort, showOther) {
 
 const OrderSortMap = {
   Alphabetical: alphaCompare,
-  CMC: (a, b) => cardCmc(a) - cardCmc(b),
+  'Mana Value': (a, b) => cardCmc(a) - cardCmc(b),
   Price: (a, b) => cardPrice(a) - cardPrice(b),
 };
 
@@ -734,7 +734,7 @@ export function sortForCSVDownload(
   cards,
   primary = 'Color Category',
   secondary = 'Types-Multicolor',
-  tertiary = 'CMC',
+  tertiary = 'Mana Value',
   quaternary = 'Alphabetical',
   showOther = false,
 ) {


### PR DESCRIPTION
This PR changes the user-visible components with the text "CMC" or "Converted Mana Cost" to display the term "Mana Value" instead.

### What Wasn't Changed
An important distinction is that this PR only affects user-facing front-end values. Things like variable names, database fields, or route parameters were kept unchanged, as was the CSV header field. Since I'm not in the business of throwing away my time, I decided those things weren't worth changing.

### What Was Changed
- **The Card Modal:** the modal had a field called "CMC". That field was renamed to "Mana Value". Same for the corresponding field on the **Group Modal**.
- **The Filter**: A new `mv:` filter was added, and the text in the **Filter Modal** was adjusted to use "Mana Value". The documentation on the filter page was updated accordingly.
- **The Sorts**: All CMC-based sorts were renamed to their "Mana Value" equivalents, and in-code usage of sorting functions was appropriately adjusted.
- **List View**: The list view header was changed to say "MV" instead of "CMC". This is the only place that uses a shorthand form of "Mana Value" (aside from the filter), since the full phrase wouldn't fit on one line in the header and caused a jarring visual inconsistency.
- **unrelated**: fixed a bug where the server could crash if someone passed a non-numeric mana value from a card modal.

### Compatibility
To ensure that existing setups don't break too much, a few additional measures were taken to ensure some form of backwards compatibility.
- The `cmc:` filter is still available as an alternative to `mv:`.
- The `SortCollapse` and components using it will automatically translate CMC sorts to Mana Value sorts. This means that existing sort URL parameters will continue to work normally, as will the default values stored in database. Other components that require sorting, namely the analytics tabs, aren't backwards compatible. I'm of the opinion that the added complexity of trying to keep all of those backwards compatible would outweigh the benefits of that compatibility. Most players (I estimate) don't use analytics with a saved sort parameter. Those who do will not see a severe error, but simply an empty table, which can be easily corrected by changing/removing the sort value.
- As previously mentioned, all object fields, database fields, internal variables, HTML element arguments, and route parameters were left unchanged.