### PR TITLE
Fix full card name matching

### DIFF
--- a/serverjs/cards.js
+++ b/serverjs/cards.js
@@ -160,10 +160,11 @@ function reasonableId(id) {
 function getIdsFromName(name) {
   // this is a fully-spcecified card name
   if (name.includes('[') && name.includes(']')) {
-    const split = name.toLowerCase().split('[');
+    name = name.toLowerCase();
+    const split = name.split('[');
     return getIdsFromName(split[0])
       .map((id) => cardFromId(id))
-      .filter((card) => split[1].includes(card.set))
+      .filter((card) => card.full_name.toLowerCase() === name)
       .map((card) => card._id);
   }
 


### PR DESCRIPTION
When the `getMostReasonable` function was run with a fully specified card name, it returned the first printing of a matching set. If the set includes multiple versions of that card (promos, Project Booster Fun, etc.), the specified collector number is ignored in this case. 

This PR changes the `getIdsFromName` function to consider exact sets and collector numbers for fully specified card names.