### PR TITLE
Customize sort and filter usage in export

### DIFF
--- a/src/components/CubeListNavbar.js
+++ b/src/components/CubeListNavbar.js
@@ -28,6 +28,7 @@ import {
   NavbarToggler,
   Row,
   UncontrolledDropdown,
+  FormGroup,
 } from 'reactstrap';
 
 import CardModalContext from 'contexts/CardModalContext';
@@ -285,6 +286,8 @@ const CubeListNavbar = ({
   const [isOpen, setIsOpen] = useState(false);
   const [tagColorsModalOpen, setTagColorsModalOpen] = useState(false);
   const [selectEmptyModalOpen, setSelectEmptyModalOpen] = useState(false);
+  const [isSortUsed, setIsSortUsed] = useState(true);
+  const [isFilterUsed, setIsFilterUsed] = useState(true);
 
   const { canEdit, cubeID, hasCustomImages } = useContext(CubeContext);
   const { groupModalCards, openGroupModal } = useContext(GroupModalContext);
@@ -349,6 +352,7 @@ const CubeListNavbar = ({
   )}&quaternary=${enc(quaternary)}&showother=${enc(showOther)}`;
   const filterString = filter?.stringify ?? '';
   const filterUrlSegment = filterString ? `&filter=${enc(filterString)}` : '';
+  const urlSegment = `${isSortUsed ? sortUrlSegment : ''}${isFilterUsed ? filterUrlSegment : ''}`;
 
   return (
     <div className={`usercontrols${className ? ` ${className}` : ''}`}>
@@ -443,20 +447,21 @@ const CubeListNavbar = ({
                   </>
                 )}
                 <DropdownItem href={`/cube/clone/${cubeID}`}>Clone Cube</DropdownItem>
-                <DropdownItem href={`/cube/download/plaintext/${cubeID}?${sortUrlSegment}${filterUrlSegment}`}>
-                  Card Names (.txt)
+                <DropdownItem href={`/cube/download/plaintext/${cubeID}?${urlSegment}`}>Card Names (.txt)</DropdownItem>
+                <DropdownItem href={`/cube/download/csv/${cubeID}?${urlSegment}`}>Comma-Separated (.csv)</DropdownItem>
+                <DropdownItem href={`/cube/download/forge/${cubeID}?${urlSegment}`}>Forge (.dck)</DropdownItem>
+                <DropdownItem href={`/cube/download/mtgo/${cubeID}?${urlSegment}`}>MTGO (.txt)</DropdownItem>
+                <DropdownItem href={`/cube/download/xmage/${cubeID}?${urlSegment}`}>XMage (.dck)</DropdownItem>
+                <DropdownItem divider />
+                <DropdownItem toggle={false} onClick={() => setIsSortUsed((is) => !is)}>
+                  <FormGroup check>
+                    <Input type="checkbox" checked={isSortUsed} /> Use Sort
+                  </FormGroup>
                 </DropdownItem>
-                <DropdownItem href={`/cube/download/csv/${cubeID}?${sortUrlSegment}${filterUrlSegment}`}>
-                  Comma-Separated (.csv)
-                </DropdownItem>
-                <DropdownItem href={`/cube/download/forge/${cubeID}?${sortUrlSegment}${filterUrlSegment}`}>
-                  Forge (.dck)
-                </DropdownItem>
-                <DropdownItem href={`/cube/download/mtgo/${cubeID}?${sortUrlSegment}${filterUrlSegment}`}>
-                  MTGO (.txt)
-                </DropdownItem>
-                <DropdownItem href={`/cube/download/xmage/${cubeID}?${sortUrlSegment}${filterUrlSegment}`}>
-                  XMage (.dck)
+                <DropdownItem toggle={false} onClick={() => setIsFilterUsed((is) => !is)}>
+                  <FormGroup check>
+                    <Input type="checkbox" checked={isFilterUsed} /> Use Filter
+                  </FormGroup>
                 </DropdownItem>
               </DropdownMenu>
             </UncontrolledDropdown>

--- a/src/components/CubeListNavbar.js
+++ b/src/components/CubeListNavbar.js
@@ -42,6 +42,8 @@ import SortCollapse from 'components/SortCollapse';
 import SortContext from 'contexts/SortContext';
 import TagColorsModal from 'components/TagColorsModal';
 import withModal from 'components/WithModal';
+import { QuestionIcon } from '@primer/octicons-react';
+import Tooltip from 'components/Tooltip';
 
 const PasteBulkModal = ({ isOpen, toggle }) => {
   const { cubeID } = useContext(CubeContext);
@@ -454,13 +456,23 @@ const CubeListNavbar = ({
                 <DropdownItem href={`/cube/download/xmage/${cubeID}?${urlSegment}`}>XMage (.dck)</DropdownItem>
                 <DropdownItem divider />
                 <DropdownItem toggle={false} onClick={() => setIsSortUsed((is) => !is)}>
-                  <FormGroup check>
+                  <FormGroup check style={{ display: 'flex' }}>
                     <Input type="checkbox" checked={isSortUsed} /> Use Sort
+                    <Tooltip text="Order export using current sort options." wrapperTag="span" className="ml-auto mr-0">
+                      <QuestionIcon size={16} />
+                    </Tooltip>
                   </FormGroup>
                 </DropdownItem>
                 <DropdownItem toggle={false} onClick={() => setIsFilterUsed((is) => !is)}>
-                  <FormGroup check>
+                  <FormGroup check style={{ display: 'flex' }}>
                     <Input type="checkbox" checked={isFilterUsed} /> Use Filter
+                    <Tooltip
+                      text="Include in export only cards matching current filter."
+                      wrapperTag="span"
+                      className="ml-auto mr-0"
+                    >
+                      <QuestionIcon size={16} />
+                    </Tooltip>
                   </FormGroup>
                 </DropdownItem>
               </DropdownMenu>

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -3,12 +3,15 @@ import PropTypes from 'prop-types';
 
 import { UncontrolledTooltip } from 'reactstrap';
 
-const Tooltip = ({ text, children, ...props }) => {
+const Tooltip = ({ text, children, wrapperTag, tooltipProps, ...props }) => {
   const divRef = useRef();
+  const Tag = wrapperTag || 'div';
   return (
     <>
-      <div ref={divRef}>{children}</div>
-      <UncontrolledTooltip placement="top" boundariesElement="window" trigger="hover" target={divRef} {...props}>
+      <Tag ref={divRef} {...props}>
+        {children}
+      </Tag>
+      <UncontrolledTooltip placement="top" boundariesElement="window" trigger="hover" target={divRef} {...tooltipProps}>
         {text}
       </UncontrolledTooltip>
     </>
@@ -18,6 +21,13 @@ const Tooltip = ({ text, children, ...props }) => {
 Tooltip.propTypes = {
   text: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
+  wrapperTag: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+  tooltipProps: PropTypes.shape({}),
+};
+
+Tooltip.defaultProps = {
+  wrapperTag: 'div',
+  tooltipProps: {},
 };
 
 export default Tooltip;


### PR DESCRIPTION
Since we now support sorting and filtering for all export types, this PR adds the option to disable either of those for your export. It also slightly refactors the `Tooltip` component to be more configurable.
![sortfilter](https://user-images.githubusercontent.com/38463785/123410913-5e16c900-d59f-11eb-895e-f3fae2da4e66.png)
