### PR TITLE
Use user roles for patron status

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -83,7 +83,7 @@ const UserSchema = mongoose.Schema({
     type: [
       {
         type: String,
-        enum: ['Admin', 'ContentCreator'],
+        enum: ['Admin', 'ContentCreator', 'Patron'],
       },
     ],
     default: [],
@@ -100,10 +100,6 @@ const UserSchema = mongoose.Schema({
   patron: {
     type: String,
     default: null,
-  },
-  isPatron: {
-    type: Boolean,
-    default: false,
   },
 });
 

--- a/one_shot_scripts/add_patron_status.js
+++ b/one_shot_scripts/add_patron_status.js
@@ -12,7 +12,10 @@ const level = 'Cobra Hatchling';
 (async () => {
   mongoose.connect(process.env.MONGODB_URL).then(async () => {
     const user = await User.findOne({ username });
-    user.isPatron = true;
+
+    if (!user.roles.includes('Patron')) {
+      user.roles.push('Patron');
+    }
 
     const patron = await Patron.findOne({ user: user._id });
 

--- a/routes/patreon_routes.js
+++ b/routes/patreon_routes.js
@@ -92,10 +92,12 @@ router.post('/hook', async (req, res) => {
       }
 
       patron.active = true;
-      user.isPatron = true;
+      if (!user.roles.includes('Patron')) {
+        user.roles.push('Patron');
+      }
     } else if (action === 'pledges:delete') {
       patron.active = false;
-      user.isPatron = false;
+      user.roles = user.roles.filter((role) => role !== 'Patron');
     } else {
       req.logger.info(`Recieved an unsupported patreon hook action: "${action}"`);
       return res.status(500).send({
@@ -190,7 +192,9 @@ router.get('/redirect', ensureAuth, (req, res) => {
       await newPatron.save();
 
       const user = await User.findById(req.user.id);
-      user.isPatron = true;
+      if (!user.roles.includes('Patron')) {
+        user.roles.push('Patron');
+      }
       await user.save();
 
       req.flash('success', `Your Patreon account has succesfully been linked.`);

--- a/src/pages/UserAccountPage.js
+++ b/src/pages/UserAccountPage.js
@@ -264,7 +264,7 @@ const UserAccountPage = ({ user, defaultNav, loginCallback, patreonClientId, pat
               <Card>
                 {patron ? (
                   <CardBody>
-                    {user.isPatron ? (
+                    {user.roles.includes('Patron') ? (
                       <p>
                         Your account is linked at the <b>{patron.level}</b> level.
                       </p>


### PR DESCRIPTION
Instead of using a `isPatron` flag on the user object, we should just use the `roles` mechanism in place already