### PR TITLE
Fixed getDrafterState function and per cube draft analytics

### DIFF
--- a/routes/cube/api.js
+++ b/routes/cube/api.js
@@ -21,19 +21,17 @@ const {
   buildTagColors,
   cubeCardTags,
   maybeCards,
-  newCardAnalytics,
-  getEloAdjustment,
+  saveDraftAnalytics,
   addCardHtml,
 } = require('../../serverjs/cubefn.js');
 
-const { ELO_BASE, ELO_SPEED, CUBE_ELO_SPEED, rotateArrayLeft, createPool } = require('./helper');
+const { rotateArrayLeft, createPool } = require('./helper');
 
 // Bring in models
 const Cube = require('../../models/cube');
 const Draft = require('../../models/draft');
 const GridDraft = require('../../models/gridDraft');
 const CubeAnalytic = require('../../models/cubeAnalytic');
-const CardRating = require('../../models/cardrating');
 const Package = require('../../models/package');
 const Blog = require('../../models/blog');
 
@@ -992,103 +990,14 @@ router.post(
   }),
 );
 
-router.post(
-  '/draftpickcard/:id',
-  util.wrapAsyncApi(async (req, res) => {
-    const draftQ = Draft.findById({
-      _id: req.body.draft_id,
-    }).lean();
-    const ratingQ = CardRating.findOne({
-      name: req.body.pick,
-    }).then((rating) => rating || new CardRating());
-    const packQ = CardRating.find({
-      name: {
-        $in: req.body.pack,
-      },
-    });
-
-    const [draft, rating, packRatings] = await Promise.all([draftQ, ratingQ, packQ]);
-
-    if (draft) {
-      try {
-        let analytic = await CubeAnalytic.findOne({ cube: draft.cube });
-
-        if (!analytic) {
-          analytic = new CubeAnalytic();
-          analytic.cube = draft.cube;
-        }
-
-        let pickIndex = analytic.cards.findIndex((card) => card.cardName === req.body.pick.toLowerCase());
-        if (pickIndex === -1) {
-          pickIndex = analytic.cards.push(newCardAnalytics(req.body.pick, ELO_BASE)) - 1;
-        }
-
-        const packIndeces = {};
-        for (const packCard of req.body.pack) {
-          let index = analytic.cards.findIndex((card) => card.cardName === packCard.toLowerCase());
-          if (index === -1) {
-            index = analytic.cards.push(newCardAnalytics(packCard.toLowerCase(), ELO_BASE)) - 1;
-          }
-          packIndeces[packCard] = index;
-
-          const adjustments = getEloAdjustment(
-            analytic.cards[pickIndex].elo,
-            analytic.cards[index].elo,
-            CUBE_ELO_SPEED,
-          );
-          analytic.cards[pickIndex].elo += adjustments[0];
-          analytic.cards[index].elo += adjustments[1];
-
-          analytic.cards[index].passes += 1;
-        }
-
-        analytic.cards[pickIndex].picks += 1;
-
-        await analytic.save();
-      } catch (err) {
-        req.logger.error(err);
-      }
-
-      if (!rating.elo) {
-        rating.name = req.body.pick;
-        rating.elo = ELO_BASE;
-      }
-
-      if (!rating.picks) {
-        rating.picks = 0;
-      }
-      rating.picks += 1;
-
-      if (!Number.isFinite(rating.elo)) {
-        rating.elo = ELO_BASE;
-      }
-      // Update Elo.
-      for (const other of packRatings) {
-        if (!Number.isFinite(other.elo)) {
-          if (!Number.isFinite(other.value)) {
-            other.elo = ELO_BASE;
-          }
-        }
-
-        const adjustments = getEloAdjustment(rating.elo, other.elo, ELO_SPEED);
-
-        rating.elo += adjustments[0];
-        other.elo += adjustments[1];
-      }
-      await Promise.all([rating.save(), packRatings.map((r) => r.save())]);
-    }
-    res.status(200).send({
-      success: 'true',
-    });
-  }),
-);
-
 router.post('/submitdraft/:id', async (req, res) => {
   const draft = await Draft.findOne({
     _id: req.body._id,
   });
   draft.seats = req.body.seats;
   await draft.save();
+
+  await saveDraftAnalytics(draft);
 
   return res.status(200).send({
     success: 'true',

--- a/routes/cube/api.js
+++ b/routes/cube/api.js
@@ -997,7 +997,7 @@ router.post('/submitdraft/:id', async (req, res) => {
   draft.seats = req.body.seats;
   await draft.save();
 
-  await saveDraftAnalytics(draft);
+  await saveDraftAnalytics(draft, 0, carddb);
 
   return res.status(200).send({
     success: 'true',

--- a/serverjs/cubefn.js
+++ b/serverjs/cubefn.js
@@ -416,6 +416,92 @@ const addDeckCardAnalytics = async (cube, deck, carddb) => {
   }
 };
 
+const saveDraftAnalytics = async (draft) => {
+  console.log(draft);
+
+  /*
+  const ratingQ = CardRating.findOne({
+    name: req.body.pick,
+  }).then((rating) => rating || new CardRating());
+
+  const packQ = CardRating.find({
+    name: {
+      $in: req.body.pack,
+    },
+  });
+
+  const [rating, packRatings] = await Promise.all([draftQ, ratingQ, packQ]);
+
+  if (draft) {
+    try {
+      let analytic = await CubeAnalytic.findOne({ cube: draft.cube });
+
+      if (!analytic) {
+        analytic = new CubeAnalytic();
+        analytic.cube = draft.cube;
+      }
+
+      console.log(analytic);
+      console.log(draft);
+
+      let pickIndex = analytic.cards.findIndex((card) => card.cardName === req.body.pick.toLowerCase());
+      if (pickIndex === -1) {
+        pickIndex = analytic.cards.push(newCardAnalytics(req.body.pick, ELO_BASE)) - 1;
+      }
+
+      const packIndeces = {};
+      for (const packCard of req.body.pack) {
+        let index = analytic.cards.findIndex((card) => card.cardName === packCard.toLowerCase());
+        if (index === -1) {
+          index = analytic.cards.push(newCardAnalytics(packCard.toLowerCase(), ELO_BASE)) - 1;
+        }
+        packIndeces[packCard] = index;
+
+        const adjustments = getEloAdjustment(analytic.cards[pickIndex].elo, analytic.cards[index].elo, CUBE_ELO_SPEED);
+        analytic.cards[pickIndex].elo += adjustments[0];
+        analytic.cards[index].elo += adjustments[1];
+
+        analytic.cards[index].passes += 1;
+      }
+
+      analytic.cards[pickIndex].picks += 1;
+
+      await analytic.save();
+    } catch (err) {
+      req.logger.error(err);
+    }
+
+    if (!rating.elo) {
+      rating.name = req.body.pick;
+      rating.elo = ELO_BASE;
+    }
+
+    if (!rating.picks) {
+      rating.picks = 0;
+    }
+    rating.picks += 1;
+
+    if (!Number.isFinite(rating.elo)) {
+      rating.elo = ELO_BASE;
+    }
+    // Update Elo.
+    for (const other of packRatings) {
+      if (!Number.isFinite(other.elo)) {
+        if (!Number.isFinite(other.value)) {
+          other.elo = ELO_BASE;
+        }
+      }
+
+      const adjustments = getEloAdjustment(rating.elo, other.elo, ELO_SPEED);
+
+      rating.elo += adjustments[0];
+      other.elo += adjustments[1];
+    }
+    await Promise.all([rating.save(), packRatings.map((r) => r.save())]);
+  }
+  */
+};
+
 /*
 Forked from https://github.com/lukechilds/merge-images
 to support border radius for cards and width/height for custom card images.
@@ -631,6 +717,7 @@ const methods = {
   removeDeckCardAnalytics,
   addDeckCardAnalytics,
   cachePromise,
+  saveDraftAnalytics,
 };
 
 module.exports = methods;

--- a/serverjs/cubefn.js
+++ b/serverjs/cubefn.js
@@ -11,7 +11,7 @@ const util = require('./util');
 const { getDraftFormat, createDraft } = require('../dist/drafting/createdraft');
 const { getDrafterState } = require('../dist/drafting/draftutil');
 
-const { ELO_BASE, ELO_SPEED, CUBE_ELO_SPEED, rotateArrayLeft, createPool } = require('../routes/cube/helper');
+const { ELO_BASE, ELO_SPEED, CUBE_ELO_SPEED } = require('../routes/cube/helper');
 
 function getCubeId(cube) {
   if (cube.shortID) return cube.shortID;
@@ -545,7 +545,6 @@ const saveDraftAnalytics = async (draft, seatNumber, carddb) => {
     await analytic.save();
     await Promise.all(cards.map((card) => card.save()));
   } catch (err) {
-    console.error(err);
     winston.error(err);
   }
 };

--- a/src/components/DecksPickBreakdown.js
+++ b/src/components/DecksPickBreakdown.js
@@ -32,20 +32,26 @@ export const usePickListAndDrafterState = ({ draft, seatIndex, defaultIndex }) =
     const drafterStates = [];
     let prevTrashedNum = 0;
     let prevPickedNum = 0;
-    let action = null;
     for (let pickNumber2 = 0; pickNumber2 <= numToTake; pickNumber2++) {
       const drafterState = getDrafterState({ draft, seatNumber: seatIndex, pickNumber: pickNumber2 });
-      const { packNum, pickedNum, trashedNum } = drafterState;
+      const { packNum, pickedNum, trashedNum, step } = drafterState;
       // This handles the case of empty packs which we'll hopefully never have to deal with.
       while (packNum >= takenCards.length) takenCards.push([]);
       // It should not be possible for both to increase across 1 pick number
       // If it did we'd have a problem since multiple cards would be marked as part of the same pick.
       if (trashedNum > prevTrashedNum) {
-        takenCards[packNum].push({ action, card: cards[trashorder[prevTrashedNum]], pickNumber: pickNumber2 - 1 });
+        takenCards[packNum].push({
+          action: step.action,
+          card: cards[trashorder[prevTrashedNum]],
+          pickNumber: pickNumber2 - 1,
+        });
       } else if (pickedNum > prevPickedNum) {
-        takenCards[packNum].push({ action, card: cards[pickorder[prevPickedNum]], pickNumber: pickNumber2 - 1 });
+        takenCards[packNum].push({
+          action: step.action,
+          card: cards[pickorder[prevPickedNum]],
+          pickNumber: pickNumber2 - 1,
+        });
       }
-      action = drafterState.step.action;
       prevTrashedNum = trashedNum;
       prevPickedNum = pickedNum;
       drafterStates.push(drafterState);
@@ -65,8 +71,12 @@ export const usePickListAndDrafterState = ({ draft, seatIndex, defaultIndex }) =
   return { picksList, drafterState, setPickNumberFromEvent };
 };
 
-const DecksPickBreakdownInternal = (props) => {
-  const { picksList, setPickNumberFromEvent, drafterState } = usePickListAndDrafterState(props);
+const DecksPickBreakdownInternal = ({ draft, seatIndex, defaultIndex }) => {
+  const { picksList, setPickNumberFromEvent, drafterState } = usePickListAndDrafterState({
+    draft,
+    seatIndex,
+    defaultIndex,
+  });
   const { cards, cardsInPack, pickNum, packNum } = drafterState;
   return (
     <Row>
@@ -110,11 +120,8 @@ const DecksPickBreakdownInternal = (props) => {
   );
 };
 DecksPickBreakdownInternal.propTypes = {
-  // eslint-disable-next-line
   draft: DraftPropType.isRequired,
-  // eslint-disable-next-line
   seatIndex: PropTypes.number.isRequired,
-  // eslint-disable-next-line
   defaultIndex: PropTypes.number,
 };
 DecksPickBreakdownInternal.defaultProps = {

--- a/src/drafting/draftutil.js
+++ b/src/drafting/draftutil.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-loop-func */
 import seedrandom from 'seedrandom';
 
 import { moveOrAddCard } from 'drafting/DraftLocation';
@@ -39,19 +40,17 @@ export const getDrafterState = ({ draft, seatNumber, pickNumber = -1, stepNumber
 
   // loop through each pack
   while (packNum < numPacks) {
-    const curPackNum = packNum;
-
     let done = false;
-    packsWithCards = draft.initial_state.map((packsForSeat) => packsForSeat[curPackNum].cards.slice());
+    packsWithCards = draft.initial_state.map((packsForSeat) => packsForSeat[packNum].cards.slice());
     pickNum = 0;
     packSize = packsWithCards[seatNum].length;
     offset = 0;
-    const steps = ourPacks[curPackNum].steps ?? defaultStepsForLength(ourPacks[curPackNum].cards.length);
+    const steps = ourPacks[packNum].steps ?? defaultStepsForLength(ourPacks[packNum].cards.length);
     seen.push(...packsWithCards[seatNum]); // We see the pack we opened.
 
     // loop through each step of this pack
     for ({ action, amount } of steps) {
-      const passLeft = (curPackNum % 2 === 0) === (amount || 1) >= 0;
+      const passLeft = (packNum % 2 === 0) === (amount || 1) >= 0;
 
       // repeat the action for the amount
       amount = Math.abs(amount ?? 1);
@@ -115,7 +114,7 @@ export const getDrafterState = ({ draft, seatNumber, pickNumber = -1, stepNumber
     } // step
     if (done || (useFinal && (curStepNumber > (stepEnd ?? curStepNumber + 1) || pickedNum + trashedNum >= pickEnd))) {
       if (!skipAutoPass && packsWithCards[seatNum].length === 0 && packNum + 1 < numPacks) {
-        packsWithCards = draft.initial_state.map((packsForSeat) => packsForSeat[curPackNum + 1].cards.slice());
+        packsWithCards = draft.initial_state.map((packsForSeat) => packsForSeat[packNum + 1].cards.slice());
         seen.push(...packsWithCards[seatNum]); // We see the pack we opened.
       }
       break;

--- a/src/drafting/draftutil.js
+++ b/src/drafting/draftutil.js
@@ -15,7 +15,7 @@ export const defaultStepsForLength = (length) =>
     .slice(0, length * 2 - 1) // Remove the final pass.
     .map((action) => ({ ...action }));
 
-export const getDrafterState = ({ draft, seatNumber, pickNumber = -1, stepNumber = null }) => {
+export const getDrafterState = ({ draft, seatNumber, pickNumber = -1, stepNumber = null }, skipAutoPass = false) => {
   const { cards, basics } = draft;
   const numSeats = draft.initial_state.length;
   const seatNum = parseInt(seatNumber, 10);
@@ -114,7 +114,7 @@ export const getDrafterState = ({ draft, seatNumber, pickNumber = -1, stepNumber
       }
     } // step
     if (done || (useFinal && (curStepNumber > (stepEnd ?? curStepNumber + 1) || pickedNum + trashedNum >= pickEnd))) {
-      if (packsWithCards[seatNum].length === 0 && packNum + 1 < numPacks) {
+      if (!skipAutoPass && packsWithCards[seatNum].length === 0 && packNum + 1 < numPacks) {
         packsWithCards = draft.initial_state.map((packsForSeat) => packsForSeat[curPackNum + 1].cards.slice());
         seen.push(...packsWithCards[seatNum]); // We see the pack we opened.
       }

--- a/src/pages/CubeDraftPage.js
+++ b/src/pages/CubeDraftPage.js
@@ -164,10 +164,10 @@ const CubeDraftPlayerUI = ({ drafterState, drafted, takeCard, moveCard }) => {
   );
   const instructions = useMemo(() => {
     if (action === 'pick') {
-      return `Pick ${amount} More Card${amount > 1 ? 's' : ''}.`;
+      return `Pick ${amount + 1} More Card${amount + 1 > 1 ? 's' : ''}.`;
     }
     if (action === 'trash') {
-      return `Trash ${amount} More Card${amount > 1 ? 's' : ''}.`;
+      return `Trash ${amount + 1} More Card${amount + 1 > 1 ? 's' : ''}.`;
     }
     return null;
   }, [action, amount]);

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -181,6 +181,7 @@ const serverConfig = merge(config, {
     'pages/PackagePage': './src/pages/PackagePage.js',
     'utils/Card': './src/utils/Card.js',
     'drafting/createdraft': './src/drafting/createdraft.js',
+    'drafting/draftutil': './src/drafting/draftutil.js',
     'drafting/deckutil': './src/drafting/deckutil.js',
     'filtering/FilterCards': './src/filtering/FilterCards.js',
     'utils/Sort': './src/utils/Sort.js',


### PR DESCRIPTION
`getDrafterState` was bugged in such a way that broke pick by pick breakdown. I also am using this function to update all the card analytics in one motion at the end of the draft rather than on each pick, saving DB I/O cycles.