### PR TITLE
Fully implement cube tags

### DIFF
--- a/jobs/clean_cubes.js
+++ b/jobs/clean_cubes.js
@@ -21,7 +21,11 @@ const DEFAULT_BASICS = [
 const BATCH_SIZE = 1024;
 
 const needsCleaning = (cube) =>
-  !cube.cards || !Array.isArray(cube.basics) || cardsNeedsCleaning(cube.cards) || cardsNeedsCleaning(cube.maybe);
+  !cube.cards ||
+  !Array.isArray(cube.basics) ||
+  cardsNeedsCleaning(cube.cards) ||
+  cardsNeedsCleaning(cube.maybe) ||
+  cube.tags.some((tag) => !tag || tag.toLowerCase() !== tag);
 
 const processCube = async (leanCube) => {
   if (needsCleaning(leanCube)) {
@@ -40,6 +44,9 @@ const processCube = async (leanCube) => {
     }
     if (cardsNeedsCleaning(cube.maybe)) {
       cube.maybe = cleanCards(cube.maybe);
+    }
+    if (cube.tags.some((tag) => !tag || tag.toLowerCase() !== tag)) {
+      cube.tags = cube.tags.filter((tag) => tag && tag.length > 0).map((tag) => tag.toLowerCase());
     }
 
     await cube.save();

--- a/jobs/populate_analytics.js
+++ b/jobs/populate_analytics.js
@@ -75,14 +75,14 @@ const processDeck = async (deck, oracleToIndex, correlations) => {
     const deckCards = [];
     deck.seats[0].deck.forEach((row) =>
       row.forEach((col) => {
-        if(Array.isArray(col)) {
+        if (Array.isArray(col)) {
           col.forEach((ci) => {
             if ((ci || ci === 0) && cards[ci] && cards[ci].cardID) {
               deckCards.push(carddb.cardFromId(cards[ci].cardID).oracle_id);
             }
           });
         } else {
-          winston.info("Col is not an array:");
+          winston.info('Col is not an array:');
           winston.info(col);
         }
       }),
@@ -433,16 +433,18 @@ const run = async () => {
     .cursor();
   let i = 0;
 
-  await cubeCursor.eachAsync(async (cube) => {
+  await cubeCursor.eachAsync(
+    async (cube) => {
       await processCube(cube, cardUseCount, cardCountByCubeSize, cubeCountBySize, oracleToIndex);
-      i +=1 ;
+      i += 1;
       if ((i + 1) % 100 === 0) {
         winston.info(`Finished: ${i + 1} of ${cubeCount} cubes.`);
       }
     },
     {
-       parallel: 100 
-    });
+      parallel: 100,
+    },
+  );
 
   cubeCursor.close();
   winston.info('Finished: all cubes');
@@ -450,19 +452,21 @@ const run = async () => {
   // process all deck objects
   winston.info('Started: decks');
   const deckCount = await Deck.countDocuments();
-  const deckCursor = Deck.find({}, 'seats cards').lean().cursor();    
+  const deckCursor = Deck.find({}, 'seats cards').lean().cursor();
   i = 0;
 
-  await deckCursor.eachAsync(async (deck) => {
-    await processDeck(deck, oracleToIndex, correlations);
-    i +=1 ;
-    if ((i + 1) % 1000 === 0) {
-      winston.info(`Finished: ${i + 1} of ${deckCount} decks.`);
-    }
-  },
-  {
-     parallel: 100 
-  });
+  await deckCursor.eachAsync(
+    async (deck) => {
+      await processDeck(deck, oracleToIndex, correlations);
+      i += 1;
+      if ((i + 1) % 1000 === 0) {
+        winston.info(`Finished: ${i + 1} of ${deckCount} decks.`);
+      }
+    },
+    {
+      parallel: 100,
+    },
+  );
 
   deckCursor.close();
   winston.info('Finished: all decks');

--- a/routes/cube/api.js
+++ b/routes/cube/api.js
@@ -161,7 +161,7 @@ router.post(
     }
 
     // cube tags
-    cube.tags = updatedCube.tags;
+    cube.tags = updatedCube.tags.filter((tag) => tag && tag.length > 0).map((tag) => tag.toLowerCase());
     setCubeType(cube, carddb);
 
     await cube.save();

--- a/routes/root.js
+++ b/routes/root.js
@@ -312,6 +312,15 @@ router.get('/search/:query/:page', async (req, res) => {
       });
     }
 
+    if (query.warnings) {
+      for (const warning of query.warnings) {
+        req.flash('danger', `Warning: ${warning}`);
+      }
+      delete query.warnings;
+    }
+
+    console.log(query);
+
     query.isListed = true;
 
     const count = await Cube.countDocuments(query);

--- a/routes/root.js
+++ b/routes/root.js
@@ -319,8 +319,6 @@ router.get('/search/:query/:page', async (req, res) => {
       delete query.warnings;
     }
 
-    console.log(query);
-
     query.isListed = true;
 
     const count = await Cube.countDocuments(query);

--- a/src/components/CubeSearchNavBar.js
+++ b/src/components/CubeSearchNavBar.js
@@ -10,7 +10,8 @@ import Advertisement from 'components/Advertisement';
 
 const AdvancedSearchModal = ({ isOpen, toggle }) => {
   const [name, setName] = useState('');
-  const [owner, setowner] = useState('');
+  const [owner, setOwner] = useState('');
+  const [tag, setTag] = useState('');
   const [decks, setDecks] = useState('');
   const [cards, setCards] = useState('');
   const [include, setInclude] = useState('');
@@ -50,7 +51,10 @@ const AdvancedSearchModal = ({ isOpen, toggle }) => {
         setName(value);
         break;
       case 'owner':
-        setowner(value);
+        setOwner(value);
+        break;
+      case 'tag':
+        setTag(value);
         break;
       case 'decks':
         setDecks(value);
@@ -83,6 +87,9 @@ const AdvancedSearchModal = ({ isOpen, toggle }) => {
     }
     if (owner.length > 0) {
       queryText += `owner:"${owner}" `;
+    }
+    if (tag.length > 0) {
+      queryText += `tag:"${tag}" `;
     }
     if (decks.length > 0) {
       queryText += `decks${decksOp}${decks} `;
@@ -124,6 +131,13 @@ const AdvancedSearchModal = ({ isOpen, toggle }) => {
             humanName="Owner Name"
             placeholder={'Any text in the owner name, e.g. "TimFReilly"'}
             value={owner}
+            onChange={handleChange}
+          />
+          <TextField
+            name="tag"
+            humanName="Cube Tags"
+            placeholder={'Any tag on a cube, e.g. "2 player"'}
+            value={tag}
             onChange={handleChange}
           />
           <NumericField

--- a/src/pages/CubeOverviewPage.js
+++ b/src/pages/CubeOverviewPage.js
@@ -261,9 +261,11 @@ const CubeOverview = ({ post, priceOwned, pricePurchase, cube, followed, followe
                 <CardFooter>
                   <div className="autocard-tags">
                     {cubeState.tags.map((tag) => (
-                      <span key={tag} className="tag">
-                        {tag}
-                      </span>
+                      <a href={`/search/tag:"${tag}"/0`}>
+                        <span key={tag} className="tag">
+                          {tag}
+                        </span>
+                      </a>
                     ))}
                   </div>
                 </CardFooter>


### PR DESCRIPTION
We've had the ability to tag cubes for a while, but all they did was add a tag below the cube description.

Recently, we pushed a change that reworks how cubes can be queried, and cube tags can now be used to search for cubes.

So, it was only natural to make the cube tags links to the search pages. To make this work properly, I've updated `clean_cubes` to ensure cube tags are all lowercase, and I've also updated cube search navbar to have the advanced search by tag.

Cube with tags:
![image](https://user-images.githubusercontent.com/28238025/121540962-e2305480-c9d4-11eb-8d6b-94e6c8158ed0.png)

After clicking a tag:
![image](https://user-images.githubusercontent.com/28238025/121541015-ea888f80-c9d4-11eb-9104-1ad630c1136c.png)

Updated modal:
![image](https://user-images.githubusercontent.com/28238025/121541044-f1170700-c9d4-11eb-9a88-41f194fbc14c.png)

