### PR TITLE
Have card search respect filter more strictly

### DIFF
--- a/routes/tools_routes.js
+++ b/routes/tools_routes.js
@@ -32,7 +32,7 @@ const getAllMostReasonable = (filter) => {
   const filtered = [];
   for (const card of cards) {
     if (!keys.has(card.name_lower)) {
-      filtered.push(carddb.getMostReasonableById(card._id));
+      filtered.push(carddb.getMostReasonableById(card._id, 'recent', filter));
       keys.add(card.name_lower);
     }
   }

--- a/serverjs/cards.js
+++ b/serverjs/cards.js
@@ -184,12 +184,23 @@ function getIdsFromName(name) {
 }
 
 // Printing = 'recent' or 'first'
-function getMostReasonable(cardName, printing = 'recent') {
+function getMostReasonable(cardName, printing = 'recent', filter = null) {
   let ids = getIdsFromName(cardName);
   if (ids === undefined || ids.length === 0) {
     // Try getting it by ID in case this is an ID.
     // eslint-disable-next-line no-use-before-define
     return getMostReasonableById(cardName, printing);
+  }
+
+  if (filter) {
+    ids = ids
+      .map((id) => ({ details: cardFromId(id) }))
+      .filter(filter)
+      .map((card) => card.details._id);
+  }
+
+  if (ids.length === 0) {
+    return null;
   }
 
   // Ids are stored in reverse chronological order, so reverse if we want first printing.
@@ -200,13 +211,13 @@ function getMostReasonable(cardName, printing = 'recent') {
   return cardFromId(ids.find(reasonableId) || ids[0]);
 }
 
-function getMostReasonableById(id, printing = 'recent') {
+function getMostReasonableById(id, printing = 'recent', filter = null) {
   const card = cardFromId(id);
   if (card.error) {
     winston.info(`Error finding most reasonable for id ${id}`);
     return null;
   }
-  return getMostReasonable(card.name, printing);
+  return getMostReasonable(card.name, printing, filter);
 }
 
 function getFirstReasonable(ids) {


### PR DESCRIPTION
Fixes #2086

This fixes an issue where if someone searches for all cards from mh2 (`set:mh2`), then they should only see versions from mh2.

The problem was that after we had filtered to a set of oracle Ids, we then chose "the most reasonable" version of each card. Instead, it can only choose the most reasonable card that complies with the filter.

Before:
![image](https://user-images.githubusercontent.com/28238025/122759505-065b2380-d268-11eb-8159-507fee53c042.png)

After:
![image](https://user-images.githubusercontent.com/28238025/122759541-0e1ac800-d268-11eb-9fef-3d787ac0ecde.png)
