### PR TITLE
Default format fix

### DIFF
--- a/routes/cube/index.js
+++ b/routes/cube/index.js
@@ -1777,6 +1777,12 @@ router.delete('/format/remove/:cubeid/:index', ensureAuth, param('index').toInt(
     }
 
     cube.draft_formats.splice(index, 1);
+    // update defaultFormat if necessary
+    if (index === cube.defaultDraftFormat) {
+      cube.defaultDraftFormat = -1;
+    } else if (index < cube.defaultDraftFormat) {
+      cube.defaultDraftFormat -= 1;
+    }
 
     await cube.save();
     return res.status(200).send({

--- a/src/pages/CubePlaytestPage.js
+++ b/src/pages/CubePlaytestPage.js
@@ -497,10 +497,10 @@ const CubePlaytestPage = ({ user, cube, decks, draftFormats, loginCallback }) =>
         .map((format, index) => ({ ...format, index }))
         .sort((a, b) => {
           if (a.index === defaultDraftFormat) {
-            return 1;
+            return -1;
           }
           if (b.index === defaultDraftFormat) {
-            return -1;
+            return 1;
           }
           return a.title.localeCompare(b.title);
         }),


### PR DESCRIPTION
Changes in this PR:
- `cube.defaultFormat` is now appropriately updated when a format is deleted
- format sorting in playtest page is fixed so that the default format appears on the top