### PR TITLE
Add UserContext

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -18,7 +18,6 @@ one_shot_scripts/validate_colors.js
 public/js/autocard.js
 public/js/index.js
 src/components/AutocompleteInput.js
-src/components/BlogPost.js
 src/components/ButtonLink.js
 src/components/CardModalForm.js
 src/components/CardModal.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -8453,9 +8453,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "requires": {
         "is-glob": "^4.0.1"
       }

--- a/routes/cube/deck.js
+++ b/routes/cube/deck.js
@@ -394,7 +394,7 @@ router.get('/decks/:cubeid/:page', async (req, res) => {
       {
         cube: cube._id,
       },
-      '_id seats date cube',
+      '_id seats date cube owner cubeOwner',
     )
       .sort({
         date: -1,

--- a/routes/cube/index.js
+++ b/routes/cube/index.js
@@ -607,7 +607,7 @@ router.get('/playtest/:id', async (req, res) => {
       {
         cube: cube._id,
       },
-      'date seats _id cube',
+      'date seats _id cube owner cubeOwner',
     )
       .sort({
         date: -1,

--- a/routes/dev_routes.js
+++ b/routes/dev_routes.js
@@ -38,7 +38,6 @@ router.get('/blog/:id', async (req, res) => {
     blogs,
     pages: Math.ceil(count / PAGESIZE),
     activePage: req.params.id,
-    userid: req.user ? req.user._id : null,
   });
 });
 

--- a/routes/users_routes.js
+++ b/routes/users_routes.js
@@ -535,7 +535,7 @@ router.get('/decks/:userid/:page', async (req, res) => {
       {
         owner: userid,
       },
-      '_id seats date cube',
+      '_id seats date cube owner cubeOwner',
     )
       .sort({
         date: -1,

--- a/src/analytics/Suggestions.js
+++ b/src/analytics/Suggestions.js
@@ -24,7 +24,7 @@ import useToggle from 'hooks/UseToggle';
 const AutocardA = withAutocard('a');
 const AddModal = withModal(AutocardA, AddToCubeModal);
 
-const Suggestion = ({ card, index, cubes, cube }) => {
+const Suggestion = ({ card, index, cube }) => {
   return (
     <ListGroupItem>
       <h6>
@@ -34,7 +34,7 @@ const Suggestion = ({ card, index, cubes, cube }) => {
           front={card.details.image_normal}
           back={card.details.image_flip ?? undefined}
           href={`/tool/card/${encodeName(card.cardID)}`}
-          modalProps={{ card: card.details, cubes, hideAnalytics: false, cubeContext: cube._id }}
+          modalProps={{ card: card.details, hideAnalytics: false, cubeContext: cube._id }}
         >
           {card.details.name}
         </AddModal>
@@ -54,18 +54,9 @@ Suggestion.propTypes = {
   }).isRequired,
   cube: CubePropType.isRequired,
   index: PropTypes.number.isRequired,
-  cubes: PropTypes.arrayOf(
-    PropTypes.shape({
-      _id: PropTypes.string.isRequired,
-    }),
-  ),
 };
 
-Suggestion.defaultProps = {
-  cubes: [],
-};
-
-const Suggestions = ({ adds, cuts, loadState, cube, filter, cubes }) => {
+const Suggestions = ({ adds, cuts, loadState, cube, filter }) => {
   const [maybeOnly, toggleMaybeOnly] = useToggle(false);
 
   const filteredCuts = useMemo(() => {
@@ -123,7 +114,7 @@ const Suggestions = ({ adds, cuts, loadState, cube, filter, cubes }) => {
                       showBottom
                       pageWrap={(element) => <CardBody>{element}</CardBody>}
                       rows={filteredAdds.slice(0).map(([add, index]) => (
-                        <Suggestion key={add.cardID} index={index} card={add} cubes={cubes} cube={cube} />
+                        <Suggestion key={add.cardID} index={index} card={add} cube={cube} />
                       ))}
                     />
                   ) : (
@@ -154,7 +145,7 @@ const Suggestions = ({ adds, cuts, loadState, cube, filter, cubes }) => {
                       showBottom
                       pageWrap={(element) => <CardBody>{element}</CardBody>}
                       rows={filteredCuts.slice(0).map(([card, index]) => (
-                        <Suggestion key={card.cardID} index={index} card={card} cubes={cubes} cube={cube} />
+                        <Suggestion key={card.cardID} index={index} card={card} cube={cube} />
                       ))}
                     />
                   ) : (
@@ -181,12 +172,10 @@ Suggestions.propTypes = {
     ),
   }).isRequired,
   filter: PropTypes.func,
-  cubes: PropTypes.arrayOf(PropTypes.shape({})),
 };
 
 Suggestions.defaultProps = {
   filter: null,
-  cubes: [],
 };
 
 export default Suggestions;

--- a/src/components/AddToCubeModal.js
+++ b/src/components/AddToCubeModal.js
@@ -1,8 +1,10 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
-import CubePropType from 'proptypes/CubePropType';
+
+import UserContext from 'contexts/UserContext';
 import ImageFallback from 'components/ImageFallback';
 import { csrfFetch } from 'utils/CSRF';
+
 import {
   Modal,
   ModalHeader,
@@ -16,7 +18,10 @@ import {
   UncontrolledAlert,
 } from 'reactstrap';
 
-const AddToCubeModal = ({ card, isOpen, toggle, hideAnalytics, cubeContext, cubes }) => {
+const AddToCubeModal = ({ card, isOpen, toggle, hideAnalytics, cubeContext }) => {
+  const user = useContext(UserContext);
+  const cubes = user ? user.cubes : [];
+
   let def = cubeContext;
   if (cubes.length > 0) {
     def = cubes.map((cube) => cube._id).includes(cubeContext) ? cubeContext : cubes[0]._id;
@@ -156,7 +161,6 @@ AddToCubeModal.propTypes = {
   hideAnalytics: PropTypes.bool,
   toggle: PropTypes.func.isRequired,
   cubeContext: PropTypes.string,
-  cubes: PropTypes.arrayOf(CubePropType).isRequired,
 };
 
 AddToCubeModal.defaultProps = {

--- a/src/components/Advertisement.js
+++ b/src/components/Advertisement.js
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 
 import { Col, Card, CardBody } from 'reactstrap';
-import UserPropType from 'proptypes/UserPropType';
+import UserContext from 'contexts/UserContext';
 
 const AD_RATE = 2; // an ad appears with probability of 1/AD_RATE
 
@@ -44,7 +44,9 @@ const adOptions = [
   </>,
 ];
 
-const Advertisement = ({ user }) => {
+const Advertisement = () => {
+  const user = useContext(UserContext);
+
   const [option] = useState(Math.floor(Math.random() * adOptions.length * AD_RATE));
   if (user && Array.isArray(user.roles) && user.roles.includes('Patron')) return <></>;
   if (option < adOptions.length) {
@@ -57,14 +59,6 @@ const Advertisement = ({ user }) => {
     );
   }
   return <></>;
-};
-
-Advertisement.propTypes = {
-  user: UserPropType,
-};
-
-Advertisement.defaultProps = {
-  user: null,
 };
 
 export default Advertisement;

--- a/src/components/Article.js
+++ b/src/components/Article.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import ArticlePropType from 'proptypes/ArticlePropType';
 
 import Markdown from 'components/Markdown';
@@ -8,7 +7,7 @@ import TimeAgo from 'react-timeago';
 
 import { CardBody, CardHeader } from 'reactstrap';
 
-const Article = ({ article, userid }) => {
+const Article = ({ article }) => {
   return (
     <>
       <CardHeader>
@@ -23,18 +22,13 @@ const Article = ({ article, userid }) => {
         <Markdown markdown={article.body} />
       </CardBody>
       <div className="border-top">
-        <CommentsSection parentType="article" parent={article._id} userid={userid} collapse={false} />
+        <CommentsSection parentType="article" parent={article._id} collapse={false} />
       </div>
     </>
   );
 };
 Article.propTypes = {
   article: ArticlePropType.isRequired,
-  userid: PropTypes.string,
-};
-
-Article.defaultProps = {
-  userid: null,
 };
 
 export default Article;

--- a/src/components/BlogPost.js
+++ b/src/components/BlogPost.js
@@ -1,125 +1,93 @@
-import React from 'react';
+import React, { useContext } from 'react';
+
+import PropTypes from 'prop-types';
+import BlogPostPropType from 'proptypes/BlogPostPropType';
+
 import TimeAgo from 'react-timeago';
+
 import { Card, CardHeader, Row, Col, CardBody, CardText } from 'reactstrap';
+
+import UserContext from 'contexts/UserContext';
 import BlogContextMenu from 'components/BlogContextMenu';
 import CommentsSection from 'components/CommentsSection';
 import Markdown from 'components/Markdown';
 
-class BlogPost extends React.Component {
-  constructor(props) {
-    super(props);
+const BlogPost = ({ post, onEdit, noScroll }) => {
+  const user = useContext(UserContext);
 
-    this.state = {
-      childExpanded: props.focused ? true : false,
-    };
+  const html = post.html === 'undefined' ? null : post.html;
 
-    this.onPost = this.onPost.bind(this);
-    this.submitEdit = this.submitEdit.bind(this);
-    this.toggleChildCollapse = this.toggleChildCollapse.bind(this);
-  }
+  const scrollStyle = noScroll ? {} : { overflow: 'auto', maxHeight: '50vh' };
 
-  error(message) {
-    console.log(message);
-  }
+  const canEdit = user && user.id === post.user;
 
-  onPost(comment) {
-    comment.index = this.props.post.comments.length;
-    this.props.post.comments.push(comment);
-    this.setState({
-      childExpanded: true,
-    });
-  }
-
-  saveEdit(comments, position, comment) {
-    if (position.length == 1) {
-      comments[position[0]] = comment;
-    } else if (position.length > 1) {
-      this.saveEdit(comments[position[0]].comments, position.slice(1), comment);
-    }
-  }
-
-  toggleChildCollapse() {
-    this.setState({
-      childExpanded: !this.state.childExpanded,
-    });
-  }
-
-  async submitEdit(comment, position) {
-    //update current state
-    this.saveEdit(this.props.post.comments, position, comment);
-  }
-
-  componentDidMount() {
-    // FIXME: Restore scrolling to highlighted comment.
-  }
-
-  render() {
-    const { post, onEdit, noScroll } = this.props;
-    if (post.html == 'undefined') {
-      post.html = null;
-    }
-    let scrollStyle = noScroll ? {} : { overflow: 'auto', maxHeight: '50vh' };
-
-    return (
-      <Card className="shadowed rounded-0 mb-3">
-        <CardHeader className="pl-4 pr-0 pt-2 pb-0">
-          <h5 className="card-title">
-            <a href={`/cube/blog/blogpost/${post._id}`}>{post.title}</a>
-            <div className="float-sm-right">
-              {this.props.canEdit && (
-                <BlogContextMenu className="float-sm-right" post={post} value="..." onEdit={onEdit} />
-              )}
-            </div>
-          </h5>
-          <h6 className="card-subtitle mb-2 text-muted">
-            <a href={'/user/view/' + post.owner}>{post.dev == 'true' ? 'Dekkaru' : post.username}</a>
-            {' posted to '}
-            {post.dev == 'true' ? (
-              <a href={'/dev/blog/0'}>Developer Blog</a>
-            ) : (
-              <a href={'/cube/overview/' + post.cube}>{post.cubename}</a>
-            )}
-            {' - '}
-            <TimeAgo date={post.date} />
-          </h6>
-        </CardHeader>
-        <div style={scrollStyle}>
-          {post.changelist && (post.html || post.markdown) ? (
-            <Row className="no-gutters">
-              <Col className="col-12 col-l-5 col-md-4 col-sm-12 blog-post-border">
-                <CardBody className="py-2">
-                  <CardText dangerouslySetInnerHTML={{ __html: post.changelist }} />
-                </CardBody>
-              </Col>
-              <Col className="col-l-7 col-m-6">
-                <CardBody className="py-2">
-                  {post.markdown ? (
-                    <Markdown markdown={post.markdown} limited />
-                  ) : (
-                    <CardText dangerouslySetInnerHTML={{ __html: post.html }} />
-                  )}
-                </CardBody>
-              </Col>
-            </Row>
+  return (
+    <Card className="shadowed rounded-0 mb-3">
+      <CardHeader className="pl-4 pr-0 pt-2 pb-0">
+        <h5 className="card-title">
+          <a href={`/cube/blog/blogpost/${post._id}`}>{post.title}</a>
+          <div className="float-sm-right">
+            {canEdit && <BlogContextMenu className="float-sm-right" post={post} value="..." onEdit={onEdit} />}
+          </div>
+        </h5>
+        <h6 className="card-subtitle mb-2 text-muted">
+          <a href={`/user/view/${post.owner}`}>{post.dev === 'true' ? 'Dekkaru' : post.username}</a>
+          {' posted to '}
+          {post.dev === 'true' ? (
+            <a href="/dev/blog/0">Developer Blog</a>
           ) : (
-            <CardBody className="py-2">
-              {post.changelist && <CardText dangerouslySetInnerHTML={{ __html: post.changelist }} />}
-              {post.body && <CardText>{post.body}</CardText>}
-              {(post.html || post.markdown) &&
-                (post.markdown ? (
+            <a href={`/cube/overview/${post.cube}`}>{post.cubename}</a>
+          )}
+          {' - '}
+          <TimeAgo date={post.date} />
+        </h6>
+      </CardHeader>
+      <div style={scrollStyle}>
+        {post.changelist && (html || post.markdown) ? (
+          <Row className="no-gutters">
+            <Col className="col-12 col-l-5 col-md-4 col-sm-12 blog-post-border">
+              <CardBody className="py-2">
+                <CardText dangerouslySetInnerHTML={{ __html: post.changelist }} />
+              </CardBody>
+            </Col>
+            <Col className="col-l-7 col-m-6">
+              <CardBody className="py-2">
+                {post.markdown ? (
                   <Markdown markdown={post.markdown} limited />
                 ) : (
-                  <CardText dangerouslySetInnerHTML={{ __html: post.html }} />
-                ))}
-            </CardBody>
-          )}
-        </div>
-        <div className="border-top">
-          <CommentsSection parentType="blog" parent={post._id} userid={this.props.userid} collapse={false} />
-        </div>
-      </Card>
-    );
-  }
-}
+                  <CardText dangerouslySetInnerHTML={{ __html: html }} />
+                )}
+              </CardBody>
+            </Col>
+          </Row>
+        ) : (
+          <CardBody className="py-2">
+            {post.changelist && <CardText dangerouslySetInnerHTML={{ __html: post.changelist }} />}
+            {post.body && <CardText>{post.body}</CardText>}
+            {(html || post.markdown) &&
+              (post.markdown ? (
+                <Markdown markdown={post.markdown} limited />
+              ) : (
+                <CardText dangerouslySetInnerHTML={{ __html: html }} />
+              ))}
+          </CardBody>
+        )}
+      </div>
+      <div className="border-top">
+        <CommentsSection parentType="blog" parent={post._id} collapse={false} />
+      </div>
+    </Card>
+  );
+};
+
+BlogPost.propTypes = {
+  post: BlogPostPropType.isRequired,
+  onEdit: PropTypes.func.isRequired,
+  noScroll: PropTypes.bool,
+};
+
+BlogPost.defaultProps = {
+  noScroll: false,
+};
 
 export default BlogPost;

--- a/src/components/CardPackage.js
+++ b/src/components/CardPackage.js
@@ -149,7 +149,7 @@ const CardPackage = ({ cardPackage, refresh }) => {
         </Row>
       </CardBody>
       <div className="border-top">
-        <CommentsSection parentType="package" parent={cardPackage._id} userid={user ? user.id : null} collapse />
+        <CommentsSection parentType="package" parent={cardPackage._id} collapse />
       </div>
     </Card>
   );

--- a/src/components/CardPackage.js
+++ b/src/components/CardPackage.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import TimeAgo from 'react-timeago';
 
+import UserContext from 'contexts/UserContext';
 import CardPackagePropType from 'proptypes/CardPackagePropType';
-import UserPropType from 'proptypes/UserPropType';
 import withAutocard from 'components/WithAutocard';
 import AddGroupToCubeModal from 'components/AddGroupToCubeModal';
 import withModal from 'components/WithModal';
@@ -18,7 +18,9 @@ import { csrfFetch } from 'utils/CSRF';
 const AddGroupToCubeModalLink = withModal(Button, AddGroupToCubeModal);
 const AutocardA = withAutocard('a');
 
-const CardPackage = ({ cardPackage, user, refresh }) => {
+const CardPackage = ({ cardPackage, refresh }) => {
+  const user = useContext(UserContext);
+
   const voted = user ? cardPackage.voters.includes(user.id) : false;
 
   const toggleVote = async () => {
@@ -155,12 +157,10 @@ const CardPackage = ({ cardPackage, user, refresh }) => {
 
 CardPackage.propTypes = {
   cardPackage: CardPackagePropType.isRequired,
-  user: UserPropType,
   refresh: PropTypes.func,
 };
 
 CardPackage.defaultProps = {
-  user: null,
   refresh: () => {},
 };
 

--- a/src/components/Comment.js
+++ b/src/components/Comment.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import CommentPropType from 'proptypes/CommentPropType';
 import TimeAgo from 'react-timeago';
@@ -17,6 +17,7 @@ import {
   Input,
 } from 'reactstrap';
 
+import UserContext from 'contexts/UserContext';
 import LinkButton from 'components/LinkButton';
 import CommentContextMenu from 'components/CommentContextMenu';
 import CSRFForm from 'components/CSRFForm';
@@ -27,7 +28,10 @@ import Markdown from 'components/Markdown';
 
 const maxDepth = 4;
 
-const Comment = ({ comment, index, depth, userid, noReplies, editComment }) => {
+const Comment = ({ comment, index, depth, noReplies, editComment }) => {
+  const user = useContext(UserContext);
+  const userid = user && user.id;
+
   const [replyExpanded, toggleReply] = useToggle(false);
   const [expanded, toggle] = useToggle(false);
   const [comments, addComment, , editChildComment] = useComments('comment', comment._id);
@@ -208,7 +212,6 @@ const Comment = ({ comment, index, depth, userid, noReplies, editComment }) => {
                       comment={item}
                       index={index + comments.length - pos}
                       depth={depth + 1}
-                      userid={userid}
                       editComment={editChildComment}
                     />
                   ))}
@@ -230,14 +233,12 @@ Comment.propTypes = {
   comment: CommentPropType.isRequired,
   index: PropTypes.number.isRequired,
   depth: PropTypes.number,
-  userid: PropTypes.string,
   noReplies: PropTypes.bool,
   editComment: PropTypes.func.isRequired,
 };
 
 Comment.defaultProps = {
   depth: 0,
-  userid: null,
   noReplies: false,
 };
 

--- a/src/components/CommentsSection.js
+++ b/src/components/CommentsSection.js
@@ -1,15 +1,19 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 
 import { Collapse, Spinner } from 'reactstrap';
 
+import UserContext from 'contexts/UserContext';
 import CommentList from 'components/PagedCommentList';
 import LinkButton from 'components/LinkButton';
 import CommentEntry from 'components/CommentEntry';
 import useToggle from 'hooks/UseToggle';
 import useComments from 'hooks/UseComments';
 
-const CommentsSection = ({ parent, parentType, collapse, userid }) => {
+const CommentsSection = ({ parent, parentType, collapse }) => {
+  const user = useContext(UserContext);
+  const userid = user && user.id;
+
   const [expanded, toggle] = useToggle(!collapse);
   const [replyExpanded, toggleReply] = useToggle(false);
   const [comments, addComment, loading, editComment] = useComments(parentType, parent);
@@ -48,7 +52,7 @@ const CommentsSection = ({ parent, parentType, collapse, userid }) => {
             </div>
           )}
           <Collapse isOpen={expanded}>
-            <CommentList comments={comments} userid={userid} editComment={editComment} />
+            <CommentList comments={comments} editComment={editComment} />
           </Collapse>
         </>
       )}
@@ -59,12 +63,10 @@ const CommentsSection = ({ parent, parentType, collapse, userid }) => {
 CommentsSection.propTypes = {
   parent: PropTypes.string.isRequired,
   parentType: PropTypes.string.isRequired,
-  userid: PropTypes.string,
   collapse: PropTypes.bool,
 };
 
 CommentsSection.defaultProps = {
-  userid: null,
   collapse: true,
 };
 

--- a/src/components/CreatorArticles.js
+++ b/src/components/CreatorArticles.js
@@ -1,9 +1,9 @@
-import React, { useState, useEffect } from 'react';
-import UserPropType from 'proptypes/UserPropType';
+import React, { useState, useEffect, useContext } from 'react';
 
 import { Navbar, Nav, NavItem, NavLink, Row, Col, CardBody } from 'reactstrap';
 
 import Loading from 'pages/Loading';
+import UserContext from 'contexts/UserContext';
 import ArticlePreview from 'components/ArticlePreview';
 import Paginate from 'components/Paginate';
 import { csrfFetch } from 'utils/CSRF';
@@ -11,7 +11,9 @@ import useQueryParam from 'hooks/useQueryParam';
 
 const PAGE_SIZE = 24;
 
-const CreatorArticles = ({ user }) => {
+const CreatorArticles = () => {
+  const user = useContext(UserContext);
+
   const [articles, setArticles] = useState([]);
   const [page, setPage] = useQueryParam('page', '0');
   const [pages, setPages] = useState(0);
@@ -66,10 +68,6 @@ const CreatorArticles = ({ user }) => {
       )}
     </>
   );
-};
-
-CreatorArticles.propTypes = {
-  user: UserPropType.isRequired,
 };
 
 export default CreatorArticles;

--- a/src/components/CreatorPodcasts.js
+++ b/src/components/CreatorPodcasts.js
@@ -1,8 +1,8 @@
-import React, { useState, useEffect } from 'react';
-import UserPropType from 'proptypes/UserPropType';
+import React, { useState, useEffect, useContext } from 'react';
 
 import { Navbar, Nav, NavItem, NavLink, Row, Col, CardBody } from 'reactstrap';
 
+import UserContext from 'contexts/UserContext';
 import Loading from 'pages/Loading';
 import PodcastPreview from 'components/PodcastPreview';
 import Paginate from 'components/Paginate';
@@ -11,7 +11,9 @@ import { csrfFetch } from 'utils/CSRF';
 
 const PAGE_SIZE = 24;
 
-const CreatorPodcasts = ({ user }) => {
+const CreatorPodcasts = () => {
+  const user = useContext(UserContext);
+
   const [podcasts, setPodcasts] = useState([]);
   const [page, setPage] = useQueryParam('page', 0);
   const [pages, setPages] = useState(0);
@@ -66,10 +68,6 @@ const CreatorPodcasts = ({ user }) => {
       )}
     </>
   );
-};
-
-CreatorPodcasts.propTypes = {
-  user: UserPropType.isRequired,
 };
 
 export default CreatorPodcasts;

--- a/src/components/CreatorVideos.js
+++ b/src/components/CreatorVideos.js
@@ -1,6 +1,6 @@
-import React, { useState, useEffect } from 'react';
-import UserPropType from 'proptypes/UserPropType';
+import React, { useState, useEffect, useContext } from 'react';
 
+import UserContext from 'contexts/UserContext';
 import { Navbar, Nav, NavItem, NavLink, Row, Col, CardBody } from 'reactstrap';
 import Loading from 'pages/Loading';
 import VideoPreview from 'components/VideoPreview';
@@ -10,7 +10,9 @@ import { csrfFetch } from 'utils/CSRF';
 
 const PAGE_SIZE = 24;
 
-const CreatorVideos = ({ user }) => {
+const CreatorVideos = () => {
+  const user = useContext(UserContext);
+
   const [videos, setVideos] = useState([]);
   const [page, setPage] = useQueryParam('page', 0);
   const [pages, setPages] = useState(0);
@@ -65,10 +67,6 @@ const CreatorVideos = ({ user }) => {
       )}
     </>
   );
-};
-
-CreatorVideos.propTypes = {
-  user: UserPropType.isRequired,
 };
 
 export default CreatorVideos;

--- a/src/components/DeckCard.js
+++ b/src/components/DeckCard.js
@@ -1,17 +1,18 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
-import { Card, CardBody, CardHeader, CardTitle, Col, Row } from 'reactstrap';
+import PropTypes from 'prop-types';
+import CardPropType from 'proptypes/CardPropType';
+import DraftSeatPropType from 'proptypes/DraftSeatPropType';
+import DeckPropType from 'proptypes/DeckPropType';
 
 import CommentsSection from 'components/CommentsSection';
 import DecksPickBreakdown from 'components/DecksPickBreakdown';
 import DraftbotBreakdown from 'components/DraftbotBreakdown';
 import FoilCardImage from 'components/FoilCardImage';
 import Markdown from 'components/Markdown';
-import CardPropType from 'proptypes/CardPropType';
-import DraftSeatPropType from 'proptypes/DraftSeatPropType';
-import DeckPropType from 'proptypes/DeckPropType';
 import { makeSubtitle } from 'utils/Card';
+
+import { Card, CardBody, CardHeader, CardTitle, Col, Row } from 'reactstrap';
 
 const DeckStacksStatic = ({ piles, cards }) => (
   <CardBody className="pt-0 border-bottom">
@@ -50,7 +51,7 @@ DeckStacksStatic.propTypes = {
   piles: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number.isRequired))).isRequired,
 };
 
-const DeckCard = ({ seat, userid, deck, seatIndex, draft, view }) => {
+const DeckCard = ({ seat, deck, seatIndex, draft, view }) => {
   const stackedDeck = seat.deck.slice();
   const stackedSideboard = seat.sideboard.slice();
   let sbCount = 0;
@@ -146,7 +147,7 @@ const DeckCard = ({ seat, userid, deck, seatIndex, draft, view }) => {
         <Markdown markdown={seat.description} />
       </CardBody>
       <div className="border-top">
-        <CommentsSection parentType="deck" parent={deck._id} userid={userid} collapse={false} />
+        <CommentsSection parentType="deck" parent={deck._id} collapse={false} />
       </div>
     </Card>
   );
@@ -154,7 +155,6 @@ const DeckCard = ({ seat, userid, deck, seatIndex, draft, view }) => {
 
 DeckCard.propTypes = {
   seat: DraftSeatPropType.isRequired,
-  userid: PropTypes.string,
   view: PropTypes.string,
   draft: PropTypes.shape({ cards: PropTypes.arrayOf(CardPropType).isRequired }).isRequired,
   deck: DeckPropType.isRequired,
@@ -162,7 +162,6 @@ DeckCard.propTypes = {
 };
 
 DeckCard.defaultProps = {
-  userid: null,
   view: 'deck',
 };
 

--- a/src/components/DeckPreview.js
+++ b/src/components/DeckPreview.js
@@ -27,8 +27,6 @@ const truncateToLength = (len, s) => {
 };
 
 const DeckPreview = ({ deck, nextURL }) => {
-  console.log(deck);
-
   const user = useContext(UserContext);
   const canEdit = user.id === deck.owner || user.id === deck.cubeOwner;
 

--- a/src/components/DeckPreview.js
+++ b/src/components/DeckPreview.js
@@ -1,8 +1,11 @@
-import React, { useCallback, useMemo, useState } from 'react';
-import TimeAgo from 'react-timeago';
+import React, { useCallback, useMemo, useState, useContext } from 'react';
+
 import PropTypes from 'prop-types';
 import DeckPropType from 'proptypes/DeckPropType';
 
+import TimeAgo from 'react-timeago';
+
+import UserContext from 'contexts/UserContext';
 import useKeyHandlers from 'hooks/UseKeyHandlers';
 import DeckDeleteModal from 'components/DeckDeleteModal';
 
@@ -23,7 +26,12 @@ const truncateToLength = (len, s) => {
   return s.length > len ? `${s.slice(0, len - 3)}...` : s;
 };
 
-const DeckPreview = ({ deck, canEdit, nextURL }) => {
+const DeckPreview = ({ deck, nextURL }) => {
+  console.log(deck);
+
+  const user = useContext(UserContext);
+  const canEdit = user.id === deck.owner || user.id === deck.cubeOwner;
+
   const { date } = deck;
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
 
@@ -100,7 +108,6 @@ const DeckPreview = ({ deck, canEdit, nextURL }) => {
 
 DeckPreview.propTypes = {
   deck: DeckPropType.isRequired,
-  canEdit: PropTypes.bool.isRequired,
   nextURL: PropTypes.string,
 };
 

--- a/src/components/NotificationsNav.js
+++ b/src/components/NotificationsNav.js
@@ -1,12 +1,15 @@
-import React, { useState } from 'react';
-import UserPropType from 'proptypes/UserPropType';
+import React, { useState, useContext } from 'react';
+
+import UserContext from 'contexts/UserContext';
 
 import { UncontrolledDropdown, DropdownToggle, DropdownMenu, Badge, CardHeader, CardFooter } from 'reactstrap';
 
 import { csrfFetch } from 'utils/CSRF';
 import LinkButton from 'components/LinkButton';
 
-const NotificationsNav = ({ user }) => {
+const NotificationsNav = () => {
+  const user = useContext(UserContext);
+
   const [notifications, setNotifications] = useState(user.notifications);
 
   const clear = async () => {
@@ -60,16 +63,6 @@ const NotificationsNav = ({ user }) => {
       </DropdownMenu>
     </UncontrolledDropdown>
   );
-};
-
-NotificationsNav.propTypes = {
-  user: UserPropType,
-};
-
-NotificationsNav.defaultProps = {
-  user: {
-    notifications: [],
-  },
 };
 
 export default NotificationsNav;

--- a/src/components/PagedCommentList.js
+++ b/src/components/PagedCommentList.js
@@ -5,7 +5,7 @@ import CommentPropType from 'proptypes/CommentPropType';
 import Comment from 'components/Comment';
 import PagedList from 'components/PagedList';
 
-const CommentList = ({ comments, startIndex, userid, editComment }) => (
+const CommentList = ({ comments, startIndex, editComment }) => (
   <PagedList
     pageSize={10}
     rows={comments
@@ -16,7 +16,6 @@ const CommentList = ({ comments, startIndex, userid, editComment }) => (
           key={`comment-${comment._id}`}
           comment={comment}
           index={startIndex + comments.length - index}
-          userid={userid}
           editComment={editComment}
         />
       ))}
@@ -26,13 +25,11 @@ const CommentList = ({ comments, startIndex, userid, editComment }) => (
 CommentList.propTypes = {
   comments: PropTypes.arrayOf(CommentPropType).isRequired,
   startIndex: PropTypes.number,
-  userid: PropTypes.string,
   editComment: PropTypes.func.isRequired,
 };
 
 CommentList.defaultProps = {
   startIndex: 0,
-  userid: null,
 };
 
 export default CommentList;

--- a/src/components/Podcast.js
+++ b/src/components/Podcast.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import PropTypes from 'prop-types';
 import PodcastPropType from 'proptypes/PodcastPropType';
 
@@ -8,7 +9,7 @@ import AspectRatioBox from 'components/AspectRatioBox';
 
 import { CardBody, CardHeader, Row, Col } from 'reactstrap';
 
-const Podcast = ({ podcast, userid, episodes }) => {
+const Podcast = ({ podcast, episodes }) => {
   return (
     <>
       <CardHeader>
@@ -41,7 +42,7 @@ const Podcast = ({ podcast, userid, episodes }) => {
         )}
       </CardBody>
       <div className="border-top">
-        <CommentsSection parentType="podcast" parent={podcast._id} userid={userid} collapse={false} />
+        <CommentsSection parentType="podcast" parent={podcast._id} collapse={false} />
       </div>
     </>
   );
@@ -49,11 +50,9 @@ const Podcast = ({ podcast, userid, episodes }) => {
 Podcast.propTypes = {
   podcast: PodcastPropType.isRequired,
   episodes: PropTypes.arrayOf(PropTypes.shape({})),
-  userid: PropTypes.string,
 };
 
 Podcast.defaultProps = {
-  userid: null,
   episodes: [],
 };
 

--- a/src/components/Video.js
+++ b/src/components/Video.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import VideoPropType from 'proptypes/VideoPropType';
 
 import Markdown from 'components/Markdown';
@@ -10,7 +9,7 @@ import ReactPlayer from 'react-player';
 
 import { CardBody, CardHeader } from 'reactstrap';
 
-const Video = ({ video, userid }) => {
+const Video = ({ video }) => {
   return (
     <>
       <CardHeader>
@@ -30,18 +29,13 @@ const Video = ({ video, userid }) => {
         <Markdown markdown={video.body} />
       </CardBody>
       <div className="border-top">
-        <CommentsSection parentType="video" parent={video._id} userid={userid} collapse={false} />
+        <CommentsSection parentType="video" parent={video._id} collapse={false} />
       </div>
     </>
   );
 };
 Video.propTypes = {
   video: VideoPropType.isRequired,
-  userid: PropTypes.string,
-};
-
-Video.defaultProps = {
-  userid: null,
 };
 
 export default Video;

--- a/src/contexts/UserContext.js
+++ b/src/contexts/UserContext.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const GroupModalContext = React.createContext();
+
+export default GroupModalContext;

--- a/src/contexts/UserContext.js
+++ b/src/contexts/UserContext.js
@@ -1,5 +1,5 @@
 import React from 'react';
 
-const GroupModalContext = React.createContext();
+const UserContext = React.createContext();
 
-export default GroupModalContext;
+export default UserContext;

--- a/src/layouts/CubeLayout.js
+++ b/src/layouts/CubeLayout.js
@@ -1,10 +1,14 @@
 import React, { useContext } from 'react';
+
 import PropTypes from 'prop-types';
 import CubePropType from 'proptypes/CubePropType';
-import { NavItem, NavLink } from 'reactstrap';
+
+import UserContext from 'contexts/UserContext';
 import CubeContext, { CubeContextProvider } from 'contexts/CubeContext';
 import ErrorBoundary from 'components/ErrorBoundary';
 import { getCubeDescription, getCubeId } from 'utils/Util';
+
+import { NavItem, NavLink } from 'reactstrap';
 
 const CubeNavItem = ({ link, activeLink, children }) => {
   const { cube } = useContext(CubeContext);
@@ -27,10 +31,11 @@ CubeNavItem.defaultProps = {
   children: false,
 };
 
-const CubeLayout = ({ cube, canEdit, activeLink, children }) => {
+const CubeLayout = ({ cube, activeLink, children }) => {
+  const user = useContext(UserContext);
   const subtitle = getCubeDescription(cube);
   return (
-    <CubeContextProvider cubeID={cube._id} initialCube={cube} canEdit={canEdit}>
+    <CubeContextProvider cubeID={cube._id} initialCube={cube} canEdit={user && cube.owner === user.id}>
       <div className="mb-3">
         <ul className="cubenav nav nav-tabs nav-fill d-flex flex-column flex-sm-row pt-2">
           <div className="nav-item px-lg-4 px-3 text-sm-left text-center font-weight-boldish mt-auto mb-2">
@@ -63,13 +68,11 @@ const CubeLayout = ({ cube, canEdit, activeLink, children }) => {
 
 CubeLayout.propTypes = {
   cube: CubePropType.isRequired,
-  canEdit: PropTypes.bool,
   activeLink: PropTypes.string.isRequired,
   children: PropTypes.node,
 };
 
 CubeLayout.defaultProps = {
-  canEdit: false,
   children: false,
 };
 

--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -21,6 +21,7 @@ import CreateCubeModal from 'components/CreateCubeModal';
 import withModal from 'components/WithModal';
 import NotificationsNav from 'components/NotificationsNav';
 import ThemeContext from 'contexts/ThemeContext';
+import UserContext from 'contexts/UserContext';
 import useToggle from 'hooks/UseToggle';
 import Footer from 'layouts/Footer';
 
@@ -31,131 +32,133 @@ const MainLayout = ({ user, children, loginCallback }) => {
   const [expanded, toggle] = useToggle(false);
 
   return (
-    <div className="flex-container flex-vertical viewport">
-      <Navbar color="dark" expand="md" dark>
-        <Container>
-          <div className="d-flex flex-nowrap w-100 header-banner">
-            <div className="overflow-hidden mr-auto">
-              <a href="/">
-                <img
-                  className="banner-image"
-                  src="/content/banner.png"
-                  alt="Cube Cobra: a site for Magic: the Gathering Cubing"
-                />
-              </a>
+    <UserContext.Provider value={user}>
+      <div className="flex-container flex-vertical viewport">
+        <Navbar color="dark" expand="md" dark>
+          <Container>
+            <div className="d-flex flex-nowrap w-100 header-banner">
+              <div className="overflow-hidden mr-auto">
+                <a href="/">
+                  <img
+                    className="banner-image"
+                    src="/content/banner.png"
+                    alt="Cube Cobra: a site for Magic: the Gathering Cubing"
+                  />
+                </a>
+              </div>
+              <button className="navbar-toggler" type="button" onClick={toggle}>
+                <span className="navbar-toggler-icon" />
+              </button>
             </div>
-            <button className="navbar-toggler" type="button" onClick={toggle}>
-              <span className="navbar-toggler-icon" />
-            </button>
-          </div>
-          <Collapse className="banner-collapse" isOpen={expanded} navbar>
-            <Nav className="mr-auto" navbar>
-              <UncontrolledDropdown nav inNavbar>
-                <DropdownToggle nav caret>
-                  Content
-                </DropdownToggle>
-                <DropdownMenu right>
-                  <DropdownItem href="/content/browse">Browse</DropdownItem>
-                  <DropdownItem href="/content/articles">Articles</DropdownItem>
-                  <DropdownItem href="/content/podcasts">Podcasts</DropdownItem>
-                  <DropdownItem href="/content/videos">Videos</DropdownItem>
-                </DropdownMenu>
-              </UncontrolledDropdown>
-              <UncontrolledDropdown nav inNavbar>
-                <DropdownToggle nav caret>
-                  Cube
-                </DropdownToggle>
-                <DropdownMenu right>
-                  <DropdownItem href="/explore">Explore Cubes</DropdownItem>
-                  <DropdownItem href="/search">Search Cubes</DropdownItem>
-                  <DropdownItem href="/random">Random Cube</DropdownItem>
-                </DropdownMenu>
-              </UncontrolledDropdown>
-              <UncontrolledDropdown nav inNavbar>
-                <DropdownToggle nav caret>
-                  Cards
-                </DropdownToggle>
-                <DropdownMenu right>
-                  <DropdownItem href="/tool/topcards">Top Cards</DropdownItem>
-                  <DropdownItem href="/tool/searchcards">Search Cards</DropdownItem>
-                  <DropdownItem href="/packages/browse">Packages</DropdownItem>
-                  <DropdownItem href="/tool/randomcard">Random Card</DropdownItem>
-                  <DropdownItem href="/filters">Filter Syntax</DropdownItem>
-                </DropdownMenu>
-              </UncontrolledDropdown>
-              <UncontrolledDropdown nav inNavbar>
-                <DropdownToggle nav caret>
-                  About
-                </DropdownToggle>
-                <DropdownMenu right>
-                  <DropdownItem href="/dev/blog">Dev Blog</DropdownItem>
-                  <DropdownItem href="/contact">Contact</DropdownItem>
-                  <DropdownItem href="https://www.inkedgaming.com/collections/artists-gwen-dekker?rfsn=4250904.d3f372&utm_source=refersion&utm_medium=affiliate&utm_campaign=4250904.d3f372">
-                    Merchandise
-                  </DropdownItem>
-                  <DropdownItem href="/ourstory">Our Story</DropdownItem>
-                  <DropdownItem href="/faq">FAQ</DropdownItem>
-                  <DropdownItem href="/donate">Donate</DropdownItem>
-                  <DropdownItem href="https://github.com/dekkerglen/CubeCobra">Github</DropdownItem>
-                </DropdownMenu>
-              </UncontrolledDropdown>
-              {user ? (
-                <>
-                  <NotificationsNav user={user} />
-                  {user.cubes && user.cubes.length > 0 && (
+            <Collapse className="banner-collapse" isOpen={expanded} navbar>
+              <Nav className="mr-auto" navbar>
+                <UncontrolledDropdown nav inNavbar>
+                  <DropdownToggle nav caret>
+                    Content
+                  </DropdownToggle>
+                  <DropdownMenu right>
+                    <DropdownItem href="/content/browse">Browse</DropdownItem>
+                    <DropdownItem href="/content/articles">Articles</DropdownItem>
+                    <DropdownItem href="/content/podcasts">Podcasts</DropdownItem>
+                    <DropdownItem href="/content/videos">Videos</DropdownItem>
+                  </DropdownMenu>
+                </UncontrolledDropdown>
+                <UncontrolledDropdown nav inNavbar>
+                  <DropdownToggle nav caret>
+                    Cube
+                  </DropdownToggle>
+                  <DropdownMenu right>
+                    <DropdownItem href="/explore">Explore Cubes</DropdownItem>
+                    <DropdownItem href="/search">Search Cubes</DropdownItem>
+                    <DropdownItem href="/random">Random Cube</DropdownItem>
+                  </DropdownMenu>
+                </UncontrolledDropdown>
+                <UncontrolledDropdown nav inNavbar>
+                  <DropdownToggle nav caret>
+                    Cards
+                  </DropdownToggle>
+                  <DropdownMenu right>
+                    <DropdownItem href="/tool/topcards">Top Cards</DropdownItem>
+                    <DropdownItem href="/tool/searchcards">Search Cards</DropdownItem>
+                    <DropdownItem href="/packages/browse">Packages</DropdownItem>
+                    <DropdownItem href="/tool/randomcard">Random Card</DropdownItem>
+                    <DropdownItem href="/filters">Filter Syntax</DropdownItem>
+                  </DropdownMenu>
+                </UncontrolledDropdown>
+                <UncontrolledDropdown nav inNavbar>
+                  <DropdownToggle nav caret>
+                    About
+                  </DropdownToggle>
+                  <DropdownMenu right>
+                    <DropdownItem href="/dev/blog">Dev Blog</DropdownItem>
+                    <DropdownItem href="/contact">Contact</DropdownItem>
+                    <DropdownItem href="https://www.inkedgaming.com/collections/artists-gwen-dekker?rfsn=4250904.d3f372&utm_source=refersion&utm_medium=affiliate&utm_campaign=4250904.d3f372">
+                      Merchandise
+                    </DropdownItem>
+                    <DropdownItem href="/ourstory">Our Story</DropdownItem>
+                    <DropdownItem href="/faq">FAQ</DropdownItem>
+                    <DropdownItem href="/donate">Donate</DropdownItem>
+                    <DropdownItem href="https://github.com/dekkerglen/CubeCobra">Github</DropdownItem>
+                  </DropdownMenu>
+                </UncontrolledDropdown>
+                {user ? (
+                  <>
+                    <NotificationsNav />
+                    {user.cubes && user.cubes.length > 0 && (
+                      <UncontrolledDropdown nav inNavbar>
+                        <DropdownToggle nav caret>
+                          Your Cubes
+                        </DropdownToggle>
+                        <DropdownMenu right>
+                          {user.cubes.map((item) => (
+                            <DropdownItem key={`dropdown_cube_${item.name}`} href={`/cube/overview/${item._id}`}>
+                              {item.name}
+                            </DropdownItem>
+                          ))}
+                        </DropdownMenu>
+                      </UncontrolledDropdown>
+                    )}
                     <UncontrolledDropdown nav inNavbar>
                       <DropdownToggle nav caret>
-                        Your Cubes
+                        {user.username}
                       </DropdownToggle>
                       <DropdownMenu right>
-                        {user.cubes.map((item) => (
-                          <DropdownItem key={`dropdown_cube_${item.name}`} href={`/cube/overview/${item._id}`}>
-                            {item.name}
-                          </DropdownItem>
-                        ))}
+                        <DropdownItem href={`/user/view/${user.id}`}>Your Profile</DropdownItem>
+                        {user.roles && user.roles.includes('Admin') && (
+                          <DropdownItem href="/admin/dashboard">Admin Page</DropdownItem>
+                        )}
+                        {user.roles && user.roles.includes('ContentCreator') && (
+                          <DropdownItem href="/content/creators">Content Creator Dashboard</DropdownItem>
+                        )}
+                        <CreateCubeModalLink>Create A New Cube</CreateCubeModalLink>
+                        <DropdownItem href="/user/social">Social</DropdownItem>
+                        <DropdownItem href="/user/account">Account Information</DropdownItem>
+                        <DropdownItem href="/user/logout">Logout</DropdownItem>
                       </DropdownMenu>
                     </UncontrolledDropdown>
-                  )}
-                  <UncontrolledDropdown nav inNavbar>
-                    <DropdownToggle nav caret>
-                      {user.username}
-                    </DropdownToggle>
-                    <DropdownMenu right>
-                      <DropdownItem href={`/user/view/${user.id}`}>Your Profile</DropdownItem>
-                      {user.roles && user.roles.includes('Admin') && (
-                        <DropdownItem href="/admin/dashboard">Admin Page</DropdownItem>
-                      )}
-                      {user.roles && user.roles.includes('ContentCreator') && (
-                        <DropdownItem href="/content/creators">Content Creator Dashboard</DropdownItem>
-                      )}
-                      <CreateCubeModalLink>Create A New Cube</CreateCubeModalLink>
-                      <DropdownItem href="/user/social">Social</DropdownItem>
-                      <DropdownItem href="/user/account">Account Information</DropdownItem>
-                      <DropdownItem href="/user/logout">Logout</DropdownItem>
-                    </DropdownMenu>
-                  </UncontrolledDropdown>
-                </>
-              ) : (
-                <>
-                  <NavItem>
-                    <NavLink href="/user/register">Register</NavLink>
-                  </NavItem>
-                  <NavItem>
-                    <LoginModalLink modalProps={{ loginCallback }}>Login</LoginModalLink>
-                  </NavItem>
-                </>
-              )}
-            </Nav>
-          </Collapse>
+                  </>
+                ) : (
+                  <>
+                    <NavItem>
+                      <NavLink href="/user/register">Register</NavLink>
+                    </NavItem>
+                    <NavItem>
+                      <LoginModalLink modalProps={{ loginCallback }}>Login</LoginModalLink>
+                    </NavItem>
+                  </>
+                )}
+              </Nav>
+            </Collapse>
+          </Container>
+        </Navbar>
+        <Container className="flex-grow">
+          <ThemeContext.Provider value={user?.theme ?? 'default'}>
+            <ErrorBoundary>{children}</ErrorBoundary>
+          </ThemeContext.Provider>
         </Container>
-      </Navbar>
-      <Container className="flex-grow">
-        <ThemeContext.Provider value={user?.theme ?? 'default'}>
-          <ErrorBoundary>{children}</ErrorBoundary>
-        </ThemeContext.Provider>
-      </Container>
-      <Footer />
-    </div>
+        <Footer />
+      </div>
+    </UserContext.Provider>
   );
 };
 

--- a/src/layouts/UserLayout.js
+++ b/src/layouts/UserLayout.js
@@ -1,17 +1,22 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 
-import { Button, Nav, Navbar, NavItem, NavLink, Row } from 'reactstrap';
+import UserContext from 'contexts/UserContext';
 
 import ErrorBoundary from 'components/ErrorBoundary';
 import FollowersModal from 'components/FollowersModal';
 import withModal from 'components/WithModal';
 import CreateCubeModal from 'components/CreateCubeModal';
 
+import { Button, Nav, Navbar, NavItem, NavLink, Row } from 'reactstrap';
+
 const FollowersModalLink = withModal('a', FollowersModal);
 const CreateCubeModalLink = withModal(NavLink, CreateCubeModal);
 
-const UserLayout = ({ user, followers, following, canEdit, activeLink, children }) => {
+const UserLayout = ({ user, followers, following, activeLink, children }) => {
+  const activeUser = useContext(UserContext);
+  const canEdit = activeUser.id === user._id;
+
   const numFollowers = followers.length;
   const followersText = (
     <h6>
@@ -81,13 +86,11 @@ UserLayout.propTypes = {
   }).isRequired,
   followers: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   following: PropTypes.bool.isRequired,
-  canEdit: PropTypes.bool,
   activeLink: PropTypes.string.isRequired,
   children: PropTypes.node,
 };
 
 UserLayout.defaultProps = {
-  canEdit: false,
   children: false,
 };
 

--- a/src/pages/AdminCommentsPage.js
+++ b/src/pages/AdminCommentsPage.js
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import UserPropType from 'proptypes/UserPropType';
 import CommentPropType from 'proptypes/CommentPropType';
 
 import { Card, CardHeader } from 'reactstrap';
 
+import UserContext from 'contexts/UserContext';
 import DynamicFlash from 'components/DynamicFlash';
 import Paginate from 'components/Paginate';
 import MainLayout from 'layouts/MainLayout';
@@ -13,36 +13,39 @@ import Comment from 'components/Comment';
 
 const PAGE_SIZE = 24;
 
-const AdminCommentsPage = ({ user, loginCallback, comments, count, page }) => (
-  <MainLayout loginCallback={loginCallback} user={user}>
-    <DynamicFlash />
-    <Card className="my-3">
-      <CardHeader>
-        <h5>Comment Reports</h5>
-        {count > PAGE_SIZE ? (
-          <>
-            <h6>
-              {`Displaying ${PAGE_SIZE * page + 1}-${Math.min(count, PAGE_SIZE * (page + 1))} of ${count} Comments`}
-            </h6>
-            <Paginate
-              count={Math.ceil(count / PAGE_SIZE)}
-              active={parseInt(page, 10)}
-              urlF={(i) => `/admin/comments/${i}`}
-            />
-          </>
-        ) : (
-          <h6>{`Displaying all ${count} Comments`}</h6>
-        )}
-      </CardHeader>
-      {comments.map((comment) => (
-        <Comment comment={comment} userid={user && user.id} index={0} noReplies editComment={() => {}} />
-      ))}
-    </Card>
-  </MainLayout>
-);
+const AdminCommentsPage = ({ loginCallback, comments, count, page }) => {
+  const user = useContext(UserContext);
+
+  return (
+    <MainLayout loginCallback={loginCallback} user={user}>
+      <DynamicFlash />
+      <Card className="my-3">
+        <CardHeader>
+          <h5>Comment Reports</h5>
+          {count > PAGE_SIZE ? (
+            <>
+              <h6>
+                {`Displaying ${PAGE_SIZE * page + 1}-${Math.min(count, PAGE_SIZE * (page + 1))} of ${count} Comments`}
+              </h6>
+              <Paginate
+                count={Math.ceil(count / PAGE_SIZE)}
+                active={parseInt(page, 10)}
+                urlF={(i) => `/admin/comments/${i}`}
+              />
+            </>
+          ) : (
+            <h6>{`Displaying all ${count} Comments`}</h6>
+          )}
+        </CardHeader>
+        {comments.map((comment) => (
+          <Comment comment={comment} userid={user && user.id} index={0} noReplies editComment={() => {}} />
+        ))}
+      </Card>
+    </MainLayout>
+  );
+};
 
 AdminCommentsPage.propTypes = {
-  user: UserPropType,
   loginCallback: PropTypes.string,
   comments: PropTypes.arrayOf(CommentPropType).isRequired,
   count: PropTypes.number.isRequired,
@@ -50,7 +53,6 @@ AdminCommentsPage.propTypes = {
 };
 
 AdminCommentsPage.defaultProps = {
-  user: null,
   loginCallback: '/',
 };
 

--- a/src/pages/AdminCommentsPage.js
+++ b/src/pages/AdminCommentsPage.js
@@ -38,7 +38,7 @@ const AdminCommentsPage = ({ loginCallback, comments, count, page }) => {
           )}
         </CardHeader>
         {comments.map((comment) => (
-          <Comment comment={comment} userid={user && user.id} index={0} noReplies editComment={() => {}} />
+          <Comment comment={comment} index={0} noReplies editComment={() => {}} />
         ))}
       </Card>
     </MainLayout>

--- a/src/pages/ArticlePage.js
+++ b/src/pages/ArticlePage.js
@@ -28,7 +28,7 @@ const ArticlePage = ({ user, loginCallback, article }) => {
             </h5>
           </CardHeader>
         )}
-        <Article article={article} userid={user && user.id} />
+        <Article article={article} />
       </Card>
     </MainLayout>
   );

--- a/src/pages/BlogPostPage.js
+++ b/src/pages/BlogPostPage.js
@@ -12,14 +12,7 @@ const BlogPostPage = ({ post, user, loginCallback }) => (
   <MainLayout loginCallback={loginCallback} user={user}>
     <Advertisement user={user} />
     <DynamicFlash />
-    <BlogPost
-      key={post._id}
-      post={post}
-      canEdit={false}
-      noScroll
-      userid={user ? user.id : null}
-      loggedIn={user !== null}
-    />
+    <BlogPost key={post._id} post={post} canEdit={false} noScroll loggedIn={user !== null} />
   </MainLayout>
 );
 

--- a/src/pages/CardPage.js
+++ b/src/pages/CardPage.js
@@ -270,13 +270,7 @@ const CardPage = ({ user, card, data, versions, related, loginCallback }) => {
                 Played in {cardPopularity({ details: card })}%
                 <span className="percent">{cardCubeCount({ details: card })}</span> Cubes total.
               </p>
-              <AddModal
-                color="success"
-                block
-                outline
-                className="mb-1 mr-2"
-                modalProps={{ card, cubes: user ? user.cubes : [], hideAnalytics: true }}
-              >
+              <AddModal color="success" block outline className="mb-1 mr-2" modalProps={{ card, hideAnalytics: true }}>
                 Add to Cube...
               </AddModal>
               <CardIdBadge id={card._id} />
@@ -552,12 +546,7 @@ const CardPage = ({ user, card, data, versions, related, loginCallback }) => {
               </TabPane>
               <TabPane tabId="5">
                 <div className="border-left border-bottom">
-                  <CommentsSection
-                    parentType="card"
-                    parent={card.oracle_id}
-                    userid={user && user.id}
-                    collapse={false}
-                  />
+                  <CommentsSection parentType="card" parent={card.oracle_id} collapse={false} />
                 </div>
               </TabPane>
             </TabContent>

--- a/src/pages/CardPage.js
+++ b/src/pages/CardPage.js
@@ -791,13 +791,11 @@ CardPage.propTypes = {
       prices: CardPricePropType.isRequired,
     }).isRequired,
   ).isRequired,
-  cubes: PropTypes.arrayOf(PropTypes.shape([])),
   user: UserPropType,
   loginCallback: PropTypes.string,
 };
 
 CardPage.defaultProps = {
-  cubes: [],
   user: null,
   loginCallback: '/',
 };

--- a/src/pages/CommentPage.js
+++ b/src/pages/CommentPage.js
@@ -49,9 +49,9 @@ const CommentPage = ({ comment, user, loginCallback }) => {
             {`Responding to this ${translateType[content.parentType]}`}
           </a>
         </CardHeader>
-        <Comment comment={content} userid={user && user.id} index={0} noReplies editComment={setContent} />
+        <Comment comment={content} index={0} noReplies editComment={setContent} />
         <div className="border-top">
-          <CommentsSection parentType="comment" parent={content._id} userid={user && user.id} />
+          <CommentsSection parentType="comment" parent={content._id} />
         </div>
       </Card>
     </MainLayout>

--- a/src/pages/CubeAnalysisPage.js
+++ b/src/pages/CubeAnalysisPage.js
@@ -231,7 +231,6 @@ const CubeAnalysisPage = ({
           cuts={cutCards}
           filter={filter}
           loadState={loadState}
-          cubes={user ? user.cubes : []}
         />
       ),
     },

--- a/src/pages/CubeBlogPage.js
+++ b/src/pages/CubeBlogPage.js
@@ -101,7 +101,7 @@ const CubeBlogPage = ({ user, cube, pages, activePage, posts, loginCallback }) =
 
   return (
     <MainLayout loginCallback={loginCallback} user={user}>
-      <CubeLayout cube={cube} canEdit={user && cube.owner === user.id} activeLink="blog">
+      <CubeLayout cube={cube} activeLink="blog">
         <Navbar expand light className="usercontrols mb-3">
           <Collapse navbar>
             <Nav navbar>
@@ -116,16 +116,7 @@ const CubeBlogPage = ({ user, cube, pages, activePage, posts, loginCallback }) =
         <DynamicFlash />
         {pages > 1 && <Paginate count={pages} active={activePage} urlF={(i) => `/cube/blog/${cube._id}/${i}`} />}
         {posts.length > 0 ? (
-          posts.map((post) => (
-            <BlogPost
-              key={post._id}
-              post={post}
-              canEdit={user && post.owner === user.id}
-              userid={user ? user.id : null}
-              loggedIn={user !== null}
-              onEdit={handleEdit}
-            />
-          ))
+          posts.map((post) => <BlogPost key={post._id} post={post} loggedIn={user !== null} onEdit={handleEdit} />)
         ) : (
           <h5>No blog posts for this cube.</h5>
         )}

--- a/src/pages/CubeDeckPage.js
+++ b/src/pages/CubeDeckPage.js
@@ -188,7 +188,6 @@ const CubeDeckPage = ({ user, cube, deck, draft, loginCallback }) => {
               <DeckCard
                 seat={deck.seats[seatIndex]}
                 deckid={deck._id}
-                userid={user ? user.id : null}
                 deck={deck}
                 seatIndex={`${seatIndex}`}
                 draft={draft}

--- a/src/pages/CubeListPage.js
+++ b/src/pages/CubeListPage.js
@@ -157,7 +157,7 @@ const CubeListPage = ({
   loginCallback,
 }) => (
   <MainLayout loginCallback={loginCallback} user={user}>
-    <CubeLayout cube={cube} canEdit={user && cube.owner === user.id} activeLink="list">
+    <CubeLayout cube={cube} activeLink="list">
       <CubeListPageRaw
         defaultShowTagColors={defaultShowTagColors}
         defaultFilterText={defaultFilterText}

--- a/src/pages/CubeOverviewPage.js
+++ b/src/pages/CubeOverviewPage.js
@@ -89,7 +89,7 @@ const CubeOverview = ({ post, priceOwned, pricePurchase, cube, followed, followe
   };
   return (
     <MainLayout loginCallback={loginCallback} user={user}>
-      <CubeLayout cube={cubeState} canEdit={user && cubeState.owner === user.id} activeLink="overview">
+      <CubeLayout cube={cubeState} activeLink="overview">
         {user && cubeState.owner === user.id ? (
           <Navbar expand="md" light className="usercontrols mb-3">
             <NavbarToggler
@@ -273,17 +273,7 @@ const CubeOverview = ({ post, priceOwned, pricePurchase, cube, followed, followe
             </Card>
           </Col>
         </Row>
-        <div className="mb-3">
-          {post && (
-            <BlogPost
-              key={post._id}
-              post={post}
-              canEdit={false}
-              userid={user ? user.id : null}
-              loggedIn={user !== null}
-            />
-          )}
-        </div>
+        <div className="mb-3">{post && <BlogPost key={post._id} post={post} loggedIn={user !== null} />}</div>
       </CubeLayout>
     </MainLayout>
   );

--- a/src/pages/CubePlaytestPage.js
+++ b/src/pages/CubePlaytestPage.js
@@ -375,7 +375,7 @@ const GridCard = () => {
   );
 };
 
-const DecksCard = ({ decks, userID, ...props }) => {
+const DecksCard = ({ decks, ...props }) => {
   const { cubeID } = useContext(CubeContext);
   return (
     <Card {...props}>
@@ -384,7 +384,7 @@ const DecksCard = ({ decks, userID, ...props }) => {
       </CardHeader>
       <CardBody className="p-0">
         {decks.map((deck) => (
-          <DeckPreview key={deck._id} deck={deck} canEdit={userID === deck.seats[0].userid} />
+          <DeckPreview key={deck._id} deck={deck} />
         ))}
       </CardBody>
       <CardFooter>
@@ -396,7 +396,6 @@ const DecksCard = ({ decks, userID, ...props }) => {
 
 DecksCard.propTypes = {
   decks: PropTypes.arrayOf(DeckPropType).isRequired,
-  userID: PropTypes.string.isRequired,
 };
 
 const SamplePackCard = (props) => {
@@ -527,7 +526,7 @@ const CubePlaytestPage = ({ user, cube, decks, loginCallback }) => {
   );
   return (
     <MainLayout loginCallback={loginCallback} user={user}>
-      <CubeLayout cube={cube} canEdit={user && cube.owner === user.id} activeLink="playtest">
+      <CubeLayout cube={cube} activeLink="playtest">
         {user && cube.owner === user.id ? (
           <Navbar light expand className="usercontrols mb-3">
             <Nav navbar>
@@ -565,7 +564,7 @@ const CubePlaytestPage = ({ user, cube, decks, loginCallback }) => {
             <GridCard className="mb-3" />
           </Col>
           <Col xs="12" md="6" xl="6">
-            {decks.length !== 0 && <DecksCard decks={decks} userID={user && user.id} className="mb-3" />}
+            {decks.length !== 0 && <DecksCard decks={decks} className="mb-3" />}
             <SamplePackCard className="mb-3" />
           </Col>
         </Row>

--- a/src/pages/CubeSamplePackPage.js
+++ b/src/pages/CubeSamplePackPage.js
@@ -16,7 +16,7 @@ import RenderToRoot from 'utils/RenderToRoot';
 const SamplePackPage = ({ user, seed, pack, cube, loginCallback }) => {
   return (
     <MainLayout loginCallback={loginCallback} user={user}>
-      <CubeLayout cube={cube} canEdit={user && cube.owner === user.id} activeLink="playtest">
+      <CubeLayout cube={cube} activeLink="playtest">
         <DynamicFlash />
         <div className="container" />
         <br />

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -111,9 +111,7 @@ const DashboardPage = ({ posts, cubes, decks, user, loginCallback, content, feat
         <Col xs="12" md="8">
           <h5 className="mt-3">Feed</h5>
           {posts.length > 0 ? (
-            posts.map((post) => (
-              <BlogPost key={post._id} post={post} canEdit={false} userid={user ? user.id : null} loggedIn />
-            ))
+            posts.map((post) => <BlogPost key={post._id} post={post} />)
           ) : (
             <p>
               No posts to show. <a href="/explore">Find some cubes</a> to follow!

--- a/src/pages/DevBlog.js
+++ b/src/pages/DevBlog.js
@@ -1,9 +1,8 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Card, CardBody, FormGroup, Label, Input, Button } from 'reactstrap';
 
-import UserContext from 'contexts/UserContext';
 import Paginate from 'components/Paginate';
 import BlogPost from 'components/BlogPost';
 import CSRFForm from 'components/CSRFForm';
@@ -11,10 +10,9 @@ import MainLayout from 'layouts/MainLayout';
 import RenderToRoot from 'utils/RenderToRoot';
 import Advertisement from 'components/Advertisement';
 import DynamicFlash from 'components/DynamicFlash';
+import UserPropType from 'proptypes/UserPropType';
 
-const DevBlog = ({ blogs, pages, userid, activePage, loginCallback }) => {
-  const user = useContext(UserContext);
-
+const DevBlog = ({ blogs, pages, activePage, loginCallback, user }) => {
   return (
     <MainLayout loginCallback={loginCallback} user={user}>
       <Advertisement user={user} />
@@ -45,9 +43,7 @@ const DevBlog = ({ blogs, pages, userid, activePage, loginCallback }) => {
           <Paginate count={parseInt(pages, 10)} active={parseInt(activePage, 10)} urlF={(i) => `/dev/blog/${i}`} />
         )}
         {blogs.length > 0 ? (
-          blogs.map((post) => (
-            <BlogPost key={post._id} post={post} canEdit={false} userid={userid} loggedIn={userid !== null} />
-          ))
+          blogs.map((post) => <BlogPost key={post._id} post={post} />)
         ) : (
           <h5>No developer blogs have been posted.</h5>
         )}
@@ -63,12 +59,13 @@ DevBlog.propTypes = {
   blogs: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   pages: PropTypes.number.isRequired,
   activePage: PropTypes.number.isRequired,
-  userid: PropTypes.string.isRequired,
   loginCallback: PropTypes.string,
+  user: UserPropType,
 };
 
 DevBlog.defaultProps = {
   loginCallback: '/',
+  user: null,
 };
 
 export default RenderToRoot(DevBlog);

--- a/src/pages/DevBlog.js
+++ b/src/pages/DevBlog.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import UserPropType from 'proptypes/UserPropType';
 
 import { Card, CardBody, FormGroup, Label, Input, Button } from 'reactstrap';
 
+import UserContext from 'contexts/UserContext';
 import Paginate from 'components/Paginate';
 import BlogPost from 'components/BlogPost';
 import CSRFForm from 'components/CSRFForm';
@@ -12,60 +12,62 @@ import RenderToRoot from 'utils/RenderToRoot';
 import Advertisement from 'components/Advertisement';
 import DynamicFlash from 'components/DynamicFlash';
 
-const DevBlog = ({ blogs, pages, userid, activePage, user, loginCallback }) => (
-  <MainLayout loginCallback={loginCallback} user={user}>
-    <Advertisement />
-    <DynamicFlash />
-    <div className="mt-3">
-      <h3 className="centered">Developer Blog</h3>
-      {user && user.roles.includes('Admin') && (
-        <Card>
-          <CardBody>
-            <h5>Create New Blog Post</h5>
-            <CSRFForm method="POST" action="/dev/blogpost/">
-              <FormGroup>
-                <Label>Title:</Label>
-                <Input maxLength="200" name="title" type="text" />
-              </FormGroup>
-              <FormGroup>
-                <Label>HTML:</Label>
-                <Input name="html" type="textarea" />
-              </FormGroup>
-              <Button type="submit" color="success" block outline>
-                Submit
-              </Button>
-            </CSRFForm>
-          </CardBody>
-        </Card>
-      )}
-      {pages > 1 && (
-        <Paginate count={parseInt(pages, 10)} active={parseInt(activePage, 10)} urlF={(i) => `/dev/blog/${i}`} />
-      )}
-      {blogs.length > 0 ? (
-        blogs.map((post) => (
-          <BlogPost key={post._id} post={post} canEdit={false} userid={userid} loggedIn={userid !== null} />
-        ))
-      ) : (
-        <h5>No developer blogs have been posted.</h5>
-      )}
-      {pages > 1 && (
-        <Paginate count={parseInt(pages, 10)} active={parseInt(activePage, 10)} urlF={(i) => `/dev/blog/${i}`} />
-      )}
-    </div>
-  </MainLayout>
-);
+const DevBlog = ({ blogs, pages, userid, activePage, loginCallback }) => {
+  const user = useContext(UserContext);
+
+  return (
+    <MainLayout loginCallback={loginCallback} user={user}>
+      <Advertisement />
+      <DynamicFlash />
+      <div className="mt-3">
+        <h3 className="centered">Developer Blog</h3>
+        {user && user.roles.includes('Admin') && (
+          <Card>
+            <CardBody>
+              <h5>Create New Blog Post</h5>
+              <CSRFForm method="POST" action="/dev/blogpost/">
+                <FormGroup>
+                  <Label>Title:</Label>
+                  <Input maxLength="200" name="title" type="text" />
+                </FormGroup>
+                <FormGroup>
+                  <Label>HTML:</Label>
+                  <Input name="html" type="textarea" />
+                </FormGroup>
+                <Button type="submit" color="success" block outline>
+                  Submit
+                </Button>
+              </CSRFForm>
+            </CardBody>
+          </Card>
+        )}
+        {pages > 1 && (
+          <Paginate count={parseInt(pages, 10)} active={parseInt(activePage, 10)} urlF={(i) => `/dev/blog/${i}`} />
+        )}
+        {blogs.length > 0 ? (
+          blogs.map((post) => (
+            <BlogPost key={post._id} post={post} canEdit={false} userid={userid} loggedIn={userid !== null} />
+          ))
+        ) : (
+          <h5>No developer blogs have been posted.</h5>
+        )}
+        {pages > 1 && (
+          <Paginate count={parseInt(pages, 10)} active={parseInt(activePage, 10)} urlF={(i) => `/dev/blog/${i}`} />
+        )}
+      </div>
+    </MainLayout>
+  );
+};
 
 DevBlog.propTypes = {
   blogs: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   pages: PropTypes.number.isRequired,
   activePage: PropTypes.number.isRequired,
   userid: PropTypes.string.isRequired,
-  user: UserPropType,
   loginCallback: PropTypes.string,
 };
 
 DevBlog.defaultProps = {
-  user: null,
   loginCallback: '/',
 };
 

--- a/src/pages/PodcastEpisodePage.js
+++ b/src/pages/PodcastEpisodePage.js
@@ -40,7 +40,7 @@ const PodcastEpisodePage = ({ user, loginCallback, episode }) => {
           </Col>
         </Row>
         <div className="border-top">
-          <CommentsSection parentType="episode" parent={episode._id} userid={user && user.id} collapse={false} />
+          <CommentsSection parentType="episode" parent={episode._id} collapse={false} />
         </div>
       </Card>
     </MainLayout>

--- a/src/pages/PodcastPage.js
+++ b/src/pages/PodcastPage.js
@@ -33,7 +33,7 @@ const PodcastPage = ({ user, loginCallback, podcast, episodes }) => {
             </h5>
           </CardHeader>
         )}
-        <Podcast podcast={podcast} userid={user && user.id} episodes={episodes} />
+        <Podcast podcast={podcast} episodes={episodes} />
       </Card>
     </MainLayout>
   );

--- a/src/pages/UserBlogPage.js
+++ b/src/pages/UserBlogPage.js
@@ -12,13 +12,7 @@ import RenderToRoot from 'utils/RenderToRoot';
 
 const UserBlogPage = ({ user, followers, following, posts, owner, loginCallback, pages, activePage }) => (
   <MainLayout loginCallback={loginCallback} user={user}>
-    <UserLayout
-      user={owner}
-      followers={followers}
-      following={following}
-      canEdit={user && user.id === owner._id}
-      activeLink="blog"
-    >
+    <UserLayout user={owner} followers={followers} following={following} activeLink="blog">
       <Advertisement user={user} />
       <DynamicFlash />
 
@@ -26,17 +20,7 @@ const UserBlogPage = ({ user, followers, following, posts, owner, loginCallback,
         <Paginate count={pages} active={parseInt(activePage, 10)} urlF={(i) => `/user/blog/${owner._id}/${i}`} />
       )}
       {posts.length > 0 ? (
-        posts
-          .slice(0)
-          .map((post) => (
-            <BlogPost
-              key={post._id}
-              post={post}
-              canEdit={user && user.id === owner._id}
-              userid={user && user.id}
-              loggedIn
-            />
-          ))
+        posts.slice(0).map((post) => <BlogPost key={post._id} post={post} loggedIn />)
       ) : (
         <p>This user has no blog posts!</p>
       )}

--- a/src/pages/UserCubePage.js
+++ b/src/pages/UserCubePage.js
@@ -15,13 +15,7 @@ import Markdown from 'components/Markdown';
 
 const UserCubePage = ({ user, owner, followers, following, cubes, loginCallback }) => (
   <MainLayout loginCallback={loginCallback} user={user}>
-    <UserLayout
-      user={owner}
-      followers={followers}
-      following={following}
-      canEdit={user && user.id === owner._id}
-      activeLink="view"
-    >
+    <UserLayout user={owner} followers={followers} following={following} activeLink="view">
       <Advertisement user={user} />
       <DynamicFlash />
       <Card>

--- a/src/pages/UserDecksPage.js
+++ b/src/pages/UserDecksPage.js
@@ -15,13 +15,7 @@ import RenderToRoot from 'utils/RenderToRoot';
 
 const UserDecksPage = ({ user, owner, followers, following, decks, pages, activePage, loginCallback }) => (
   <MainLayout loginCallback={loginCallback} user={user}>
-    <UserLayout
-      user={owner}
-      followers={followers}
-      following={following}
-      canEdit={user && user.id === owner._id}
-      activeLink="decks"
-    >
+    <UserLayout user={owner} followers={followers} following={following} activeLink="decks">
       <Advertisement user={user} />
       <DynamicFlash />
       {pages > 1 && <Paginate count={pages} active={activePage} urlF={(i) => `/user/decks/${owner._id}/${i}`} />}
@@ -32,12 +26,7 @@ const UserDecksPage = ({ user, owner, followers, following, decks, pages, active
         {decks.length > 0 ? (
           <CardBody className="p-0">
             {decks.map((deck) => (
-              <DeckPreview
-                key={deck._id}
-                deck={deck}
-                canEdit={user && user.id === owner._id}
-                nextURL={`/user/decks/${owner._id}/${activePage}`}
-              />
+              <DeckPreview key={deck._id} deck={deck} nextURL={`/user/decks/${owner._id}/${activePage}`} />
             ))}
           </CardBody>
         ) : (

--- a/src/pages/VideoPage.js
+++ b/src/pages/VideoPage.js
@@ -26,7 +26,7 @@ const VideoPage = ({ user, loginCallback, video }) => {
             </h5>
           </CardHeader>
         )}
-        <Video video={video} userid={user && user.id} />
+        <Video video={video} />
       </Card>
     </MainLayout>
   );

--- a/src/proptypes/BlogPostPropType.js
+++ b/src/proptypes/BlogPostPropType.js
@@ -1,0 +1,5 @@
+import PropTypes from 'prop-types';
+
+const BlogPostPropType = PropTypes.shape({});
+
+export default BlogPostPropType;

--- a/src/proptypes/DeckPropType.js
+++ b/src/proptypes/DeckPropType.js
@@ -4,6 +4,8 @@ import DraftSeatPropType from 'proptypes/DraftSeatPropType';
 const DeckPropType = PropTypes.shape({
   _id: PropTypes.string,
   cube: PropTypes.string,
+  owner: PropTypes.string,
+  cubeOwner: PropTypes.string,
   seats: PropTypes.arrayOf(DraftSeatPropType),
   date: PropTypes.instanceOf(Date),
   comments: PropTypes.arrayOf(PropTypes.object),


### PR DESCRIPTION
Fixes #1573

Before having a `userContext`, we passed around `user` objects and `userid` into components, and it was quite messy and not necessary. Many components (such as all the have comments) required this field in order to function, and essentially just had a prop parameter solely just to pass through to it's respective comments section.

This PR userContext, which gets populated in `mainLayout`, and is across many components. Notably, this removes the `canEdit` pattern that we use in multiple places, and also cleans up a lot of ownership checks across the entire site.