### PR TITLE
Fixed sample pack generation

### DIFF
--- a/serverjs/cubefn.js
+++ b/serverjs/cubefn.js
@@ -573,7 +573,7 @@ const methods = {
     cube.cards = cube.cards.map((card) => ({ ...card, details: { ...carddb.getCardDetails(card) } }));
     const formatId = cube.defaultDraftFormat === undefined ? -1 : cube.defaultDraftFormat;
     const format = getDraftFormat({ id: formatId, packs: 1, cards: 15 }, cube);
-    const draft = createDraft(format, cube.cards, 1, 1, { username: 'Anonymous' }, false, seed);
+    const draft = createDraft(format, cube.cards, 1, { username: 'Anonymous' }, false, seed);
     return {
       seed,
       pack: draft.initial_state[0][0].cards.map((cardIndex) => ({


### PR DESCRIPTION
Fixes #1993 

### Issue
When creating the draft from which the sample pack is generated, the `createDraft` function was being passed an extra parameter. Because of this, the following arguments were misaligned and the `seed` parameter was always `false`, forcing the function to always use current datetime as the seed instead.

### Fix
Remove the extra parameter.