### PR TITLE
Correctly sort by release date

### DIFF
--- a/serverjs/cards.js
+++ b/serverjs/cards.js
@@ -2,6 +2,8 @@ const fs = require('fs');
 const winston = require('winston');
 const util = require('./util.js');
 
+const { SortFunctions, ORDERED_SORTS } = require('../dist/utils/Sort.js');
+
 let data = {
   cardtree: {},
   imagedict: {},
@@ -203,11 +205,20 @@ function getMostReasonable(cardName, printing = 'recent', filter = null) {
     return null;
   }
 
+  // sort chronologically by default
+  const cards = ids.map((id) => ({
+    details: cardFromId(id),
+  }));
+  cards.sort(SortFunctions[ORDERED_SORTS['Release Date']]);
+
+  ids = cards.map((card) => card.details._id);
+
   // Ids are stored in reverse chronological order, so reverse if we want first printing.
   if (printing !== 'recent') {
     ids = [...ids];
     ids.reverse();
   }
+
   return cardFromId(ids.find(reasonableId) || ids[0]);
 }
 


### PR DESCRIPTION
The order of the cards can't be relied on to be chronological, so we will manually sort by release date in `getMostReasonable`

Fixes #1543