### PR TITLE
Fix pack deletion

### DIFF
--- a/src/components/CustomDraftFormatModal.js
+++ b/src/components/CustomDraftFormatModal.js
@@ -132,7 +132,7 @@ const CustomDraftFormatModal = ({ isOpen, toggle, formatIndex, format, setFormat
   const useMutateFormat = (mutation) =>
     useCallback(
       (event) => {
-        const { target } = event;
+        const target = event.currentTarget;
         if (target) {
           const { value } = target;
           const packIndex = toNullableInt(target.getAttribute('data-pack-index'));


### PR DESCRIPTION
The `target` is a span with the "X" inside the button, not the button itself. Therefore `packIndex` was just always null.