### PR TITLE
Added white carets to dark mode

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -47,3 +47,7 @@
   --code-bg: rgb(43, 43, 43);
   --read-only-disabled: #797c8f;
 }
+
+.custom-select {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='4' height='5' viewBox='0 0 4 5'%3e%3cpath fill='%23fff' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e")
+}


### PR DESCRIPTION
Fixes #2083.

### Issue
The carets used in `select` inputs have the exact same color as the dark mode background, making them invisible in dark mode.

### Fix
Recreate the carets in dark mode, except in white.

### Screenshot
![Screenshot 2021-06-25 at 11-17-23 Cube Cobra List MTGO Vintage Cube](https://user-images.githubusercontent.com/38463785/123418238-57408400-d5a8-11eb-966d-61439c8dba1e.png)
