### PR TITLE
Tweak card pages, fix 5.4 bug

### DIFF
--- a/routes/patreon_routes.js
+++ b/routes/patreon_routes.js
@@ -32,6 +32,7 @@ router.get('/unlink', ensureAuth, async (req, res) => {
 
     const user = await User.findById(req.user.id);
     user.roles = user.roles.filter((role) => role !== 'Patron');
+    user.patron = undefined;
     await user.save();
 
     req.flash('success', `Patron account has been unlinked.`);

--- a/routes/patreon_routes.js
+++ b/routes/patreon_routes.js
@@ -200,6 +200,7 @@ router.get('/redirect', ensureAuth, (req, res) => {
       if (!user.roles.includes('Patron')) {
         user.roles.push('Patron');
       }
+      user.patron = patron._id;
       await user.save();
 
       req.flash('success', `Your Patreon account has succesfully been linked.`);

--- a/src/pages/CardPage.js
+++ b/src/pages/CardPage.js
@@ -44,7 +44,7 @@ import MainLayout from 'layouts/MainLayout';
 import RenderToRoot from 'utils/RenderToRoot';
 import Tab from 'components/Tab';
 
-import { cardPrice, cardFoilPrice, cardPriceEur, cardTix, cardElo } from 'utils/Card';
+import { cardPrice, cardFoilPrice, cardPriceEur, cardTix, cardElo, cardPopularity, cardCubeCount } from 'utils/Card';
 import { getTCGLink, getCardMarketLink, getCardHoarderLink, getCardKingdomLink } from 'utils/Affiliate';
 import { ArrowSwitchIcon, CheckIcon, ClippyIcon } from '@primer/octicons-react';
 
@@ -267,8 +267,8 @@ const CardPage = ({ user, card, data, versions, related, loginCallback }) => {
             )}
             <CardBody className="breakdown p-1">
               <p>
-                Played in {Math.round(data.current.total[1] * 1000.0) / 10}%
-                <span className="percent">{data.current.total[0]}</span> Cubes total.
+                Played in {cardPopularity({ details: card })}%
+                <span className="percent">{cardCubeCount({ details: card })}</span> Cubes total.
               </p>
               <AddModal
                 color="success"

--- a/src/utils/Card.js
+++ b/src/utils/Card.js
@@ -191,7 +191,7 @@ export const cardTokens = (card) => card.details.tokens;
 
 export const cardElo = (card) => (card.details ? card.details.elo || 1200 : 1200);
 
-export const cardPopularity = (card) => (card.details.popularity || 0).toFixed(0);
+export const cardPopularity = (card) => parseFloat(card.details.popularity || 0).toFixed(0);
 
 export const cardCubeCount = (card) => card.details.cubeCount || 0;
 


### PR DESCRIPTION
This PR does two things:
- Have card pages use carddb values for popularity and cube count
- Correctly use the `user.patron` field