### PR TITLE
Fix cube card count on bulk upload

### DIFF
--- a/__tests__/routes/cube/download.test.js
+++ b/__tests__/routes/cube/download.test.js
@@ -5,9 +5,14 @@ const Papa = require('papaparse');
 const router = require('../../../routes/cube/download');
 const Cube = require('../../../models/cube');
 const carddb = require('../../../serverjs/cards');
-const { buildIdQuery } = require('../../../serverjs/cubefn');
 const cubefixture = require('../../../fixtures/examplecube');
 const dbSetup = require('../../helpers/dbTestSetup');
+
+const splitText = (text) =>
+  text
+    .trim()
+    .split('\n')
+    .map((l) => l.trim());
 
 const exampleCubeWithName = (name) => {
   const cube = new Cube(cubefixture.exampleCube);
@@ -45,7 +50,7 @@ test('cubecobra text download', () => {
     .expect('Content-disposition', `attachment; filename=${sanitizedCubeName}.txt`)
     .expect((res) => {
       const lines = splitText(res.text);
-      expect(lines[0]).toEqual('Acclaimed Contender [eld-1]');
+      expect(lines[0]).toEqual('Faerie Guidemother [eld-11]');
       expect(lines.length).toEqual(exampleCube.cards.length);
     });
 });
@@ -58,7 +63,7 @@ test('plaintext download', () => {
     .expect('Content-disposition', `attachment; filename=${sanitizedCubeName}.txt`)
     .expect((res) => {
       const lines = splitText(res.text);
-      expect(lines[0]).toEqual('Acclaimed Contender');
+      expect(lines[0]).toEqual('Faerie Guidemother');
       expect(lines.length).toEqual(exampleCube.cards.length);
     });
 });
@@ -71,8 +76,8 @@ test('MTGO download', () => {
     .expect('Content-disposition', `attachment; filename=${sanitizedCubeName}.txt`)
     .expect((res) => {
       const lines = splitText(res.text);
-      expect(lines[0]).toEqual('1 Acclaimed Contender');
-      expect(lines[1]).toEqual('2 Brazen Borrower');
+      expect(lines[0]).toEqual('1 Faerie Guidemother');
+      expect(lines[1]).toEqual('1 Giant Killer');
       // The two Brazen Borrowers in the cube are deduped
       expect(lines.length).toEqual(exampleCube.cards.length - 1);
     });
@@ -143,7 +148,7 @@ test('forge download', () => {
       expect(lines[0]).toEqual('[metadata]');
       expect(lines[1]).toEqual(`Name=${exampleCube.name}`);
       expect(lines[2]).toEqual('[Main]');
-      expect(lines[3]).toEqual('1 Acclaimed Contender|ELD');
+      expect(lines[3]).toEqual('1 Faerie Guidemother|ELD');
       // Extra lines expected for [metadata] and [Main] headings, and cube name
       expect(lines.length).toEqual(exampleCube.cards.length + 3);
     });
@@ -157,13 +162,7 @@ test('xmage download', () => {
     .expect('Content-disposition', `attachment; filename=${sanitizedCubeName}.dck`)
     .expect((res) => {
       const lines = splitText(res.text);
-      expect(lines[0]).toEqual('1 [ELD:1] Acclaimed Contender');
+      expect(lines[0]).toEqual('1 [ELD:11] Faerie Guidemother');
       expect(lines.length).toEqual(exampleCube.cards.length);
     });
 });
-
-const splitText = (text) =>
-  text
-    .trim()
-    .split('\n')
-    .map((l) => l.trim());

--- a/routes/cube/download.js
+++ b/routes/cube/download.js
@@ -17,6 +17,27 @@ const Cube = require('../../models/cube');
 
 const router = express.Router();
 
+const sortCardsByQuery = (req, cards) => {
+  if (req.query.filter) {
+    const { filter, err } = filterutil.makeFilter(req.query.filter);
+    if (err) {
+      throw err;
+    }
+    if (filter) {
+      cards = cards.filter(filter);
+    }
+  }
+
+  return sortutil.sortForDownload(
+    cards,
+    req.query.primary,
+    req.query.secondary,
+    req.query.tertiary,
+    req.query.quaternary,
+    req.query.showother,
+  );
+};
+
 router.get('/cubecobra/:id', async (req, res) => {
   try {
     const cube = await Cube.findOne(buildIdQuery(req.params.id)).lean();
@@ -25,11 +46,18 @@ router.get('/cubecobra/:id', async (req, res) => {
       return res.redirect('/404');
     }
 
+    for (const card of cube.cards) {
+      const details = carddb.cardFromId(card.cardID);
+      card.details = details;
+    }
+
+    cube.cards = sortCardsByQuery(req, cube.cards);
+
     res.setHeader('Content-disposition', `attachment; filename=${cube.name.replace(/\W/g, '')}.txt`);
     res.setHeader('Content-type', 'text/plain');
     res.charset = 'UTF-8';
     for (const card of cube.cards) {
-      res.write(`${carddb.cardFromId(card.cardID).full_name}\r\n`);
+      res.write(`${card.details.full_name}\r\n`);
     }
     return res.end();
   } catch (err) {
@@ -51,28 +79,7 @@ router.get('/csv/:id', async (req, res) => {
       card.details = details;
     }
 
-    if (req.query.filter) {
-      const { filter, err } = filterutil.makeFilter(req.query.filter);
-      if (err) {
-        return util.handleRouteError(
-          req,
-          res,
-          'Error parsing filter.',
-          `/cube/list/${encodeURIComponent(req.params.id)}`,
-        );
-      }
-      if (filter) {
-        cube.cards = cube.cards.filter(filter);
-      }
-    }
-
-    cube.cards = sortutil.sortForCSVDownload(
-      cube.cards,
-      req.query.primary,
-      req.query.secondary,
-      req.query.tertiary,
-      req.query.quaternary,
-    );
+    cube.cards = sortCardsByQuery(req, cube.cards);
 
     res.setHeader('Content-disposition', `attachment; filename=${cube.name.replace(/\W/g, '')}.csv`);
     res.setHeader('Content-type', 'text/plain');
@@ -102,6 +109,13 @@ router.get('/forge/:id', async (req, res) => {
       return res.redirect('/404');
     }
 
+    for (const card of cube.cards) {
+      const details = carddb.cardFromId(card.cardID);
+      card.details = details;
+    }
+
+    cube.cards = sortCardsByQuery(req, cube.cards);
+
     res.setHeader('Content-disposition', `attachment; filename=${cube.name.replace(/\W/g, '')}.dck`);
     res.setHeader('Content-type', 'text/plain');
     res.charset = 'UTF-8';
@@ -109,9 +123,7 @@ router.get('/forge/:id', async (req, res) => {
     res.write(`Name=${cube.name}\r\n`);
     res.write('[Main]\r\n');
     for (const card of cube.cards) {
-      const { name } = carddb.cardFromId(card.cardID);
-      const { set } = carddb.cardFromId(card.cardID);
-      res.write(`1 ${name}|${set.toUpperCase()}\r\n`);
+      res.write(`1 ${card.details.name}|${card.details.set.toUpperCase()}\r\n`);
     }
     return res.end();
   } catch (err) {
@@ -126,6 +138,14 @@ router.get('/mtgo/:id', async (req, res) => {
       req.flash('danger', `Cube ID ${req.params.id} not found/`);
       return res.redirect('/404');
     }
+
+    for (const card of cube.cards) {
+      const details = carddb.cardFromId(card.cardID);
+      card.details = details;
+    }
+
+    cube.cards = sortCardsByQuery(req, cube.cards);
+
     return exportToMtgo(res, cube.name, cube.cards, cube.maybe);
   } catch (err) {
     return util.handleRouteError(req, res, err, '/404');
@@ -140,14 +160,18 @@ router.get('/xmage/:id', async (req, res) => {
       return res.redirect('/404');
     }
 
+    for (const card of cube.cards) {
+      const details = carddb.cardFromId(card.cardID);
+      card.details = details;
+    }
+
+    cube.cards = sortCardsByQuery(req, cube.cards);
+
     res.setHeader('Content-disposition', `attachment; filename=${cube.name.replace(/\W/g, '')}.dck`);
     res.setHeader('Content-type', 'text/plain');
     res.charset = 'UTF-8';
     for (const card of cube.cards) {
-      const { name } = carddb.cardFromId(card.cardID);
-      const { set } = carddb.cardFromId(card.cardID);
-      const collectorNumber = carddb.cardFromId(card.cardID).collector_number;
-      res.write(`1 [${set.toUpperCase()}:${collectorNumber}] ${name}\r\n`);
+      res.write(`1 [${card.details.set.toUpperCase()}:${card.details.collector_number}] ${card.details.name}\r\n`);
     }
     return res.end();
   } catch (err) {
@@ -163,11 +187,18 @@ router.get('/plaintext/:id', async (req, res) => {
       return res.redirect('/404');
     }
 
+    for (const card of cube.cards) {
+      const details = carddb.cardFromId(card.cardID);
+      card.details = details;
+    }
+
+    cube.cards = sortCardsByQuery(req, cube.cards);
+
     res.setHeader('Content-disposition', `attachment; filename=${cube.name.replace(/\W/g, '')}.txt`);
     res.setHeader('Content-type', 'text/plain');
     res.charset = 'UTF-8';
     for (const card of cube.cards) {
-      res.write(`${carddb.cardFromId(card.cardID).name}\r\n`);
+      res.write(`${card.details.name}\r\n`);
     }
     return res.end();
   } catch (err) {

--- a/serverjs/cubefn.js
+++ b/serverjs/cubefn.js
@@ -137,6 +137,8 @@ function setCubeType(cube, carddb) {
   cube.keywords.push(...cube.categories);
   cube.keywords = Array.from(new Set(cube.keywords));
 
+  cube.card_count = cube.cards.length;
+
   return cube;
 }
 

--- a/src/components/CubeListNavbar.js
+++ b/src/components/CubeListNavbar.js
@@ -288,7 +288,7 @@ const CubeListNavbar = ({
 
   const { canEdit, cubeID, hasCustomImages } = useContext(CubeContext);
   const { groupModalCards, openGroupModal } = useContext(GroupModalContext);
-  const { primary, secondary, tertiary, quaternary } = useContext(SortContext);
+  const { primary, secondary, tertiary, quaternary, showOther } = useContext(SortContext);
   const openCardModal = useContext(CardModalContext);
   const {
     showCustomImages,
@@ -346,7 +346,7 @@ const CubeListNavbar = ({
   const enc = encodeURIComponent;
   const sortUrlSegment = `primary=${enc(primary)}&secondary=${enc(secondary)}&tertiary=${enc(
     tertiary,
-  )}&quaternary=${enc(quaternary)}`;
+  )}&quaternary=${enc(quaternary)}&showother=${enc(showOther)}`;
   const filterString = filter?.stringify ?? '';
   const filterUrlSegment = filterString ? `&filter=${enc(filterString)}` : '';
 
@@ -440,13 +440,21 @@ const CubeListNavbar = ({
                   </>
                 )}
                 <DropdownItem href={`/cube/clone/${cubeID}`}>Clone Cube</DropdownItem>
-                <DropdownItem href={`/cube/download/plaintext/${cubeID}`}>Card Names (.txt)</DropdownItem>
+                <DropdownItem href={`/cube/download/plaintext/${cubeID}?${sortUrlSegment}${filterUrlSegment}`}>
+                  Card Names (.txt)
+                </DropdownItem>
                 <DropdownItem href={`/cube/download/csv/${cubeID}?${sortUrlSegment}${filterUrlSegment}`}>
                   Comma-Separated (.csv)
                 </DropdownItem>
-                <DropdownItem href={`/cube/download/forge/${cubeID}`}>Forge (.dck)</DropdownItem>
-                <DropdownItem href={`/cube/download/mtgo/${cubeID}`}>MTGO (.txt)</DropdownItem>
-                <DropdownItem href={`/cube/download/xmage/${cubeID}`}>XMage (.dck)</DropdownItem>
+                <DropdownItem href={`/cube/download/forge/${cubeID}?${sortUrlSegment}${filterUrlSegment}`}>
+                  Forge (.dck)
+                </DropdownItem>
+                <DropdownItem href={`/cube/download/mtgo/${cubeID}?${sortUrlSegment}${filterUrlSegment}`}>
+                  MTGO (.txt)
+                </DropdownItem>
+                <DropdownItem href={`/cube/download/xmage/${cubeID}?${sortUrlSegment}${filterUrlSegment}`}>
+                  XMage (.dck)
+                </DropdownItem>
               </DropdownMenu>
             </UncontrolledDropdown>
           </Nav>

--- a/src/utils/Sort.js
+++ b/src/utils/Sort.js
@@ -761,7 +761,7 @@ export function countGroup(group) {
   return group.length;
 }
 
-export function sortForCSVDownload(
+export function sortForDownload(
   cards,
   primary = 'Color Category',
   secondary = 'Types-Multicolor',


### PR DESCRIPTION
Fixes #2074, Fixes #2042, Fixes #2033

In 5.4, we introduced a pre-save hook to the cube schema to update the cube's card_count, but it doesn't trigger off of update calls. This line adds ensures it will always be done.

Edit:
Accidentally pushed to this branch, this PR now also has all cube downloads respect selected sorts, and also respects the "showther" parameter