### PR TITLE
Correctly list all versions on card pages

### DIFF
--- a/routes/tools_routes.js
+++ b/routes/tools_routes.js
@@ -199,7 +199,9 @@ router.get('/card/:id', async (req, res) => {
       {
         card,
         data,
-        versions: data.versions.map((cardid) => carddb.cardFromId(cardid)),
+        versions: carddb.oracleToId[card.oracle_id]
+          .filter((cid) => cid !== card._id)
+          .map((cardid) => carddb.cardFromId(cardid)),
         related,
       },
       {


### PR DESCRIPTION
Fixes #1578

Versions field on cardHistory shouldn't be used for this, carddb is more reliable