### PR TITLE
Updated the look of the downtime page

### DIFF
--- a/src/pages/DownTimePage.js
+++ b/src/pages/DownTimePage.js
@@ -10,11 +10,11 @@ const DownTimePage = () => (
     </Row>
     <Card>
       <CardHeader>
-        <h5>Cube Cobra is currently down for scheduled maintenence.</h5>
+        <h5>Cube Cobra is currently down for scheduled maintenance.</h5>
       </CardHeader>
       <CardBody>
         <p>
-          The Cube Cobra developers are working hard on improving the service! This downtime is neccesary to improve the
+          The Cube Cobra developers are working hard on improving the service! This downtime is necessary to improve the
           long-term performance of Cube Cobra. Sorry for any temporary inconvenience!
         </p>
         <p>

--- a/src/pages/DownTimePage.js
+++ b/src/pages/DownTimePage.js
@@ -1,15 +1,14 @@
 import React from 'react';
 
 import { Row, Col, Card, CardHeader, CardBody } from 'reactstrap';
-
-import DynamicFlash from 'components/DynamicFlash';
-import MainLayout from 'layouts/MainLayout';
 import RenderToRoot from 'utils/RenderToRoot';
 
 const DownTimePage = () => (
-  <MainLayout>
-    <DynamicFlash />
-    <Card className="my-3 mx-4">
+  <Col xs="12" md="8" xl="5" style={{ margin: 'auto' }}>
+    <Row style={{ margin: 'auto' }} width="50%" className="mb-5 mt-4">
+      <img src="/content/logo.png" alt="Cube Cobra logo" width="50%" style={{ margin: 'auto' }} />
+    </Row>
+    <Card>
       <CardHeader>
         <h5>Cube Cobra is currently down for scheduled maintenence.</h5>
       </CardHeader>
@@ -22,6 +21,7 @@ const DownTimePage = () => (
           Feel free to contact us if you have any issues or concerns. Comments, ideas, and suggestions are always
           welcome. Here are the easiest ways to get in touch with us:
         </p>
+
         <Row>
           <Col xs="12" sm="4">
             <strong>Official Twitter</strong>
@@ -48,7 +48,7 @@ const DownTimePage = () => (
         </Row>
       </CardBody>
     </Card>
-  </MainLayout>
+  </Col>
 );
 
 export default RenderToRoot(DownTimePage);

--- a/src/pages/DownTimePage.js
+++ b/src/pages/DownTimePage.js
@@ -5,7 +5,7 @@ import RenderToRoot from 'utils/RenderToRoot';
 
 const DownTimePage = () => (
   <Col xs="12" md="8" xl="5" style={{ margin: 'auto' }}>
-    <Row style={{ margin: 'auto' }} width="50%" className="mb-5 mt-4">
+    <Row className="mb-5 mt-4">
       <img src="/content/logo.png" alt="Cube Cobra logo" width="50%" style={{ margin: 'auto' }} />
     </Row>
     <Card>


### PR DESCRIPTION
The current downtime page uses `MainLayout`, which includes a lot of links, which are totally redundant in any situation where a downtime page would be used. This PR attempts to redesign the page to show only the relevant information and thus be a little leaner and more aesthetically focused. (It also fixes some typos on the page.)
## Screenshots
*(The logo is actually smooth, the pixelation is just an artifact of the screenshot tool.)*
### Desktop
#### New
![dt-new-desktop](https://user-images.githubusercontent.com/38463785/118374049-8cb98100-b5a9-11eb-97ee-c98a5503f3e1.png)
#### Old
![dt-old-desktop](https://user-images.githubusercontent.com/38463785/118374051-92af6200-b5a9-11eb-88ed-a671b9e94a53.png)

### Mobile
#### New
![dt-new-mobile](https://user-images.githubusercontent.com/38463785/118374067-ace94000-b5a9-11eb-92dc-e735728d9bb4.png)
#### Old
![dt-old-mobile](https://user-images.githubusercontent.com/38463785/118374074-b5da1180-b5a9-11eb-9938-44b815d7e60a.png)

### Tablet
#### New
![dt-new-t-hori](https://user-images.githubusercontent.com/38463785/118374083-c25e6a00-b5a9-11eb-9544-194fb69b54b3.png)
![dt-new-t-vert](https://user-images.githubusercontent.com/38463785/118374085-c2f70080-b5a9-11eb-8c69-8390b1bab83d.png)

#### Old
![dt-old-t-hori](https://user-images.githubusercontent.com/38463785/118374092-cab6a500-b5a9-11eb-828a-a9b3b3bcdc13.png)
![dt-old-t-vert](https://user-images.githubusercontent.com/38463785/118374093-cbe7d200-b5a9-11eb-93b5-da0471755264.png)


