### PR TITLE
Add script for clearing out old drafts.

### DIFF
--- a/jobs/clear_old_drafts.js
+++ b/jobs/clear_old_drafts.js
@@ -1,0 +1,50 @@
+// Load Environment Variables
+require('dotenv').config();
+const mongoose = require('mongoose');
+
+const Deck = require('../models/deck');
+const Draft = require('../models/draft');
+
+const SEVEN_DAYS = 7 * 24 * 60 * 60 * 1000;
+const BATCH_SIZE = 1024;
+const NOW = Date.now();
+
+const getObjectCreatedAtPlus7 = (obj) => {
+  return new Date(parseInt(obj._id.toString().slice(0, 8), 16) * 1000 + SEVEN_DAYS);
+};
+
+const processDraft = async (draft) => {
+  if (draft !== null && getObjectCreatedAtPlus7(draft) < NOW) {
+    if (await Deck.exists({ draft: draft._id })) {
+      return draft._id;
+    }
+  }
+  return null;
+};
+
+(async () => {
+  await mongoose.connect(process.env.MONGODB_URL, { useNewUrlParser: true, useUnifiedTopology: true });
+  const count = await Draft.count();
+  console.log(`There are ${count} drafts in the database.`);
+  const cursor = Draft.find().lean().cursor();
+  const drafts = [];
+  for (let i = 0; i < count; i++) {
+    const draftPromises = [];
+    const nextBound = Math.min(i + BATCH_SIZE, count);
+    for (let j = i; j < nextBound; j++) {
+      // eslint-disable-next-line no-await-in-loop
+      draftPromises.push(processDraft(await cursor.next()));
+    }
+    // eslint-disable-next-line no-await-in-loop
+    drafts.push(...(await Promise.all(draftPromises)).filter((d) => d));
+    i = nextBound - 1;
+    console.log(`Processed ${i + 1} out of ${count} drafts, marking ${drafts.length} for deletion.`);
+  }
+  if (drafts.length > 0) {
+    console.log(`Deleting ${drafts.length} drafts.`);
+    // eslint-disable-next-line no-await-in-loop
+    await Draft.deleteMany({ _id: { $in: drafts } });
+  }
+  mongoose.disconnect();
+  process.exit();
+})();

--- a/jobs/clear_old_drafts.js
+++ b/jobs/clear_old_drafts.js
@@ -15,7 +15,7 @@ const getObjectCreatedAtPlus7 = (obj) => {
 
 const processDraft = async (draft) => {
   if (draft !== null && getObjectCreatedAtPlus7(draft) < NOW) {
-    if (await Deck.exists({ draft: draft._id })) {
+    if (!(await Deck.exists({ draft: draft._id }))) {
       return draft._id;
     }
   }

--- a/models/deck.js
+++ b/models/deck.js
@@ -18,24 +18,27 @@ const SeatDeck = {
 };
 
 // Deck schema
-const deckSchema = mongoose.Schema({
-  cube: String,
-  cubeOwner: String,
-  owner: String,
-  date: Date,
-  draft: {
-    type: String,
-    default: '',
+const deckSchema = mongoose.Schema(
+  {
+    cube: String,
+    cubeOwner: String,
+    owner: String,
+    date: Date,
+    draft: {
+      type: String,
+      default: '',
+    },
+    cubename: {
+      type: String,
+      default: 'Cube',
+    },
+    seats: {
+      type: [SeatDeck],
+      default: [],
+    },
   },
-  cubename: {
-    type: String,
-    default: 'Cube',
-  },
-  seats: {
-    type: [SeatDeck],
-    default: [],
-  },
-});
+  { timestamps: true },
+);
 
 deckSchema.index({
   cubeOwner: 1,
@@ -54,6 +57,10 @@ deckSchema.index({
 deckSchema.index({
   owner: 1,
   date: -1,
+});
+
+deckSchema.index({
+  draft: 1,
 });
 
 module.exports = mongoose.model('Deck', deckSchema);

--- a/models/draft.js
+++ b/models/draft.js
@@ -13,20 +13,23 @@ const Seat = {
 };
 
 // Cube schema
-const draftSchema = mongoose.Schema({
-  cube: String,
-  initial_state: [[[cardSchema]]],
-  seats: [Seat],
-  unopenedPacks: [[[cardSchema]]],
-  basics: {
-    default: [],
-    type: {
-      details: cardSchema,
-      cardID: String,
-      cmc: Number,
-      type_line: String,
+const draftSchema = mongoose.Schema(
+  {
+    cube: String,
+    initial_state: [[[cardSchema]]],
+    seats: [Seat],
+    unopenedPacks: [[[cardSchema]]],
+    basics: {
+      default: [],
+      type: {
+        details: cardSchema,
+        cardID: String,
+        cmc: Number,
+        type_line: String,
+      },
     },
   },
-});
+  { timestamps: true },
+);
 
 module.exports = mongoose.model('Draft', draftSchema);


### PR DESCRIPTION
We have a bunch of unreachable drafts saved that are at least 1 week old so unlikely to be open in any tabs and that haven't been completed so no decks refer to them(if the deck was deleted then we consider it never finished since it's effectively the same thing). Currently they make up about 25% of the database by size so it's a considerable savings to get rid of them.