### PR TITLE
Show custom formats on the playtest page

### DIFF
--- a/src/pages/CubePlaytestPage.js
+++ b/src/pages/CubePlaytestPage.js
@@ -431,7 +431,7 @@ const DEFAULT_FORMAT = {
 };
 const CubePlaytestPage = ({ user, cube, decks, loginCallback }) => {
   const { alerts, addAlert } = useAlerts();
-  const [formats, setFormats] = useState(cube.draftFormats ?? []);
+  const [formats, setFormats] = useState(cube.draft_formats ?? []);
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [editFormatIndex, setEditFormatIndex] = useState(-1);
   const [editFormat, setEditFormat] = useState({});
@@ -585,12 +585,7 @@ CubePlaytestPage.propTypes = {
     defaultDraftFormat: PropTypes.number,
     _id: PropTypes.string.isRequired,
     owner: PropTypes.string.isRequired,
-    draftFormats: PropTypes.arrayOf(
-      PropTypes.shape({
-        title: PropTypes.string.isRequired,
-        markdown: PropTypes.string,
-      }),
-    ),
+    draft_formats: PropTypes.arrayOf(PropTypes.object),
   }).isRequired,
   decks: PropTypes.arrayOf(DeckPropType).isRequired,
   user: UserPropType,

--- a/src/pages/CubePlaytestPage.js
+++ b/src/pages/CubePlaytestPage.js
@@ -585,20 +585,24 @@ CubePlaytestPage.propTypes = {
     defaultDraftFormat: PropTypes.number,
     _id: PropTypes.string.isRequired,
     owner: PropTypes.string.isRequired,
-    draft_formats: PropTypes.shape({
-      title: PropTypes.string,
-      multiples: PropTypes.bool,
-      markdown: PropTypes.string.isRequired,
-      packs: PropTypes.arrayOf(
-        PropTypes.shape({
-          slots: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
-          steps: PropTypes.shape({
-            action: PropTypes.oneOf(['pass', 'pick', 'trash', 'pickrandom', 'trashrandom']),
-            amount: PropTypes.number,
-          }),
-        }).isRequired,
-      ).isRequired,
-    }).isRequired,
+    draft_formats: PropTypes.arrayOf(
+      PropTypes.shape({
+        title: PropTypes.string,
+        multiples: PropTypes.bool,
+        markdown: PropTypes.string.isRequired,
+        packs: PropTypes.arrayOf(
+          PropTypes.shape({
+            slots: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+            steps: PropTypes.arrayOf(
+              PropTypes.shape({
+                action: PropTypes.oneOf(['pass', 'pick', 'trash', 'pickrandom', 'trashrandom']),
+                amount: PropTypes.number,
+              }),
+            ),
+          }).isRequired,
+        ).isRequired,
+      }).isRequired,
+    ),
   }).isRequired,
   decks: PropTypes.arrayOf(DeckPropType).isRequired,
   user: UserPropType,

--- a/src/pages/CubePlaytestPage.js
+++ b/src/pages/CubePlaytestPage.js
@@ -585,7 +585,20 @@ CubePlaytestPage.propTypes = {
     defaultDraftFormat: PropTypes.number,
     _id: PropTypes.string.isRequired,
     owner: PropTypes.string.isRequired,
-    draft_formats: PropTypes.arrayOf(PropTypes.object),
+    draft_formats: PropTypes.shape({
+      title: PropTypes.string,
+      multiples: PropTypes.bool,
+      markdown: PropTypes.string.isRequired,
+      packs: PropTypes.arrayOf(
+        PropTypes.shape({
+          slots: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+          steps: PropTypes.shape({
+            action: PropTypes.oneOf(['pass', 'pick', 'trash', 'pickrandom', 'trashrandom']),
+            amount: PropTypes.number,
+          }),
+        }).isRequired,
+      ).isRequired,
+    }).isRequired,
   }).isRequired,
   decks: PropTypes.arrayOf(DeckPropType).isRequired,
   user: UserPropType,


### PR DESCRIPTION
Under the old model, the drafts from the database were transformed into the `draftFormats` property. Since there's now no need for that, the transformation was removed, however a reference to `draftFormats` was left in the playtest page, causing `formats` to always be empty.