### PR TITLE
Add QR code modal on cube overview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2304,6 +2304,16 @@
         "lodash": "^4.17.11"
       }
     },
+    "@react-native-community/art": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/art/-/art-1.2.0.tgz",
+      "integrity": "sha512-a+ZcRGl/BzLa89yi33Mbn5SHavsEXqKUMdbfLf3U8MDLElndPqUetoJyGkv63+BcPO49UMWiQRP1YUz6/zfJ+A==",
+      "requires": {
+        "art": "^0.10.3",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.7.2"
+      }
+    },
     "@sindresorhus/is": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-2.1.1.tgz",
@@ -3456,6 +3466,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+    },
+    "art": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/art/-/art-0.10.3.tgz",
+      "integrity": "sha512-HXwbdofRTiJT6qZX/FnchtldzJjS3vkLJxQilc3Xj+ma2MXjY4UAyQ0ls1XZYVnDvVIBiFZbC6QsvtW86TD6tQ=="
     },
     "asap": {
       "version": "2.0.6",
@@ -16157,6 +16172,11 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
+    "qr.js": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
+      "integrity": "sha1-ys6GOG9ZoNuAUPqQ2baw6IoeNk8="
+    },
     "qs": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
@@ -16511,6 +16531,16 @@
         "prop-types": "^15.6.1",
         "typed-styles": "^0.0.7",
         "warning": "^4.0.2"
+      }
+    },
+    "react-qr-code": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-1.1.1.tgz",
+      "integrity": "sha512-d6nbjkI9GknmyoIJU2aQCbFojMG5sg2vl5zTH9X+KmzE/RDeXz1MYyeH4Vo0YQkGxhMvXATt6uYku86hQ8GXxw==",
+      "requires": {
+        "@react-native-community/art": "^1.2.0",
+        "prop-types": "^15.7.2",
+        "qr.js": "0.0.0"
       }
     },
     "react-responsive-mixin": {

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "react-markdown": "^5.0.2",
     "react-pivottable": "^0.9.0",
     "react-player": "^2.6.1",
+    "react-qr-code": "^1.1.1",
     "react-sortable-hoc": "^1.10.1",
     "react-syntax-highlighter": "^15.3.0",
     "react-tag-input": "^6.4.1",

--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -1295,3 +1295,7 @@ thead th.corner[scope=col] {
 .advertisement-div {
 	height: 100%
 }
+
+.qr-code-area {
+	background-color: #FFFFFF !important
+}

--- a/src/components/QRCodeModal.js
+++ b/src/components/QRCodeModal.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Modal, ModalBody, ModalHeader } from 'reactstrap';
+
+import QRCode from 'react-qr-code';
+
+const QRCodeModal = ({ isOpen, toggle, link, title }) => (
+  <Modal size="md" isOpen={isOpen} toggle={toggle}>
+    <ModalHeader toggle={toggle}>{title}</ModalHeader>
+    <ModalBody>
+      <div className="centered">
+        <QRCode value={link} />
+      </div>
+    </ModalBody>
+  </Modal>
+);
+
+QRCodeModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  toggle: PropTypes.func.isRequired,
+  link: PropTypes.string.isRequired,
+};
+
+export default QRCodeModal;

--- a/src/components/QRCodeModal.js
+++ b/src/components/QRCodeModal.js
@@ -8,7 +8,7 @@ import QRCode from 'react-qr-code';
 const QRCodeModal = ({ isOpen, toggle, link, title }) => (
   <Modal size="md" isOpen={isOpen} toggle={toggle}>
     <ModalHeader toggle={toggle}>{title}</ModalHeader>
-    <ModalBody>
+    <ModalBody className="qr-code-area">
       <div className="centered">
         <QRCode value={link} />
       </div>
@@ -20,6 +20,7 @@ QRCodeModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   toggle: PropTypes.func.isRequired,
   link: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
 };
 
 export default QRCodeModal;

--- a/src/pages/CubeOverviewPage.js
+++ b/src/pages/CubeOverviewPage.js
@@ -19,7 +19,7 @@ import {
   UncontrolledCollapse,
 } from 'reactstrap';
 
-import { LinkExternalIcon, QuestionIcon } from '@primer/octicons-react';
+import { LinkExternalIcon, QuestionIcon, ShareAndroidIcon } from '@primer/octicons-react';
 
 import { csrfFetch } from 'utils/CSRF';
 import { getCubeId, getCubeDescription } from 'utils/Util';
@@ -41,12 +41,14 @@ import RenderToRoot from 'utils/RenderToRoot';
 import DeleteCubeModal from 'components/DeleteCubeModal';
 import CustomizeBasicsModal from 'components/CustomizeBasicsModal';
 import CubeIdModal from 'components/CubeIdModal';
+import QRCodeModal from 'components/QRCodeModal';
 
 const FollowersModalLink = withModal('a', FollowersModal);
 const CubeSettingsModalLink = withModal(NavLink, CubeSettingsModal);
 const DeleteCubeModalLink = withModal(NavLink, DeleteCubeModal);
 const CustomizeBasicsModalLink = withModal(NavLink, CustomizeBasicsModal);
 const CubeIdModalLink = withModal('span', CubeIdModal);
+const QRCodeModalLink = withModal('a', QRCodeModal);
 
 const CubeOverview = ({ post, priceOwned, pricePurchase, cube, followed, followers, loginCallback }) => {
   const user = useContext(UserContext);
@@ -150,7 +152,19 @@ const CubeOverview = ({ post, priceOwned, pricePurchase, cube, followed, followe
           <Col md="4" className="mb-3">
             <Card>
               <CardHeader>
-                <h3>{cubeState.name}</h3>
+                <Row>
+                  <Col>
+                    <h3>{cubeState.name}</h3>
+                  </Col>
+                  <div className="float-right" style={{ paddingTop: 3, marginRight: '0.25rem' }}>
+                    <QRCodeModalLink
+                      href="#"
+                      modalProps={{ link: `https://cubecobra.com/c/${cube._id}`, title: `Link to ${cube.name}` }}
+                    >
+                      QR Code <ShareAndroidIcon size={16} />
+                    </QRCodeModalLink>
+                  </div>
+                </Row>
                 <Row>
                   <Col>
                     <h6 className="card-subtitle mb-2" style={{ marginTop: 10 }}>


### PR DESCRIPTION
Adds a link to cube overview that opens up a modal with a QR code to your cube.

![image](https://user-images.githubusercontent.com/28238025/123354212-2c671900-d531-11eb-8771-7c901af2c331.png)
![image](https://user-images.githubusercontent.com/28238025/123354228-35f08100-d531-11eb-9b84-5838697f62fd.png)

![image](https://user-images.githubusercontent.com/28238025/123354235-39840800-d531-11eb-9bd4-d6c4a4e58632.png)
![image](https://user-images.githubusercontent.com/28238025/123354242-3c7ef880-d531-11eb-86ec-1194e7fa0f19.png)

![image](https://user-images.githubusercontent.com/28238025/123354254-43a60680-d531-11eb-810c-938d1f58e83b.png)![image](https://user-images.githubusercontent.com/28238025/123355088-ee6af480-d532-11eb-9b1d-01ca4e2434a9.png)

![image](https://user-images.githubusercontent.com/28238025/123354295-57516d00-d531-11eb-9c0f-6813fab77cbd.png)![image](https://user-images.githubusercontent.com/28238025/123355076-e7dc7d00-d532-11eb-8c59-f3f16a3ba3b5.png)

