### PR TITLE
Remove unnecesary card name to lowercase

### DIFF
--- a/jobs/archived/process_decks.js
+++ b/jobs/archived/process_decks.js
@@ -91,7 +91,7 @@ const processDeck = (deck, draft, analytic) => {
       for (const col of deck.seats[0].deck) {
         for (const current of col) {
           let pickIndex = analytic.cards.findIndex(
-            (card) => card.cardName.toLowerCase() === carddb.cardFromId(current.cardID).name.toLowerCase(),
+            (card) => card.cardName === carddb.cardFromId(current.cardID).name.toLowerCase(),
           );
           if (pickIndex === -1) {
             pickIndex =
@@ -103,7 +103,7 @@ const processDeck = (deck, draft, analytic) => {
       for (const col of deck.seats[0].sideboard) {
         for (const current of col) {
           let pickIndex = analytic.cards.findIndex(
-            (card) => card.cardName.toLowerCase() === carddb.cardFromId(current.cardID).name.toLowerCase(),
+            (card) => card.cardName === carddb.cardFromId(current.cardID).name.toLowerCase(),
           );
           if (pickIndex === -1) {
             pickIndex =

--- a/routes/cube/api.js
+++ b/routes/cube/api.js
@@ -1019,14 +1019,14 @@ router.post(
           analytic.cube = draft.cube;
         }
 
-        let pickIndex = analytic.cards.findIndex((card) => card.cardName.toLowerCase() === req.body.pick.toLowerCase());
+        let pickIndex = analytic.cards.findIndex((card) => card.cardName === req.body.pick.toLowerCase());
         if (pickIndex === -1) {
-          pickIndex = analytic.cards.push(newCardAnalytics(req.body.pick.toLowerCase(), ELO_BASE)) - 1;
+          pickIndex = analytic.cards.push(newCardAnalytics(req.body.pick, ELO_BASE)) - 1;
         }
 
         const packIndeces = {};
         for (const packCard of req.body.pack) {
-          let index = analytic.cards.findIndex((card) => card.cardName.toLowerCase() === packCard.toLowerCase());
+          let index = analytic.cards.findIndex((card) => card.cardName === packCard.toLowerCase());
           if (index === -1) {
             index = analytic.cards.push(newCardAnalytics(packCard.toLowerCase(), ELO_BASE)) - 1;
           }

--- a/serverjs/cubefn.js
+++ b/serverjs/cubefn.js
@@ -321,7 +321,7 @@ const removeDeckCardAnalytics = async (cube, deck, carddb) => {
       for (const col of row) {
         for (const ci of col) {
           let pickIndex = analytic.cards.findIndex(
-            (card) => card.cardName.toLowerCase() === carddb.cardFromId(deck.cards[ci].cardID).name.toLowerCase(),
+            (card) => card.cardName === carddb.cardFromId(deck.cards[ci].cardID).name.toLowerCase(),
           );
           if (pickIndex === -1) {
             pickIndex =
@@ -336,7 +336,7 @@ const removeDeckCardAnalytics = async (cube, deck, carddb) => {
       for (const col of row) {
         for (const ci of col) {
           let pickIndex = analytic.cards.findIndex(
-            (card) => card.cardName.toLowerCase() === carddb.cardFromId(deck.cards[ci].cardID).name.toLowerCase(),
+            (card) => card.cardName === carddb.cardFromId(deck.cards[ci].cardID).name.toLowerCase(),
           );
           if (pickIndex === -1) {
             pickIndex =
@@ -366,7 +366,7 @@ const addDeckCardAnalytics = async (cube, deck, carddb) => {
       for (const col of row) {
         for (const ci of col) {
           let pickIndex = analytic.cards.findIndex(
-            (card) => card.cardName.toLowerCase() === carddb.cardFromId(deck.cards[ci].cardID).name.toLowerCase(),
+            (card) => card.cardName === carddb.cardFromId(deck.cards[ci].cardID).name.toLowerCase(),
           );
           if (pickIndex === -1) {
             pickIndex =
@@ -381,7 +381,7 @@ const addDeckCardAnalytics = async (cube, deck, carddb) => {
       for (const col of row) {
         for (const ci of col) {
           let pickIndex = analytic.cards.findIndex(
-            (card) => card.cardName.toLowerCase() === carddb.cardFromId(deck.cards[ci].cardID).name.toLowerCase(),
+            (card) => card.cardName === carddb.cardFromId(deck.cards[ci].cardID).name.toLowerCase(),
           );
           if (pickIndex === -1) {
             pickIndex =


### PR DESCRIPTION
Fixes #1984

Somehow cube analytics can have a null cardname, but all the card names are always inserted as .toLowerCase(), so this change requires no data cleaning and will fix the behavior