### PR TITLE
Pack creation visual update

### DIFF
--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -1259,3 +1259,7 @@ thead th.corner[scope=col] {
 	justify-content: space-between;
 	align-items: baseline;
 }
+
+.pack-outline {
+	background-color: var(--bg-dark);
+}

--- a/src/components/CustomPackCard.js
+++ b/src/components/CustomPackCard.js
@@ -20,6 +20,7 @@ import {
 import PropTypes from 'prop-types';
 
 import useToggle from 'hooks/UseToggle';
+import { ChevronDownIcon, ChevronUpIcon } from '@primer/octicons-react';
 
 const DEFAULT_STEP = Object.freeze([
   { action: 'pick', amount: 1 },
@@ -34,6 +35,15 @@ const ACTION_LABELS = Object.freeze({
   trashrandom: 'Randomly Trash',
 });
 
+const CollapsibleCardTitle = ({ children, isOpen, ...props }) => {
+  return (
+    <CardTitle {...props}>
+      {children}
+      <span style={{ float: 'right' }}>{isOpen ? <ChevronUpIcon size={24} /> : <ChevronDownIcon size={24} />}</span>
+    </CardTitle>
+  );
+};
+
 const CustomPackCard = ({ packIndex, pack, canRemove, mutations }) => {
   const [slotsOpen, toggleSlotsOpen] = useToggle(true);
   const [stepsOpen, toggleStepsOpen] = useToggle(false);
@@ -47,7 +57,7 @@ const CustomPackCard = ({ packIndex, pack, canRemove, mutations }) => {
     [pack],
   );
   return (
-    <Card key={packIndex} className="mb-3">
+    <Card key={packIndex} className="mb-4 pack-outline">
       <CardHeader>
         <CardTitle className="mb-0">
           Pack {packIndex + 1} - {pack.slots.length} Cards
@@ -55,9 +65,11 @@ const CustomPackCard = ({ packIndex, pack, canRemove, mutations }) => {
         </CardTitle>
       </CardHeader>
       <CardBody className="p-1">
-        <Card key="slots" className="mb-2 mx-1">
+        <Card key="slots" className="mb-3 m-2">
           <CardHeader onClick={toggleSlotsOpen}>
-            <CardTitle className="mb-0">Card Slots</CardTitle>
+            <CollapsibleCardTitle isOpen={slotsOpen} className="mb-0">
+              Card Slots
+            </CollapsibleCardTitle>
           </CardHeader>
           <Collapse isOpen={slotsOpen}>
             <CardBody>
@@ -97,9 +109,11 @@ const CustomPackCard = ({ packIndex, pack, canRemove, mutations }) => {
             </CardFooter>
           </Collapse>
         </Card>
-        <Card key="steps" className="mb-2 mx-1">
+        <Card key="steps" className="m-2">
           <CardHeader onClick={toggleStepsOpen}>
-            <CardTitle className="mb-0">Steps for Drafting</CardTitle>
+            <CollapsibleCardTitle isOpen={stepsOpen} className="mb-0">
+              Steps for Drafting
+            </CollapsibleCardTitle>
           </CardHeader>
           <Collapse isOpen={stepsOpen}>
             <CardBody>
@@ -169,6 +183,11 @@ const CustomPackCard = ({ packIndex, pack, canRemove, mutations }) => {
       </CardFooter>
     </Card>
   );
+};
+
+CollapsibleCardTitle.propTypes = {
+  children: PropTypes.string.isRequired,
+  isOpen: PropTypes.bool.isRequired,
 };
 
 CustomPackCard.propTypes = {

--- a/src/components/CustomPackCard.js
+++ b/src/components/CustomPackCard.js
@@ -174,9 +174,6 @@ const CustomPackCard = ({ packIndex, pack, canRemove, mutations }) => {
         </Card>
       </CardBody>
       <CardFooter>
-        <Button className="mr-2" color="success" onClick={mutations.addSlot} data-pack-index={packIndex}>
-          Add Card Slot
-        </Button>
         <Button color="success" onClick={mutations.duplicatePack} data-pack-index={packIndex}>
           Duplicate Pack
         </Button>

--- a/src/components/CustomPackCard.js
+++ b/src/components/CustomPackCard.js
@@ -119,7 +119,7 @@ const CustomPackCard = ({ packIndex, pack, canRemove, mutations }) => {
             <CardBody>
               {steps.map((step, stepIndex) => (
                 // eslint-disable-next-line react/no-array-index-key
-                <InputGroup key={stepIndex}>
+                <InputGroup key={stepIndex} className="pb-1">
                   <InputGroupAddon addonType="prepend">
                     <InputGroupText>{stepIndex + 1}</InputGroupText>
                   </InputGroupAddon>


### PR DESCRIPTION
This PR updates the look of the Custom Draft Format modal.

Changes in this PR:
- added a chevron to "Card Slots" and "Steps for Drafting" sections to show they're collapsible
- added some more space between packs to better delineate them
- changed colors and margins of Pack insides to better convey the levels of nesting
- added some padding between steps
- removed redundant "Add Card Slot" button

## Comparisons
### Default mode
#### Before
![lm_before](https://user-images.githubusercontent.com/38463785/120666433-1c04d680-c47c-11eb-8c4c-da63f5e25d24.png)

#### After
![lm_after](https://user-images.githubusercontent.com/38463785/120666446-20c98a80-c47c-11eb-8dc2-36c47d124aba.png)

### Dark mode
#### Before
![dm_before](https://user-images.githubusercontent.com/38463785/120666459-23c47b00-c47c-11eb-86c3-74b8e3061e85.png)

#### After
![dm_after](https://user-images.githubusercontent.com/38463785/120666473-27580200-c47c-11eb-8f08-e3f96a048f8f.png)
