### PR TITLE
Fix basics and moving cards

### DIFF
--- a/jobs/definition/weekly.sh
+++ b/jobs/definition/weekly.sh
@@ -2,4 +2,4 @@
 node jobs/populate_embeddings.js
 node jobs/clean_cubes.js
 node jobs/download_cubes.js
-node --max-old-space-size=8192 --expose_gc jobs/populate_analytics.js
+node --max-old-space-size=8192 jobs/populate_analytics.js

--- a/src/pages/CubeDeckbuilderPage.js
+++ b/src/pages/CubeDeckbuilderPage.js
@@ -30,7 +30,6 @@ const CubeDeckbuilderPage = ({ user, cube, initialDeck, loginCallback }) => {
   const [deck, setDeck] = useState(
     initialDeck.seats[0].deck.map((row) => row.map((col) => col.map((cardIndex) => initialDeck.cards[cardIndex]))),
   );
-  console.debug(deck);
   const [sideboard, setSideboard] = useState(
     initialDeck.seats[0].sideboard.map((row) => row.map((col) => col.map((cardIndex) => initialDeck.cards[cardIndex]))),
   );
@@ -46,12 +45,18 @@ const CubeDeckbuilderPage = ({ user, cube, initialDeck, loginCallback }) => {
         return;
       }
 
-      const [sourceCards, setSource] = locationMap[source.type];
-      const [targetCards, setTarget] = locationMap[target.type];
+      if (source.type === target.type) {
+        const [cards, setSource] = locationMap[source.type];
 
-      const [card, newSourceCards] = removeCard(sourceCards, source.data);
-      setSource(newSourceCards);
-      setTarget(moveOrAddCard(targetCards, target.data, card));
+        setSource(moveOrAddCard(cards, target.data, source.data));
+      } else {
+        const [sourceCards, setSource] = locationMap[source.type];
+        const [targetCards, setTarget] = locationMap[target.type];
+
+        const [card, newSourceCards] = removeCard(sourceCards, source.data);
+        setSource(newSourceCards);
+        setTarget(moveOrAddCard(targetCards, target.data, card));
+      }
     },
     [locationMap],
   );
@@ -80,14 +85,14 @@ const CubeDeckbuilderPage = ({ user, cube, initialDeck, loginCallback }) => {
 
   const addBasics = useCallback(
     (numBasics) => {
-      const toAdd = numBasics.map((count, index) => new Array(count).fill(basics[index])).flat();
+      const toAdd = numBasics.map((count, index) => new Array(count).fill(initialDeck.cards[basics[index]])).flat();
       const newDeck = [...deck];
       newDeck[1][0] = [].concat(newDeck[1][0], toAdd);
       setDeck(newDeck);
     },
-    [deck, basics],
+    [deck, basics, initialDeck],
   );
-  console.debug('initialDeck.cards', initialDeck.cards);
+
   const currentDeck = { ...initialDeck };
   currentDeck.playerdeck = deck;
   currentDeck.playersideboard = sideboard;


### PR DESCRIPTION
Fixes #1938

This PR fixes a bug where basics would be added as the index value instead of the correct value.  

This also fixes a bug where moving a card within the same location would cause it to duplicate.