### PR TITLE
Have sample pack handle the case of not being able to build pack

### DIFF
--- a/routes/cube/index.js
+++ b/routes/cube/index.js
@@ -723,7 +723,13 @@ router.get('/samplepack/:id', (req, res) => {
 router.get('/samplepack/:id/:seed', async (req, res) => {
   try {
     const cube = await Cube.findOne(buildIdQuery(req.params.id)).lean();
-    const pack = await generatePack(req.params.id, carddb, req.params.seed);
+    let pack;
+    try {
+      pack = await generatePack(req.params.id, carddb, req.params.seed);
+    } catch (err) {
+      req.flash('danger', err.message);
+      return res.redirect(`/cube/playtest/${encodeURIComponent(req.params.id)}`);
+    }
 
     const width = Math.floor(Math.sqrt((5 / 3) * pack.pack.length));
     const height = Math.ceil(pack.pack.length / width);


### PR DESCRIPTION
If there are not enough cards for a given draft format, we just throw an exception and return a 500 error code, but this should be a 400 error, and a handled exception. It now flashes a warning and redirects to cube playtest page.