### PR TITLE
Fix patreon integration bug

### DIFF
--- a/routes/patreon_routes.js
+++ b/routes/patreon_routes.js
@@ -201,7 +201,7 @@ router.get('/redirect', ensureAuth, (req, res) => {
       if (!user.roles.includes('Patron')) {
         user.roles.push('Patron');
       }
-      user.patron = patron._id;
+      user.patron = newPatron._id;
       await user.save();
 
       req.flash('success', `Your Patreon account has succesfully been linked.`);


### PR DESCRIPTION
Had a reference to `patron` instead of `newPatron`, causing a null pointer exception