### PR TITLE
Packages QoL improvements

### DIFF
--- a/routes/packages.js
+++ b/routes/packages.js
@@ -223,4 +223,8 @@ router.get('/:id', async (req, res) => {
   });
 });
 
+router.get('/', (req, res) => {
+  res.redirect('/packages/browse');
+});
+
 module.exports = router;

--- a/routes/packages.js
+++ b/routes/packages.js
@@ -84,14 +84,14 @@ router.get('/browse', async (req, res) => {
 router.post('/submit', ensureAuth, async (req, res) => {
   const { cards, packageName } = req.body;
 
-  if (packageName === 'Untitled Package') {
+  if (typeof packageName !== 'string' || packageName.length === 0) {
     return res.status(400).send({
       success: 'false',
       message: 'Please provide a name for your new package.',
     });
   }
 
-  if (cards.length < 2) {
+  if (!Array.isArray(cards) || cards.length < 2) {
     return res.status(400).send({
       success: 'false',
       message: 'Please provide more than one card for your package.',

--- a/src/components/CreatePackageModal.js
+++ b/src/components/CreatePackageModal.js
@@ -23,7 +23,7 @@ import AutocompleteInput from 'components/AutocompleteInput';
 const CreatePackageModal = ({ isOpen, toggle, onError, onSuccess }) => {
   const [cards, setCards] = useState([]);
   const [cardName, setCardName] = useState('');
-  const [packageName, setPackageName] = useState('Untitled Package');
+  const [packageName, setPackageName] = useState('');
   const [imageDict, setImageDict] = useState({});
 
   useEffect(() => {
@@ -57,6 +57,9 @@ const CreatePackageModal = ({ isOpen, toggle, onError, onSuccess }) => {
 
     if (json.success === 'true') {
       onSuccess('Succesfully created package');
+      setCards([]);
+      setCardName('');
+      setPackageName('');
     } else {
       console.log(json);
       onError(`Error creating package: ${json.message}`);
@@ -76,7 +79,12 @@ const CreatePackageModal = ({ isOpen, toggle, onError, onSuccess }) => {
           <InputGroupAddon addonType="prepend">
             <InputGroupText>Package Name</InputGroupText>
           </InputGroupAddon>
-          <Input type="text" value={packageName} onChange={(e) => setPackageName(e.target.value)} />
+          <Input
+            type="text"
+            value={packageName}
+            placeholder="Untitled Package"
+            onChange={(e) => setPackageName(e.target.value)}
+          />
         </InputGroup>
         <Row className="pb-3">
           <Col xs="12" md="8">

--- a/src/pages/BrowsePackagesPage.js
+++ b/src/pages/BrowsePackagesPage.js
@@ -45,7 +45,7 @@ const BrowsePackagesPage = ({ user, loginCallback }) => {
   const [alerts, setAlerts] = useState([]);
   const [page, setPage] = useQueryParam('p', 0);
   const [filter, setFilter] = useQueryParam('f', '');
-  const [filterTemp, setFilterTemp] = useState(filter);
+  const [filterTemp, setFilterTemp] = useState('');
   const [sort, setSort] = useQueryParam('s', 'votes');
   const [sortDirection, setSortDirection] = useQueryParam('d', '-1');
   const [selectedTab, setSelectedTab] = useQueryParam('tab', '0');
@@ -82,7 +82,7 @@ const BrowsePackagesPage = ({ user, loginCallback }) => {
       }
       return [];
     };
-    fetchData();
+    fetchData().then(() => setFilterTemp(filter));
   }, [filter, page, sort, sortDirection, selectedTab, refresh, setRefresh]);
 
   return (

--- a/src/pages/BrowsePackagesPage.js
+++ b/src/pages/BrowsePackagesPage.js
@@ -132,6 +132,7 @@ const BrowsePackagesPage = ({ user, loginCallback }) => {
               valid={filterTemp !== filter}
               value={filterTemp}
               onChange={(e) => setFilterTemp(e.target.value)}
+              onKeyDown={(e) => e.keyCode === 13 && setFilter(filterTemp)}
             />
             <InputGroupAddon addonType="append">
               <Button color="success" className="square-left" onClick={() => setFilter(filterTemp)}>


### PR DESCRIPTION
Changes in this PR:
- going to `/packages` now redirects to `/packages/browse`
- pressing Enter in the keyword filter input submits the filter
- the filter input is now populated properly from the query parameter
- the Create Package modal is cleared after a package is successfully saved
- the package name submission has better validation