### PR TITLE
Fixed circular dependency

### DIFF
--- a/jobs/archived/process_decks.js
+++ b/jobs/archived/process_decks.js
@@ -12,11 +12,8 @@ const Draft = require('../../models/draft');
 const Cube = require('../../models/cube');
 const CubeAnalytic = require('../../models/cubeAnalytic');
 const carddb = require('../../serverjs/cards.js');
-const { newCardAnalytics, getEloAdjustment } = require('../../serverjs/cubefn');
+const { newCardAnalytics, getEloAdjustment, ELO_BASE, CUBE_ELO_SPEED } = require('../../serverjs/cubefn');
 const { fromEntries } = require('../../serverjs/util');
-
-const ELO_BASE = 1200;
-const CUBE_ELO_SPEED = 10;
 
 const getPackAsSeen = (initialState, index, deck) => {
   const cardsInPack = [];

--- a/routes/cube/helper.js
+++ b/routes/cube/helper.js
@@ -19,10 +19,6 @@ const DEFAULT_BASICS = [
   '0c4eaecf-dd4c-45ab-9b50-2abe987d35d4',
 ];
 
-const ELO_BASE = 1200;
-const ELO_SPEED = 1 / 128;
-const CUBE_ELO_SPEED = 4;
-
 const CARD_HEIGHT = 680;
 const CARD_WIDTH = 488;
 const CSV_HEADER =
@@ -270,10 +266,7 @@ module.exports = {
   CARD_HEIGHT,
   CARD_WIDTH,
   CSV_HEADER,
-  CUBE_ELO_SPEED,
   DEFAULT_BASICS,
-  ELO_BASE,
-  ELO_SPEED,
   addBasics,
   bulkUpload,
   createPool,

--- a/serverjs/cubefn.js
+++ b/serverjs/cubefn.js
@@ -11,7 +11,9 @@ const util = require('./util');
 const { getDraftFormat, createDraft } = require('../dist/drafting/createdraft');
 const { getDrafterState } = require('../dist/drafting/draftutil');
 
-const { ELO_BASE, ELO_SPEED, CUBE_ELO_SPEED } = require('../routes/cube/helper');
+const ELO_BASE = 1200;
+const ELO_SPEED = 1 / 128;
+const CUBE_ELO_SPEED = 4;
 
 function getCubeId(cube) {
   if (cube.shortID) return cube.shortID;
@@ -757,6 +759,9 @@ const methods = {
   addDeckCardAnalytics,
   cachePromise,
   saveDraftAnalytics,
+  ELO_BASE,
+  ELO_SPEED,
+  CUBE_ELO_SPEED,
 };
 
 module.exports = methods;


### PR DESCRIPTION
`routes/cube/helper.js` and `serverjs/cubefn.js` were in a circular dependency due to the latter using some variables defined in the former. Because these variables were only used in `cubefn` and not actually anywhere in `helper`, I just moved their declarations to `cubefn` instead, breaking the loop. 

(the last change is just so that `process_decks.js` doesn't redefine its own constants, though it's a bit moot given that the job is archived)