### PR TITLE
Upload decklist fix

### DIFF
--- a/routes/cube/deck.js
+++ b/routes/cube/deck.js
@@ -814,7 +814,7 @@ router.get('/redraft/:id', async (req, res) => {
 
 router.post('/uploaddecklist/:id', ensureAuth, async (req, res) => {
   try {
-    const cube = await Cube.findOne(buildIdQuery(req.params.id)).lean();
+    const cube = await Cube.findOne(buildIdQuery(req.params.id));
     if (!cube) {
       req.flash('danger', 'Cube not found.');
       return res.redirect('/404');


### PR DESCRIPTION
In the `/cube/uploaddecklist` route, the cube is fetched as a lean object, but then is modified. When we attempt to save those modifications, it results in an error, since `cube.save` doesn't exist.

Since the modification is necessary, the obvious solution is to not get a lean object from mongoose.﻿
