### PR TITLE
Added infinite scroll for dashboard feed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16420,6 +16420,14 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
+    "react-infinite-scroll-component": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-infinite-scroll-component/-/react-infinite-scroll-component-6.1.0.tgz",
+      "integrity": "sha512-SQu5nCqy8DxQWpnUVLx7V7b7LcA37aM7tvoWjTLZp1dk6EJibM5/4EJKzOnl07/BsM1Y40sKLuqjCwwH/xV0TQ==",
+      "requires": {
+        "throttle-debounce": "^2.1.0"
+      }
+    },
     "react-is": {
       "version": "16.13.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
@@ -18893,6 +18901,11 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "dev": true
+    },
+    "throttle-debounce": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.3.0.tgz",
+      "integrity": "sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ=="
     },
     "through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "react-dnd-html5-backend": "^8.0.3",
     "react-dnd-touch-backend": "^10.0.2",
     "react-dom": "^16.13.1",
+    "react-infinite-scroll-component": "^6.1.0",
     "react-latex": "^2.0.0",
     "react-leaf-carousel": "^2.0.0",
     "react-markdown": "^5.0.2",

--- a/src/components/BlogPost.js
+++ b/src/components/BlogPost.js
@@ -81,7 +81,7 @@ const BlogPost = ({ post, onEdit, noScroll }) => {
 };
 
 BlogPost.propTypes = {
-  post: BlogPostPropType.isRequired,
+  post: PropTypes.arrayOf(BlogPostPropType).isRequired,
   onEdit: PropTypes.func.isRequired,
   noScroll: PropTypes.bool,
 };

--- a/src/components/Feed.js
+++ b/src/components/Feed.js
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+
+import InfiniteScroll from 'react-infinite-scroll-component';
+
+import BlogPost from 'components/BlogPost';
+import { csrfFetch } from 'utils/CSRF';
+
+import { Spinner } from 'reactstrap';
+import BlogPostPropType from 'proptypes/BlogPostPropType';
+
+const wait = async (ms) => {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+};
+
+const Feed = ({ items }) => {
+  const [feedItems, setFeedItems] = useState(items);
+
+  const fetchMoreData = async () => {
+    // intentionally wait to avoid too many DB queries
+    await wait(2000);
+
+    const response = await csrfFetch(`/tool/getfeeditems/${feedItems.length}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (response.ok) {
+      const json = await response.json();
+      if (json.success === 'true') {
+        const newFeedItems = [...feedItems];
+        for (const item of json.items) {
+          let found = false;
+          for (const existingItem of feedItems) {
+            if (existingItem._id === item._id) {
+              found = true;
+            }
+          }
+          if (!found) {
+            newFeedItems.push(item);
+          }
+        }
+        newFeedItems.push(...json.items);
+        setFeedItems(newFeedItems);
+      }
+    }
+  };
+
+  const loader = (
+    <div className="centered py-3 my-4">
+      <Spinner className="position-absolute" />
+    </div>
+  );
+
+  return (
+    <InfiniteScroll dataLength={feedItems.length} next={fetchMoreData} hasMore loader={loader}>
+      {feedItems.map((item) => (
+        <BlogPost key={item._id} post={item} />
+      ))}
+    </InfiniteScroll>
+  );
+};
+
+Feed.propTypes = {
+  items: BlogPostPropType.isRequired,
+};
+
+export default Feed;

--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -35,7 +35,7 @@ const MainLayout = ({ user, children, loginCallback }) => {
     <UserContext.Provider value={user}>
       <div className="flex-container flex-vertical viewport">
         <Navbar color="dark" expand="md" dark>
-          <Container>
+          <Container fluid="xl">
             <div className="d-flex flex-nowrap w-100 header-banner">
               <div className="overflow-hidden mr-auto">
                 <a href="/">
@@ -151,7 +151,7 @@ const MainLayout = ({ user, children, loginCallback }) => {
             </Collapse>
           </Container>
         </Navbar>
-        <Container className="flex-grow">
+        <Container fluid="xl" className="flex-grow">
           <ThemeContext.Provider value={user?.theme ?? 'default'}>
             <ErrorBoundary>{children}</ErrorBoundary>
           </ThemeContext.Provider>

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -142,7 +142,7 @@ const DashboardPage = ({ posts, cubes, decks, user, loginCallback, content, feat
 };
 
 DashboardPage.propTypes = {
-  posts: BlogPostPropType.isRequired,
+  posts: PropTypes.arrayOf(BlogPostPropType).isRequired,
   cubes: PropTypes.arrayOf(CubePropType).isRequired,
   decks: PropTypes.arrayOf(DeckPropType).isRequired,
   user: UserPropType,

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import CubePropType from 'proptypes/CubePropType';
 import DeckPropType from 'proptypes/DeckPropType';
 import UserPropType from 'proptypes/UserPropType';
+import BlogPostPropType from 'proptypes/BlogPostPropType';
 
-import BlogPost from 'components/BlogPost';
 import CubePreview from 'components/CubePreview';
 import ArticlePreview from 'components/ArticlePreview';
 import DeckPreview from 'components/DeckPreview';
@@ -16,6 +16,7 @@ import MainLayout from 'layouts/MainLayout';
 import RenderToRoot from 'utils/RenderToRoot';
 import withModal from 'components/WithModal';
 import CreateCubeModal from 'components/CreateCubeModal';
+import Feed from 'components/Feed';
 
 import { Button, Card, Col, Row, CardHeader, CardBody, CardFooter } from 'reactstrap';
 import CubesCard from 'components/CubesCard';
@@ -110,13 +111,7 @@ const DashboardPage = ({ posts, cubes, decks, user, loginCallback, content, feat
       <Row>
         <Col xs="12" md="8">
           <h5 className="mt-3">Feed</h5>
-          {posts.length > 0 ? (
-            posts.map((post) => <BlogPost key={post._id} post={post} />)
-          ) : (
-            <p>
-              No posts to show. <a href="/explore">Find some cubes</a> to follow!
-            </p>
-          )}
+          <Feed items={posts} />
         </Col>
         <Col className="d-none d-md-block mt-3" md="4">
           <Row>
@@ -147,7 +142,7 @@ const DashboardPage = ({ posts, cubes, decks, user, loginCallback, content, feat
 };
 
 DashboardPage.propTypes = {
-  posts: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  posts: BlogPostPropType.isRequired,
   cubes: PropTypes.arrayOf(CubePropType).isRequired,
   decks: PropTypes.arrayOf(DeckPropType).isRequired,
   user: UserPropType,


### PR DESCRIPTION
Previously, we used to have five pages of blogposts as the feed, and at some point I removed pagination. This PR adds back the ability to go further back, but this time with infinite scroll. There is a 2 second timeout before retrieving the next 5 blogposts, and there is also a safeguard to ensure no posts are doubled up, from a new posts being inserted during the scrolling. There is a loading wheel at the end of the feed that is displayed before more items are loaded.