### PR TITLE
Clarified cube ID presentation

### DIFF
--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -1083,6 +1083,10 @@ audio {
 	min-height: 20rem;
 }
 
+.monospaced {
+	font-family: "Fira Mono", monospace;
+}
+
 .card-header {
 	background-color: var(--header);
 }

--- a/src/components/CubeIdModal.js
+++ b/src/components/CubeIdModal.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Modal, ModalHeader, ModalBody, Button, ModalFooter, Input, Label } from 'reactstrap';
+import PropTypes from 'prop-types';
+
+const CubeIdModal = ({ toggle, isOpen, shortID, fullID }) => {
+  return (
+    <Modal isOpen={isOpen} toggle={toggle}>
+      <ModalHeader>Cube ID</ModalHeader>
+      <ModalBody>
+        <h6>Short ID</h6>
+        <Input id="short-id-input" style={{ fontFamily: 'Fira Mono' }} className="bg-white" value={shortID} readonly />
+        <Label for="short-id-input">
+          The short ID is a simple, easy to remember value that you can use to link to your cube. Cube owners can change
+          the short ID to match their cube and make it more memorable.
+        </Label>
+
+        <h6 className="mt-3">Full ID</h6>
+        <Input id="full-id-input" style={{ fontFamily: 'Fira Mono' }} className="bg-white" value={fullID} readonly />
+        <Label for="full-id-input">
+          The full ID is a unique identifier that will always stay the same for this cube, even if the short ID changes.
+          If you want to guarantee that your link to a cube will always be valid, use the full ID.
+        </Label>
+        <br />
+      </ModalBody>
+      <ModalFooter>
+        <Button color="secondary" onClick={toggle}>
+          Close
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+CubeIdModal.propTypes = {
+  toggle: PropTypes.func.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  shortID: PropTypes.string.isRequired,
+  fullID: PropTypes.string.isRequired,
+};
+
+export default CubeIdModal;

--- a/src/components/CubeIdModal.js
+++ b/src/components/CubeIdModal.js
@@ -1,25 +1,50 @@
 import React from 'react';
-import { Modal, ModalHeader, ModalBody, Button, ModalFooter, Input, Label } from 'reactstrap';
+import {
+  Modal,
+  ModalHeader,
+  ModalBody,
+  Button,
+  ModalFooter,
+  Input,
+  Label,
+  InputGroup,
+  InputGroupAddon,
+} from 'reactstrap';
 import PropTypes from 'prop-types';
+import { ClippyIcon } from '@primer/octicons-react';
 
-const CubeIdModal = ({ toggle, isOpen, shortID, fullID }) => {
+const CubeIdModal = ({ toggle, isOpen, shortID, fullID, alert }) => {
+  const onCopyClick = async (id, label) => {
+    await navigator.clipboard.writeText(id);
+    alert('success', `${label} copied to clipboard`);
+    toggle();
+  };
+
   return (
     <Modal isOpen={isOpen} toggle={toggle}>
       <ModalHeader>Cube ID</ModalHeader>
       <ModalBody>
         <h6>Short ID</h6>
-        <Input id="short-id-input" style={{ fontFamily: 'Fira Mono' }} className="bg-white" value={shortID} readonly />
-        <Label for="short-id-input">
-          The short ID is a simple, easy to remember value that you can use to link to your cube. Cube owners can change
-          the short ID to match their cube and make it more memorable.
-        </Label>
+        <InputGroup>
+          <Input className="bg-white monospaced" value={shortID} readonly />
+          <InputGroupAddon addonType="append">
+            <Button className="btn-sm input-group-button" onClick={() => onCopyClick(shortID, 'Short ID')}>
+              <ClippyIcon size={16} />
+            </Button>
+          </InputGroupAddon>
+        </InputGroup>
+        <Label for="short-id-input">A custom, memorable ID that owners are allowed to modify.</Label>
 
         <h6 className="mt-3">Full ID</h6>
-        <Input id="full-id-input" style={{ fontFamily: 'Fira Mono' }} className="bg-white" value={fullID} readonly />
-        <Label for="full-id-input">
-          The full ID is a unique identifier that will always stay the same for this cube, even if the short ID changes.
-          If you want to guarantee that your link to a cube will always be valid, use the full ID.
-        </Label>
+        <InputGroup>
+          <Input className="bg-white monospaced" value={fullID} readonly />
+          <InputGroupAddon addonType="append">
+            <Button className="btn-sm input-group-button" onClick={() => onCopyClick(fullID, 'Full ID')}>
+              <ClippyIcon size={16} />
+            </Button>
+          </InputGroupAddon>
+        </InputGroup>
+        <Label for="full-id-input">The canonical unique ID for this cube, guaranteed not to change.</Label>
         <br />
       </ModalBody>
       <ModalFooter>
@@ -36,6 +61,7 @@ CubeIdModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   shortID: PropTypes.string.isRequired,
   fullID: PropTypes.string.isRequired,
+  alert: PropTypes.func.isRequired,
 };
 
 export default CubeIdModal;

--- a/src/components/CubeIdModal.js
+++ b/src/components/CubeIdModal.js
@@ -28,7 +28,11 @@ const CubeIdModal = ({ toggle, isOpen, shortID, fullID, alert }) => {
         <InputGroup>
           <Input className="bg-white monospaced" value={shortID} readonly />
           <InputGroupAddon addonType="append">
-            <Button className="btn-sm input-group-button" onClick={() => onCopyClick(shortID, 'Short ID')}>
+            <Button
+              className="btn-sm input-group-button"
+              onClick={() => onCopyClick(shortID, 'Short ID')}
+              aria-label="Copy Short ID"
+            >
               <ClippyIcon size={16} />
             </Button>
           </InputGroupAddon>
@@ -39,7 +43,11 @@ const CubeIdModal = ({ toggle, isOpen, shortID, fullID, alert }) => {
         <InputGroup>
           <Input className="bg-white monospaced" value={fullID} readonly />
           <InputGroupAddon addonType="append">
-            <Button className="btn-sm input-group-button" onClick={() => onCopyClick(fullID, 'Full ID')}>
+            <Button
+              className="btn-sm input-group-button"
+              onClick={() => onCopyClick(fullID, 'Full ID')}
+              aria-label="Copy Full ID"
+            >
               <ClippyIcon size={16} />
             </Button>
           </InputGroupAddon>

--- a/src/components/CubeOverviewModal.js
+++ b/src/components/CubeOverviewModal.js
@@ -362,9 +362,10 @@ class CubeOverviewModal extends Component {
                 <TagInput tags={tags} {...this.tagActions} />
                 <br />
 
-                <h6>Custom ID</h6>
+                <h6>Short ID</h6>
                 <input
                   className="form-control"
+                  id="shortID"
                   name="shortID"
                   type="text"
                   value={cube.shortID}
@@ -372,6 +373,7 @@ class CubeOverviewModal extends Component {
                   required={true}
                   placeholder="Give this cube an easy to remember URL."
                 />
+                <FormText>Changing the short ID may break existing links to your cube.</FormText>
                 <br />
               </ModalBody>
               <ModalFooter>

--- a/src/pages/CubeOverviewPage.js
+++ b/src/pages/CubeOverviewPage.js
@@ -87,20 +87,6 @@ const CubeOverview = ({ post, priceOwned, pricePurchase, cube, followed, followe
       }
     });
   };
-
-  const CubeIdHeader = (
-    <span>
-      Cube ID{' '}
-      <CubeIdModalLink
-        modalProps={{ fullID: cube._id, shortID: getCubeId(cubeState) }}
-        style={{ position: 'relative', top: '-1px' /* the icon is otherwise ~1px too low */ }}
-        aria-label="Show Cube IDs"
-      >
-        <QuestionIcon size="15" />
-      </CubeIdModalLink>
-    </span>
-  );
-
   return (
     <MainLayout loginCallback={loginCallback} user={user}>
       <CubeLayout cube={cubeState} canEdit={user && cubeState.owner === user.id} activeLink="overview">
@@ -172,8 +158,8 @@ const CubeOverview = ({ post, priceOwned, pricePurchase, cube, followed, followe
                       </FollowersModalLink>
                     </h6>
                   </Col>
-                  <div className="float-right" style={{ paddingTop: 3, marginRight: '1.25rem' }}>
-                    <TextBadge name={CubeIdHeader}>
+                  <div className="float-right" style={{ paddingTop: 3, marginRight: '0.25rem' }}>
+                    <TextBadge name="Cube ID">
                       <Tooltip text="Click to copy to clipboard">
                         <button
                           type="button"
@@ -190,6 +176,14 @@ const CubeOverview = ({ post, priceOwned, pricePurchase, cube, followed, followe
                       </Tooltip>
                     </TextBadge>
                   </div>
+                  <CubeIdModalLink
+                    modalProps={{ fullID: cube._id, shortID: getCubeId(cubeState), alert: addAlert }}
+                    aria-label="Show Cube IDs"
+                    className="mr-2"
+                    style={{ position: 'relative', top: '5px' /* the icon needs to be pulled down */ }}
+                  >
+                    <QuestionIcon size="18" />
+                  </CubeIdModalLink>
                 </Row>
               </CardHeader>
               <div className="position-relative">

--- a/src/pages/CubeOverviewPage.js
+++ b/src/pages/CubeOverviewPage.js
@@ -20,7 +20,7 @@ import {
   UncontrolledCollapse,
 } from 'reactstrap';
 
-import { LinkExternalIcon } from '@primer/octicons-react';
+import { LinkExternalIcon, QuestionIcon } from '@primer/octicons-react';
 
 import { csrfFetch } from 'utils/CSRF';
 import { getCubeId, getCubeDescription } from 'utils/Util';
@@ -40,11 +40,13 @@ import MainLayout from 'layouts/MainLayout';
 import RenderToRoot from 'utils/RenderToRoot';
 import DeleteCubeModal from 'components/DeleteCubeModal';
 import CustomizeBasicsModal from 'components/CustomizeBasicsModal';
+import CubeIdModal from 'components/CubeIdModal';
 
 const FollowersModalLink = withModal('a', FollowersModal);
 const CubeSettingsModalLink = withModal(NavLink, CubeSettingsModal);
 const DeleteCubeModalLink = withModal(NavLink, DeleteCubeModal);
 const CustomizeBasicsModalLink = withModal(NavLink, CustomizeBasicsModal);
+const CubeIdModalLink = withModal('span', CubeIdModal);
 
 const CubeOverview = ({ post, priceOwned, pricePurchase, cube, followed, followers, user, loginCallback }) => {
   const [alerts, setAlerts] = useState([]);
@@ -85,6 +87,19 @@ const CubeOverview = ({ post, priceOwned, pricePurchase, cube, followed, followe
       }
     });
   };
+
+  const CubeIdHeader = (
+    <span>
+      Cube ID{' '}
+      <CubeIdModalLink
+        modalProps={{ fullID: cube._id, shortID: getCubeId(cubeState) }}
+        style={{ position: 'relative', top: '-1px' /* the icon is otherwise ~1px too low */ }}
+        aria-label="Show Cube IDs"
+      >
+        <QuestionIcon size="15" />
+      </CubeIdModalLink>
+    </span>
+  );
 
   return (
     <MainLayout loginCallback={loginCallback} user={user}>
@@ -158,7 +173,7 @@ const CubeOverview = ({ post, priceOwned, pricePurchase, cube, followed, followe
                     </h6>
                   </Col>
                   <div className="float-right" style={{ paddingTop: 3, marginRight: '1.25rem' }}>
-                    <TextBadge name="Cube ID">
+                    <TextBadge name={CubeIdHeader}>
                       <Tooltip text="Click to copy to clipboard">
                         <button
                           type="button"


### PR DESCRIPTION
This PR changes the UI of the cube page to make the full ID accessible and clarify the difference between the full ID and the short ID. Clicking the question mark icon will bring up a modal explaining the cube IDs and allowing to copy to clipboard.

## Screenshots
#### Cube page
![page](https://user-images.githubusercontent.com/38463785/119151916-59f70900-ba3f-11eb-821a-68bb108fb6e9.png)

#### Cube ID modal
![modal](https://user-images.githubusercontent.com/38463785/119152110-87dc4d80-ba3f-11eb-9191-e13d574f6365.png)

#### Clipboard alert
![alert](https://user-images.githubusercontent.com/38463785/119152159-9296e280-ba3f-11eb-8771-85e96a5d67f2.png)

#### Change to Overview modal
![ov_modal](https://user-images.githubusercontent.com/38463785/119152343-c1ad5400-ba3f-11eb-8312-7cad09af2af1.png)
