### PR TITLE
Blogpost edit hotfix

### DIFF
--- a/src/components/BlogPost.js
+++ b/src/components/BlogPost.js
@@ -19,7 +19,7 @@ const BlogPost = ({ post, onEdit, noScroll }) => {
 
   const scrollStyle = noScroll ? {} : { overflow: 'auto', maxHeight: '50vh' };
 
-  const canEdit = user && user.id === post.user;
+  const canEdit = user && user.id === post.owner;
 
   return (
     <Card className="shadowed rounded-0 mb-3">

--- a/src/pages/BlogPostPage.js
+++ b/src/pages/BlogPostPage.js
@@ -7,6 +7,7 @@ import Advertisement from 'components/Advertisement';
 import DynamicFlash from 'components/DynamicFlash';
 import MainLayout from 'layouts/MainLayout';
 import RenderToRoot from 'utils/RenderToRoot';
+import BlogPostPropType from 'proptypes/BlogPostPropType';
 
 const BlogPostPage = ({ post, user, loginCallback }) => (
   <MainLayout loginCallback={loginCallback} user={user}>
@@ -17,9 +18,7 @@ const BlogPostPage = ({ post, user, loginCallback }) => (
 );
 
 BlogPostPage.propTypes = {
-  post: PropTypes.shape({
-    _id: PropTypes.string.isRequired,
-  }).isRequired,
+  post: BlogPostPropType.isRequired,
   user: UserPropType,
   loginCallback: PropTypes.string,
 };

--- a/src/proptypes/BlogPostPropType.js
+++ b/src/proptypes/BlogPostPropType.js
@@ -1,5 +1,18 @@
 import PropTypes from 'prop-types';
 
-const BlogPostPropType = PropTypes.shape({});
+const BlogPostPropType = PropTypes.shape({
+  _id: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  owner: PropTypes.string.isRequired,
+  date: PropTypes.instanceOf(Date).isRequired,
+  cube: PropTypes.string.isRequired,
+  html: PropTypes.string,
+  markdown: PropTypes.string,
+  dev: PropTypes.string.isRequired,
+  date_formatted: PropTypes.string.isRequired,
+  changelist: PropTypes.string,
+  username: PropTypes.string.isRequired,
+  cubename: PropTypes.string.isRequired,
+});
 
 export default BlogPostPropType;


### PR DESCRIPTION
#2064 introduced a regression where noone can edit any blog posts. That's because `canEdit` is always false due to comparing to an undefined property. This PR fixes that bug and also adds an actual PropType for blog posts.