### PR TITLE
QoL changes to custom draft modal

### DIFF
--- a/src/components/CustomDraftFormatModal.js
+++ b/src/components/CustomDraftFormatModal.js
@@ -1,5 +1,6 @@
 import React, { useContext, useCallback, useMemo } from 'react';
 import {
+  Alert,
   Button,
   Col,
   FormGroup,
@@ -241,12 +242,15 @@ const CustomDraftFormatModal = ({ isOpen, toggle, formatIndex, format, setFormat
         </Button>
       </ModalBody>
       <ModalFooter>
+        {errorsInFormat &&
+          errorsInFormat.map((error, errorIndex) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <Alert key={errorIndex} color="danger">
+              {error}
+            </Alert>
+          ))}
         <CSRFForm method="POST" action={`/cube/format/add/${cubeID}`}>
           <Input type="hidden" name="serializedFormat" value={packsJson} />
-          {
-            // eslint-disable-next-line react/no-array-index-key
-            errorsInFormat && errorsInFormat.map((error, errorIndex) => <p key={errorIndex}>{error}</p>)
-          }
           <Input type="hidden" name="id" value={formatIndex} />
           <Button color={errorsInFormat ? 'error' : 'success'} type="submit" disabled={!!errorsInFormat}>
             Save

--- a/src/components/CustomDraftFormatModal.js
+++ b/src/components/CustomDraftFormatModal.js
@@ -79,6 +79,11 @@ const MUTATIONS = Object.freeze({
   changeStepAction: ({ newFormat, packIndex, stepIndex, value }) => {
     newFormat.packs[packIndex].steps = cloneSteps({ newFormat, packIndex });
     newFormat.packs[packIndex].steps[stepIndex] = { ...newFormat.packs[packIndex].steps[stepIndex], action: value };
+
+    // undefined amount value is automatically set to 1 for initial change
+    if (value !== 'pass' && newFormat.packs[packIndex].steps[stepIndex].amount === null) {
+      newFormat.packs[packIndex].steps[stepIndex].amount = 1;
+    }
   },
 
   changeStepAmount: ({ newFormat, packIndex, stepIndex, value }) => {


### PR DESCRIPTION
Few more front-end updates:
- changed how errors are displayed so that they're more visible and the interface doesn't look broken.
- when initially changing from "pass" to any other action, automatically set the value to 1

## Alert change
### Before
![invalid_old](https://user-images.githubusercontent.com/38463785/120684048-cf29fb80-c48d-11eb-980d-d2bc8c0466eb.png)

### After
![invalid_new](https://user-images.githubusercontent.com/38463785/120684169-e963d980-c48d-11eb-9f54-fb225ac7bb6e.png)
