### PR TITLE
Popularity sort changes

### DIFF
--- a/src/utils/Card.js
+++ b/src/utils/Card.js
@@ -191,7 +191,7 @@ export const cardTokens = (card) => card.details.tokens;
 
 export const cardElo = (card) => (card.details ? card.details.elo || 1200 : 1200);
 
-export const cardPopularity = (card) => card.details.Popularity;
+export const cardPopularity = (card) => card.details.popularity;
 
 export const cardLayout = (card) => card.details.layout;
 

--- a/src/utils/Sort.js
+++ b/src/utils/Sort.js
@@ -9,6 +9,7 @@ import {
   cardCmc,
   COLOR_COMBINATIONS,
   cardRarity,
+  cardPopularity,
 } from 'utils/Card';
 
 const COLOR_MAP = {
@@ -160,6 +161,7 @@ export const SORTS = [
   'Legality',
   'Loyalty',
   'Manacost Type',
+  'Popularity',
   'Power',
   'Price USD',
   'Price USD Foil',
@@ -181,7 +183,6 @@ export const SORTS = [
   'Devotion to Red',
   'Devotion to Green',
   'Unsorted',
-  'Popularity (Cube Inclusion Percentage)',
 ];
 
 export const ORDERED_SORTS = ['Alphabetical', 'Mana Value', 'Price'];
@@ -315,8 +316,8 @@ function getLabelsRaw(cube, sort, showOther) {
     ret = ['Common', 'Uncommon', 'Rare', 'Mythic', 'Special'];
   } else if (sort === 'Unsorted') {
     ret = ['All'];
-  } else if (sort === 'Popularity (Cube Inclusion Percentage)') {
-    ret = ['0-1%', '1-2%', '3-5%', '5-8', '8-12%', '12-20%', '20-30%', '30-50%', '50-100%'];
+  } else if (sort === 'Popularity') {
+    ret = ['0–1%', '1–2%', '3–5%', '5–8', '8–12%', '12–20%', '20–30%', '30–50%', '50–100%'];
   } else if (sort === 'Subtype') {
     const types = new Set();
     for (const card of cube) {
@@ -643,17 +644,17 @@ export function cardGetLabels(card, sort, showOther) {
     ret = [cardDevotion(card, 'g').toString()];
   } else if (sort === 'Unsorted') {
     ret = ['All'];
-  } else if (sort === 'Popularity (Cube Inclusion Percentage)') {
-    const popularity = card.details.popularity * 100;
-    if (popularity < 1) ret = ['0-1%'];
-    else if (popularity < 2) ret = ['1-2%'];
-    else if (popularity < 5) ret = ['3-5%'];
-    else if (popularity < 8) ret = ['5-8%'];
-    else if (popularity < 12) ret = ['8-12%'];
-    else if (popularity < 20) ret = ['12-20%'];
-    else if (popularity < 30) ret = ['20-30%'];
-    else if (popularity < 50) ret = ['30-50%'];
-    else if (popularity <= 100) ret = ['50-100%'];
+  } else if (sort === 'Popularity') {
+    const popularity = cardPopularity(card) * 100;
+    if (popularity < 1) ret = ['0–1%'];
+    else if (popularity < 2) ret = ['1–2%'];
+    else if (popularity < 5) ret = ['3–5%'];
+    else if (popularity < 8) ret = ['5–8%'];
+    else if (popularity < 12) ret = ['8–12%'];
+    else if (popularity < 20) ret = ['12–20%'];
+    else if (popularity < 30) ret = ['20–30%'];
+    else if (popularity < 50) ret = ['30–50%'];
+    else if (popularity <= 100) ret = ['50–100%'];
   } else if (sort === 'Elo') {
     ret = [getEloBucket(card.details.elo ?? ELO_DEFAULT)];
   }


### PR DESCRIPTION
Changes in this PR:
- **Fixed typo in `cardPopularity` accessor**
- **Made popularity sort use the accessor** - since we have the accessors, it would be a good idea to use them
- **Removed the parentheses from sort name** - no other sort has an explanation attached, so adding one just to this feels disjointed. Plus, it seems pretty self-explanatory just from the name and categories.
- **Moved Popularity sort in the list** - the list is mostly alphabetical, so it's good to keep it that way
- **Changed hyphens to en dashes** - this is just my personal nitpick, but an en dash *is* the correct typographic symbol here