### PR TITLE
Have basics modal recommend plains again

### DIFF
--- a/src/components/BasicsModal.js
+++ b/src/components/BasicsModal.js
@@ -27,7 +27,7 @@ const BasicsModal = ({ isOpen, toggle, addBasics, deck, basics, cards }) => {
     for (const row of newDeck) {
       for (const col of row) {
         for (const cardIndex of col) {
-          if (basicIds[cardIndex]) {
+          if (basicIds[cardIndex] || basicIds[cardIndex] === 0) {
             newCounts[basicIds[cardIndex]] += 1;
           }
         }


### PR DESCRIPTION
Fixes #2025

The issue was that plains had index `0`, which actually evaluates to false. One of the js moments