### PR TITLE
Hotfix package keywords

### DIFF
--- a/routes/packages.js
+++ b/routes/packages.js
@@ -134,7 +134,7 @@ router.post('/submit', ensureAuth, async (req, res) => {
   }
 
   // make distinct
-  pack.keywords = pack.keywords.filter((value, index, self) => self.indexOf(value));
+  pack.keywords = pack.keywords.filter((value, index, self) => self.indexOf(value) === index);
 
   await pack.save();
 


### PR DESCRIPTION
Fixes the filter that makes keywords unique for a package.

I would suggest a correction script is run that re-adds the first word into the list.