### PR TITLE
Short ID merge

### DIFF
--- a/__tests__/serverjs/cubefn.test.js
+++ b/__tests__/serverjs/cubefn.test.js
@@ -22,17 +22,7 @@ afterEach(() => {
   carddb.unloadCardDb();
 });
 
-test('getCubeId returns urlAlias when defined', () => {
-  const testCube = {
-    urlAlias: 'a',
-    shortID: 'bbb',
-    _id: 'c',
-  };
-  const result = cubefn.getCubeId(testCube);
-  expect(result).toBe(testCube.urlAlias);
-});
-
-test('getCubeId returns shortId when urlAlias is not present', () => {
+test('getCubeId returns shortID when defined', () => {
   const testCube = {
     shortID: 'bbb',
     _id: 'c',
@@ -55,13 +45,10 @@ test('buildIdQuery returns a simple query when passed a 24-character alphanumeri
   expect(result._id).toBe(testId);
 });
 
-test('buildIdQuery returns a boolean query when passed a non-alphanumeric string', () => {
+test('buildIdQuery returns a shortID query when passed a non-alphanumeric string', () => {
   const testId = 'a1a-a1a1a1a1a1a1a1a1a1a1';
   const result = cubefn.buildIdQuery(testId);
-  const condition = result.$or;
-  expect(condition.length).toBe(2);
-  expect(condition[0].shortID).toBe(testId);
-  expect(condition[1].urlAlias).toBe(testId);
+  expect(result.shortID).toBe(testId);
 });
 
 test('cardsAreEquivalent returns true for two equivalent cards', () => {
@@ -117,7 +104,6 @@ test('legalityToInt returns the expected values', () => {
 test('generateShortId returns a valid short ID', async () => {
   const dummyModel = {
     shortID: '1x',
-    urlAlias: 'a real alias',
   };
   const queryMockPromise = new Promise((resolve) => {
     process.nextTick(() => {
@@ -136,7 +122,6 @@ test('generateShortId returns a valid short ID', async () => {
 test('generateShortId returns a valid short ID with profanity', async () => {
   const dummyModel = {
     shortID: '1x',
-    urlAlias: 'a real alias',
   };
   const queryMockPromise = new Promise((resolve) => {
     process.nextTick(() => {

--- a/models/cube.js
+++ b/models/cube.js
@@ -55,10 +55,6 @@ const cubeSchema = mongoose.Schema({
     required: true,
     unique: true,
   },
-  urlAlias: {
-    type: String,
-    unique: true,
-  },
   owner: {
     type: String,
     required: true,
@@ -174,10 +170,6 @@ cubeSchema.index({
 });
 
 cubeSchema.index({
-  urlAlias: 1,
-});
-
-cubeSchema.index({
   isListed: 1,
 });
 
@@ -212,8 +204,8 @@ cubeSchema.index({
 const Cube = mongoose.model('Cube', cubeSchema);
 
 Cube.LAYOUT_FIELDS =
-  '_id owner name type card_count overrideCategory categoryOverride categoryPrefixes image_uri urlAlias';
+  '_id owner name type card_count overrideCategory categoryOverride categoryPrefixes image_uri shortID';
 Cube.PREVIEW_FIELDS =
-  '_id shortId urlAlias name card_count type overrideCategory categoryOverride categoryPrefixes image_name image_artist image_uri owner owner_name image_uri';
+  '_id shortID name card_count type overrideCategory categoryOverride categoryPrefixes image_name image_artist image_uri owner owner_name image_uri';
 
 module.exports = Cube;

--- a/routes/cube/api.js
+++ b/routes/cube/api.js
@@ -24,6 +24,7 @@ const {
   newCardAnalytics,
   getEloAdjustment,
   addCardHtml,
+  generateShortId,
 } = require('../../serverjs/cubefn.js');
 
 const { DEFAULT_BASICS, ELO_BASE, ELO_SPEED, CUBE_ELO_SPEED } = require('./helper');
@@ -63,13 +64,13 @@ router.post(
     max: 100,
   }),
   body('name', 'Cube name may not use profanity.').custom((value) => !util.hasProfanity(value)),
-  body('urlAlias', 'Custom URL must contain only alphanumeric characters, dashes, and underscores.').matches(
+  body('shortID', 'Custom URL must contain only alphanumeric characters, dashes, and underscores.').matches(
     /^[A-Za-z0-9_-]*$/,
   ),
-  body('urlAlias', `Custom URL may not be longer than 100 characters.`).isLength({
+  body('shortID', `Custom URL may not be longer than 100 characters.`).isLength({
     max: 100,
   }),
-  body('urlAlias', 'Custom URL may not use profanity.').custom((value) => !util.hasProfanity(value)),
+  body('shortID', 'Custom URL may not use profanity.').custom((value) => !util.hasProfanity(value)),
   jsonValidationErrors,
   util.wrapAsyncApi(async (req, res) => {
     const updatedCube = req.body;
@@ -90,9 +91,9 @@ router.post(
       });
     }
 
-    if (updatedCube.urlAlias && updatedCube.urlAlias.length > 0 && updatedCube.urlAlias !== cube.urlAlias) {
-      updatedCube.urlAlias = updatedCube.urlAlias.toLowerCase();
-      const taken = await Cube.findOne(buildIdQuery(updatedCube.urlAlias));
+    if (updatedCube.shortID && updatedCube.shortID.length > 0 && updatedCube.shortID !== cube.shortID) {
+      updatedCube.shortID = updatedCube.shortID.toLowerCase();
+      const taken = await Cube.findOne(buildIdQuery(updatedCube.shortID));
 
       if (taken) {
         return res.status(400).send({
@@ -101,9 +102,9 @@ router.post(
         });
       }
 
-      cube.urlAlias = updatedCube.urlAlias;
-    } else if (!updatedCube.urlAlias || updatedCube.urlAlias === '') {
-      cube.urlAlias = null;
+      cube.shortID = updatedCube.shortID;
+    } else if (!updatedCube.shortID || updatedCube.shortID === '') {
+      cube.shortID = generateShortId(); // generate a new short ID if old one is deleted
     }
 
     cube.name = updatedCube.name;

--- a/routes/cube/api.js
+++ b/routes/cube/api.js
@@ -24,7 +24,6 @@ const {
   newCardAnalytics,
   getEloAdjustment,
   addCardHtml,
-  generateShortId,
 } = require('../../serverjs/cubefn.js');
 
 const { DEFAULT_BASICS, ELO_BASE, ELO_SPEED, CUBE_ELO_SPEED } = require('./helper');
@@ -67,7 +66,8 @@ router.post(
   body('shortID', 'Custom URL must contain only alphanumeric characters, dashes, and underscores.').matches(
     /^[A-Za-z0-9_-]*$/,
   ),
-  body('shortID', `Custom URL may not be longer than 100 characters.`).isLength({
+  body('shortID', `Custom URL may not be empty or longer than 100 characters.`).isLength({
+    min: 1,
     max: 100,
   }),
   body('shortID', 'Custom URL may not use profanity.').custom((value) => !util.hasProfanity(value)),
@@ -91,7 +91,7 @@ router.post(
       });
     }
 
-    if (updatedCube.shortID && updatedCube.shortID.length > 0 && updatedCube.shortID !== cube.shortID) {
+    if (updatedCube.shortID !== cube.shortID) {
       updatedCube.shortID = updatedCube.shortID.toLowerCase();
       const taken = await Cube.findOne(buildIdQuery(updatedCube.shortID));
 
@@ -103,8 +103,6 @@ router.post(
       }
 
       cube.shortID = updatedCube.shortID;
-    } else if (!updatedCube.shortID || updatedCube.shortID === '') {
-      cube.shortID = generateShortId(); // generate a new short ID if old one is deleted
     }
 
     cube.name = updatedCube.name;

--- a/routes/cube/index.js
+++ b/routes/cube/index.js
@@ -547,7 +547,7 @@ router.get('/compare/:idA/to/:idB', async (req, res) => {
 router.get('/list/:id', async (req, res) => {
   try {
     const fields =
-      'cards maybe name owner card_count type tag_colors default_sorts default_show_unsorted overrideCategory categoryOverride categoryPrefixes image_uri urlAlias';
+      'cards maybe name owner card_count type tag_colors default_sorts default_show_unsorted overrideCategory categoryOverride categoryPrefixes image_uri shortID';
     const cube = await Cube.findOne(buildIdQuery(req.params.id), fields).lean();
     if (!cube) {
       req.flash('danger', 'Cube not found');

--- a/routes/root.js
+++ b/routes/root.js
@@ -21,7 +21,7 @@ const router = express.Router();
 router.use(csrfProtection);
 
 const CUBE_PREVIEW_FIELDS =
-  '_id urlAlias shortId image_uri image_name image_artist name owner owner_name type card_count overrideCategory categoryPrefixes categoryOverride';
+  '_id shortID image_uri image_name image_artist name owner owner_name type card_count overrideCategory categoryPrefixes categoryOverride';
 
 // Home route
 router.get('/', async (req, res) => (req.user ? res.redirect('/dashboard') : res.redirect('/landing')));

--- a/seeds/cubes.json
+++ b/seeds/cubes.json
@@ -10007,8 +10007,7 @@
     "publicPrices": false, 
     "shortID": "1", 
     "type": "Vintage", 
-    "updated_string": "9/8/2019, 4:03:55 PM", 
-    "urlAlias": null
+    "updated_string": "9/8/2019, 4:03:55 PM"
   }, 
   {
     "_id": "5d755eba846f3a19d8b4dfa1", 
@@ -17606,7 +17605,6 @@
     "publicPrices": false, 
     "shortID": "2", 
     "type": "Vintage", 
-    "updated_string": "9/8/2019, 4:04:34 PM", 
-    "urlAlias": "seedcube"
+    "updated_string": "9/8/2019, 4:04:34 PM"
   }
 ]

--- a/serverjs/cubefn.js
+++ b/serverjs/cubefn.js
@@ -10,34 +10,21 @@ const util = require('./util');
 const { getDraftFormat, createDraft } = require('../dist/utils/draftutil.js');
 
 function getCubeId(cube) {
-  if (cube.urlAlias) return cube.urlAlias;
   if (cube.shortID) return cube.shortID;
   return cube._id;
 }
 
 function buildIdQuery(id) {
   if (!id || id.match(/^[0-9a-fA-F]{24}$/)) {
-    return {
-      _id: id,
-    };
+    return { _id: id };
   }
-  return {
-    $or: [
-      {
-        shortID: id.toLowerCase(),
-      },
-      {
-        urlAlias: id.toLowerCase(),
-      },
-    ],
-  };
+  return { shortID: id.toLowerCase() };
 }
 
 async function generateShortId() {
-  const cubes = await Cube.find({}, ['shortID', 'urlAlias']);
+  const cubes = await Cube.find({}, ['shortID']);
 
   const shortIds = cubes.map((cube) => cube.shortID);
-  const urlAliases = cubes.map((cube) => cube.urlAlias);
 
   const ids = cubes.map((cube) => util.fromBase36(cube.shortID));
   let max = Math.max(...ids);
@@ -52,7 +39,7 @@ async function generateShortId() {
     max += 1;
     newId = util.toBase36(max);
 
-    isGoodId = !util.hasProfanity(newId) && !shortIds.includes(newId) && !urlAliases.includes(newId);
+    isGoodId = !util.hasProfanity(newId) && !shortIds.includes(newId);
   }
 
   return newId;

--- a/serverjs/cubefn.js
+++ b/serverjs/cubefn.js
@@ -23,22 +23,14 @@ function buildIdQuery(id) {
 
 async function generateShortId() {
   const cubes = await Cube.find({}, ['shortID']);
-
   const shortIds = cubes.map((cube) => cube.shortID);
-
-  const ids = cubes.map((cube) => util.fromBase36(cube.shortID));
-  let max = Math.max(...ids);
-
-  if (max < 0) {
-    max = 0;
-  }
+  const space = shortIds.length * 2;
 
   let newId = '';
   let isGoodId = false;
   while (!isGoodId) {
-    max += 1;
-    newId = util.toBase36(max);
-
+    const rand = Math.floor(Math.random() * space);
+    newId = util.toBase36(rand);
     isGoodId = !util.hasProfanity(newId) && !shortIds.includes(newId);
   }
 

--- a/src/components/CubeOverviewModal.js
+++ b/src/components/CubeOverviewModal.js
@@ -231,12 +231,13 @@ class CubeOverviewModal extends Component {
               <ModalBody>
                 <h6>Cube Name</h6>
                 <input
-                  className="form-control"
-                  name="name"
-                  type="text"
+                  className='form-control'
+                  name='name'
+                  type='text'
                   value={cube.name}
+                  required={true}
                   onChange={this.handleChange}
-                ></input>
+                />
                 <br />
 
                 <h6>Options</h6>
@@ -368,6 +369,7 @@ class CubeOverviewModal extends Component {
                   type="text"
                   value={cube.shortID}
                   onChange={this.handleChange}
+                  required={true}
                   placeholder="Give this cube an easy to remember URL."
                 />
                 <br />

--- a/src/components/CubeOverviewModal.js
+++ b/src/components/CubeOverviewModal.js
@@ -231,9 +231,9 @@ class CubeOverviewModal extends Component {
               <ModalBody>
                 <h6>Cube Name</h6>
                 <input
-                  className='form-control'
-                  name='name'
-                  type='text'
+                  className="form-control"
+                  name="name"
+                  type="text"
                   value={cube.name}
                   required={true}
                   onChange={this.handleChange}

--- a/src/components/CubeOverviewModal.js
+++ b/src/components/CubeOverviewModal.js
@@ -168,7 +168,7 @@ class CubeOverviewModal extends Component {
         },
       }));
     } else {
-      if (target.name === 'urlAlias') this.setState({ urlChanged: true });
+      if (target.name === 'shortID') this.setState({ urlChanged: true });
       this.setState((prevState) => ({
         cube: {
           ...prevState.cube,
@@ -364,9 +364,9 @@ class CubeOverviewModal extends Component {
                 <h6>Custom ID</h6>
                 <input
                   className="form-control"
-                  name="urlAlias"
+                  name="shortID"
                   type="text"
-                  value={cube.urlAlias ? cube.urlAlias : ''}
+                  value={cube.shortID}
                   onChange={this.handleChange}
                   placeholder="Give this cube an easy to remember URL."
                 />

--- a/src/pages/BrowsePackagesPage.js
+++ b/src/pages/BrowsePackagesPage.js
@@ -60,8 +60,8 @@ const BrowsePackagesPage = ({ user, loginCallback }) => {
   };
 
   const changeTab = (i) => {
-	setPage(0);
-	setSelectedTab(i);
+    setPage(0);
+    setSelectedTab(i);
   };
 
   useEffect(() => {

--- a/src/proptypes/CubeAnalyticPropType.js
+++ b/src/proptypes/CubeAnalyticPropType.js
@@ -3,8 +3,7 @@ import CardPropType from 'proptypes/CardPropType';
 
 const CubePropType = PropTypes.shape({
   _id: PropTypes.string.isRequired,
-  shortId: PropTypes.string,
-  urlAlias: PropTypes.string,
+  shortID: PropTypes.string,
   name: PropTypes.string,
   card_count: PropTypes.number,
   cards: PropTypes.arrayOf(CardPropType),

--- a/src/utils/Util.js
+++ b/src/utils/Util.js
@@ -168,7 +168,7 @@ export function isTouchDevice() {
 }
 
 export function getCubeId(cube) {
-  return cube.urlAlias || cube.shortID || cube._id;
+  return cube.shortID || cube._id;
 }
 
 export function getCubeDescription(cube) {


### PR DESCRIPTION
Resolves #1875.

This PR changes the cube's data model so that `shortID` and `urlAlias` are merged into a single property - `shortID` - and it updates the usage accordingly. It also changes the way shortIDs are generated to accommodate this change.

## Migration
Simply merging this PR will result in the server just ignoring existing `urlAlias` fields. This will break any links that are based on that value. To make sure that doesn't happen (and to remove the newly useless `urlAlias` values from the DB), we need to run a migration moving the values of `urlAlias` to `shortID` where appropriate. The migration can be as simple as:
```js
if (cube.urlAlias) cube.shortID = cube.urlAlias;
cube.urlAlias = undefined;
```
for each cube.
### ⚠️ Caution
If the migration is run using Mongoose, it must be run on the old models, i.e. *before* this is deployed.  If it's run on the model in this PR, Mongoose will simply ignore `urlAlias` values, set them to `undefined`, and no `shortID`s will be overwritten.