### PR TITLE
Remove the code to scale colorless cards by probability.

### DIFF
--- a/src/components/DraftbotBreakdown.js
+++ b/src/components/DraftbotBreakdown.js
@@ -29,10 +29,10 @@ const CARD_TRAIT = Object.freeze({
 });
 const TRAITS = Object.freeze([
   {
-    title: 'Casting Probability',
+    title: 'Usability Percent',
     tooltip:
-      'How likely we are to play this card on curve if we have enough lands. Applies as scaling to Rating and Pick Synergy.',
-    compute: ({ botState: { cardIndices, probabilities } }) => probabilities[cardIndices?.[0]],
+      'What percent of the rating of the card the bot thinks it can take advantage of. Based on the probability to cast the card on curve. Applies as scaling to Rating and Pick Synergy.',
+    compute: ({ botState: { cardIndices, probabilities } }) => probabilities[cardIndices?.[0]] * 100,
   },
   {
     title: 'Lands',

--- a/src/components/DraftbotBreakdown.js
+++ b/src/components/DraftbotBreakdown.js
@@ -65,7 +65,6 @@ export const DraftbotBreakdownTable = ({ drafterState }) => {
       })),
     [drafterState],
   );
-  console.debug(botEvaluations);
   const oracles = useMemo(
     () => botEvaluations[0].oracleResults.map(({ title, tooltip }) => ({ title, tooltip })),
     [botEvaluations],


### PR DESCRIPTION
The code didn't work and may not be worth doing in the first place, more investigation will be needed.

Fixes #1979 