### PR TITLE
Wiki Prototype

### DIFF
--- a/app.js
+++ b/app.js
@@ -178,6 +178,7 @@ app.use('/comment', require('./routes/comment_routes'));
 app.use('/admin', require('./routes/admin_routes'));
 app.use('/content', require('./routes/content_routes'));
 app.use('/packages', require('./routes/packages'));
+app.use('/wiki', require('./routes/wiki_routes'));
 
 app.use((req, res) => {
   return render(req, res, 'ErrorPage', {

--- a/routes/wiki_routes.js
+++ b/routes/wiki_routes.js
@@ -1,0 +1,31 @@
+const express = require('express');
+
+const fs = require('fs');
+const { render } = require('../serverjs/render');
+
+const router = express.Router();
+
+// Handles the 'wiki/' route with no path after the slash
+// Redirects to the wiki home page
+router.get('/', async (req, res) => {
+  res.redirect('/wiki/home');
+});
+
+// Handle 'wiki/topic/subtopic/...' routes
+// Match subdirectories of wiki whose names contain A-Z, a-z, _, and forward slashes only
+// Importantly, exclude '..'
+// Does match something like '//////', but that gets canonicalized to just '/'
+// Possible security issues here, since this displays the contents of files
+router.get('/:page([A-Za-z/_]+)', async (req, res) => {
+  const { page } = req.params;
+  let fileContents = 'Unable to read wiki page';
+  try {
+    const fd = fs.openSync(`wiki/${page}.md`, 'r');
+    fileContents = fs.readFileSync(fd, { encoding: 'utf-8', flag: 'r' });
+  } catch (error) {
+    return render(req, res, 'WikiPage', { markdown: `# Error loading wiki page wiki/${page}.md: ${error}` });
+  }
+  return render(req, res, 'WikiPage', { markdown: `${fileContents}` });
+});
+
+module.exports = router;

--- a/serverjs/render.js
+++ b/serverjs/render.js
@@ -63,6 +63,7 @@ if (NODE_ENV === 'production') {
   pages.VersionPage = require('../dist/pages/VersionPage').default;
   pages.VideoPage = require('../dist/pages/VideoPage').default;
   pages.VideosPage = require('../dist/pages/VideosPage').default;
+  pages.WikiPage = require('../dist/pages/WikiPage').default;
   pages.AdminCommentsPage = require('../dist/pages/AdminCommentsPage').default;
   pages.AdminDashboardPage = require('../dist/pages/AdminDashboardPage').default;
   pages.ApplicationPage = require('../dist/pages/ApplicationPage').default;

--- a/src/pages/WikiPage.js
+++ b/src/pages/WikiPage.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import RenderToRoot from 'utils/RenderToRoot';
+
+import Markdown from 'components/Markdown';
+
+// Takes in markdown stored in a wiki file and transforms it into the markdown
+// to be displayed on the site.
+//
+// This transformation could include things like...
+// - Adding a link to the home page at the bottom of each page
+// - ...
+function markdownTransform(markdown) {
+  return `${markdown}\n>>>[Back to wiki home page](/wiki/home)<<<`;
+}
+
+const WikiPage = ({ markdown }) => {
+  return <Markdown markdown={markdownTransform(markdown)} />;
+};
+
+WikiPage.propTypes = {
+  markdown: PropTypes.string.isRequired,
+};
+
+export default RenderToRoot(WikiPage);

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -85,6 +85,7 @@ const clientConfig = merge(config, {
     VideoPage: './src/pages/VideoPage.js',
     ReviewVideosPage: './src/pages/ReviewVideosPage.js',
     VideosPage: './src/pages/VideosPage.js',
+    WikiPage: './src/pages/WikiPage.js',
     EditPodcastPage: './src/pages/EditPodcastPage.js',
     PodcastPage: './src/pages/PodcastPage.js',
     ReviewPodcastsPage: './src/pages/ReviewPodcastsPage.js',

--- a/wiki/contributing.md
+++ b/wiki/contributing.md
@@ -1,0 +1,1 @@
+# Contributing to the wiki

--- a/wiki/create_cube.md
+++ b/wiki/create_cube.md
@@ -1,0 +1,7 @@
+# Information on how to make your first cube!
+
+You might want to include some staple cards, like
+
+[[!Seven Dwarves]]
+and
+[[!Hidden Gibbons]]

--- a/wiki/home.md
+++ b/wiki/home.md
@@ -1,0 +1,8 @@
+# Cube Cobra Wiki - Home Page
+
+Welcome to the Cube Cobra wiki!
+
+Links to some more pages
+[Creating a cube](create_cube)
+[Custom draft formats](site_help/custom_draft_formats)
+[Contributing to the wiki](contributing)

--- a/wiki/site_help/custom_draft_formats.md
+++ b/wiki/site_help/custom_draft_formats.md
@@ -1,0 +1,3 @@
+# Custom Draft Formats
+
+If you're having issues with running out of cards when trying to create a draft, you may need to add something like '-t: land' to each card in the pack that isn't supposed to be a land.


### PR DESCRIPTION
This PR contains some work on a wiki prototype or proof of concept.

It adds some new routes, like `cubecobra.com/wiki/home` and `cubecobra.com/wiki/site_help/custom_draft_formats` that display wiki pages with information about different topics about the site.

The wiki pages are in a new `wiki/` directory in the GitHub repo and are written in markdown. The route `cubecobra.com/wiki/<path>` attempts to read in the file `wiki/<path>.md` and parse its contents with the `Markdown` component. `<path>` is constrained to match the regular expression `[A-Za-z/_]+` for security reasons (in particular, no dots `.` are allowed). The empty path, corresponding to `cubecobra.com/wiki`, is just redirected to `cubecobra.com/wiki/home`. There may still be some security issues with the way reading in files is done, I'm not sure exactly.

This PR isn't necessarily intended to be merged, but more for thinking about whether this might be a good way to implement a wiki and get some feedback. I'm not very experienced with web programming, so a lot of the route code is based on the other route code in the repository. There definitely might be some mistakes. Errors and bad routes aren't handled particularly well right now.

Some screenshots (note these wiki pages are just for fun and testing):

Home page
![image](https://user-images.githubusercontent.com/52982949/118217851-e9972900-b43b-11eb-833d-8c0f0eb25beb.png)

Another page (`wiki/create_cube`)
![image](https://user-images.githubusercontent.com/52982949/118217985-25ca8980-b43c-11eb-88d5-b41ef03c0f7d.png)

Route that doesn't exist
![image](https://user-images.githubusercontent.com/52982949/118217922-09c6e800-b43c-11eb-8bcb-efd59195edef.png)