### PR TITLE
Fixing blog post edit modal

### DIFF
--- a/src/components/BlogPost.js
+++ b/src/components/BlogPost.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 
 import PropTypes from 'prop-types';
 import BlogPostPropType from 'proptypes/BlogPostPropType';
@@ -9,80 +9,91 @@ import { Card, CardHeader, Row, Col, CardBody, CardText } from 'reactstrap';
 
 import UserContext from 'contexts/UserContext';
 import BlogContextMenu from 'components/BlogContextMenu';
+import EditBlogModal from 'components/EditBlogModal';
 import CommentsSection from 'components/CommentsSection';
 import Markdown from 'components/Markdown';
 
-const BlogPost = ({ post, onEdit, noScroll }) => {
+const BlogPost = ({ post, noScroll }) => {
   const user = useContext(UserContext);
+  const [editOpen, setEditOpen] = useState(false);
+  const [editMarkdown, setEditMarkdown] = useState('');
 
   const html = post.html === 'undefined' ? null : post.html;
-
   const scrollStyle = noScroll ? {} : { overflow: 'auto', maxHeight: '50vh' };
-
   const canEdit = user && user.id === post.owner;
 
   return (
-    <Card className="shadowed rounded-0 mb-3">
-      <CardHeader className="pl-4 pr-0 pt-2 pb-0">
-        <h5 className="card-title">
-          <a href={`/cube/blog/blogpost/${post._id}`}>{post.title}</a>
-          <div className="float-sm-right">
-            {canEdit && <BlogContextMenu className="float-sm-right" post={post} value="..." onEdit={onEdit} />}
-          </div>
-        </h5>
-        <h6 className="card-subtitle mb-2 text-muted">
-          <a href={`/user/view/${post.owner}`}>{post.dev === 'true' ? 'Dekkaru' : post.username}</a>
-          {' posted to '}
-          {post.dev === 'true' ? (
-            <a href="/dev/blog/0">Developer Blog</a>
+    <>
+      <Card className="shadowed rounded-0 mb-3">
+        <CardHeader className="pl-4 pr-0 pt-2 pb-0">
+          <h5 className="card-title">
+            <a href={`/cube/blog/blogpost/${post._id}`}>{post.title}</a>
+            <div className="float-sm-right">
+              {canEdit && (
+                <BlogContextMenu className="float-sm-right" post={post} value="..." onEdit={() => setEditOpen(true)} />
+              )}
+            </div>
+          </h5>
+          <h6 className="card-subtitle mb-2 text-muted">
+            <a href={`/user/view/${post.owner}`}>{post.dev === 'true' ? 'Dekkaru' : post.username}</a>
+            {' posted to '}
+            {post.dev === 'true' ? (
+              <a href="/dev/blog/0">Developer Blog</a>
+            ) : (
+              <a href={`/cube/overview/${post.cube}`}>{post.cubename}</a>
+            )}
+            {' - '}
+            <TimeAgo date={post.date} />
+          </h6>
+        </CardHeader>
+        <div style={scrollStyle}>
+          {post.changelist && (html || post.markdown) ? (
+            <Row className="no-gutters">
+              <Col className="col-12 col-l-5 col-md-4 col-sm-12 blog-post-border">
+                <CardBody className="py-2">
+                  <CardText dangerouslySetInnerHTML={{ __html: post.changelist }} />
+                </CardBody>
+              </Col>
+              <Col className="col-l-7 col-m-6">
+                <CardBody className="py-2">
+                  {post.markdown ? (
+                    <Markdown markdown={post.markdown} limited />
+                  ) : (
+                    <CardText dangerouslySetInnerHTML={{ __html: html }} />
+                  )}
+                </CardBody>
+              </Col>
+            </Row>
           ) : (
-            <a href={`/cube/overview/${post.cube}`}>{post.cubename}</a>
-          )}
-          {' - '}
-          <TimeAgo date={post.date} />
-        </h6>
-      </CardHeader>
-      <div style={scrollStyle}>
-        {post.changelist && (html || post.markdown) ? (
-          <Row className="no-gutters">
-            <Col className="col-12 col-l-5 col-md-4 col-sm-12 blog-post-border">
-              <CardBody className="py-2">
-                <CardText dangerouslySetInnerHTML={{ __html: post.changelist }} />
-              </CardBody>
-            </Col>
-            <Col className="col-l-7 col-m-6">
-              <CardBody className="py-2">
-                {post.markdown ? (
+            <CardBody className="py-2">
+              {post.changelist && <CardText dangerouslySetInnerHTML={{ __html: post.changelist }} />}
+              {post.body && <CardText>{post.body}</CardText>}
+              {(html || post.markdown) &&
+                (post.markdown ? (
                   <Markdown markdown={post.markdown} limited />
                 ) : (
                   <CardText dangerouslySetInnerHTML={{ __html: html }} />
-                )}
-              </CardBody>
-            </Col>
-          </Row>
-        ) : (
-          <CardBody className="py-2">
-            {post.changelist && <CardText dangerouslySetInnerHTML={{ __html: post.changelist }} />}
-            {post.body && <CardText>{post.body}</CardText>}
-            {(html || post.markdown) &&
-              (post.markdown ? (
-                <Markdown markdown={post.markdown} limited />
-              ) : (
-                <CardText dangerouslySetInnerHTML={{ __html: html }} />
-              ))}
-          </CardBody>
-        )}
-      </div>
-      <div className="border-top">
-        <CommentsSection parentType="blog" parent={post._id} collapse={false} />
-      </div>
-    </Card>
+                ))}
+            </CardBody>
+          )}
+        </div>
+        <div className="border-top">
+          <CommentsSection parentType="blog" parent={post._id} collapse={false} />
+        </div>
+      </Card>
+      <EditBlogModal
+        isOpen={editOpen}
+        toggle={() => setEditOpen((open) => !open)}
+        post={post}
+        markdown={editMarkdown}
+        setMarkdown={setEditMarkdown}
+      />
+    </>
   );
 };
 
 BlogPost.propTypes = {
   post: PropTypes.arrayOf(BlogPostPropType).isRequired,
-  onEdit: PropTypes.func.isRequired,
   noScroll: PropTypes.bool,
 };
 

--- a/src/components/BlogPost.js
+++ b/src/components/BlogPost.js
@@ -16,7 +16,6 @@ import Markdown from 'components/Markdown';
 const BlogPost = ({ post, noScroll }) => {
   const user = useContext(UserContext);
   const [editOpen, setEditOpen] = useState(false);
-  const [editMarkdown, setEditMarkdown] = useState('');
 
   const html = post.html === 'undefined' ? null : post.html;
   const scrollStyle = noScroll ? {} : { overflow: 'auto', maxHeight: '50vh' };
@@ -81,13 +80,7 @@ const BlogPost = ({ post, noScroll }) => {
           <CommentsSection parentType="blog" parent={post._id} collapse={false} />
         </div>
       </Card>
-      <EditBlogModal
-        isOpen={editOpen}
-        toggle={() => setEditOpen((open) => !open)}
-        post={post}
-        markdown={editMarkdown}
-        setMarkdown={setEditMarkdown}
-      />
+      <EditBlogModal isOpen={editOpen} toggle={() => setEditOpen((open) => !open)} post={post} cubeID={post.cube} />
     </>
   );
 };

--- a/src/components/BlogPost.js
+++ b/src/components/BlogPost.js
@@ -22,66 +22,71 @@ const BlogPost = ({ post, noScroll }) => {
   const canEdit = user && user.id === post.owner;
 
   return (
-    <>
-      <Card className="shadowed rounded-0 mb-3">
-        <CardHeader className="pl-4 pr-0 pt-2 pb-0">
-          <h5 className="card-title">
-            <a href={`/cube/blog/blogpost/${post._id}`}>{post.title}</a>
-            <div className="float-sm-right">
-              {canEdit && (
+    <Card className="shadowed rounded-0 mb-3">
+      <CardHeader className="pl-4 pr-0 pt-2 pb-0">
+        <h5 className="card-title">
+          <a href={`/cube/blog/blogpost/${post._id}`}>{post.title}</a>
+          <div className="float-sm-right">
+            {canEdit && (
+              <>
                 <BlogContextMenu className="float-sm-right" post={post} value="..." onEdit={() => setEditOpen(true)} />
-              )}
-            </div>
-          </h5>
-          <h6 className="card-subtitle mb-2 text-muted">
-            <a href={`/user/view/${post.owner}`}>{post.dev === 'true' ? 'Dekkaru' : post.username}</a>
-            {' posted to '}
-            {post.dev === 'true' ? (
-              <a href="/dev/blog/0">Developer Blog</a>
-            ) : (
-              <a href={`/cube/overview/${post.cube}`}>{post.cubename}</a>
+                <EditBlogModal
+                  isOpen={editOpen}
+                  toggle={() => setEditOpen((open) => !open)}
+                  post={post}
+                  cubeID={post.cube}
+                />
+              </>
             )}
-            {' - '}
-            <TimeAgo date={post.date} />
-          </h6>
-        </CardHeader>
-        <div style={scrollStyle}>
-          {post.changelist && (html || post.markdown) ? (
-            <Row className="no-gutters">
-              <Col className="col-12 col-l-5 col-md-4 col-sm-12 blog-post-border">
-                <CardBody className="py-2">
-                  <CardText dangerouslySetInnerHTML={{ __html: post.changelist }} />
-                </CardBody>
-              </Col>
-              <Col className="col-l-7 col-m-6">
-                <CardBody className="py-2">
-                  {post.markdown ? (
-                    <Markdown markdown={post.markdown} limited />
-                  ) : (
-                    <CardText dangerouslySetInnerHTML={{ __html: html }} />
-                  )}
-                </CardBody>
-              </Col>
-            </Row>
+          </div>
+        </h5>
+        <h6 className="card-subtitle mb-2 text-muted">
+          <a href={`/user/view/${post.owner}`}>{post.dev === 'true' ? 'Dekkaru' : post.username}</a>
+          {' posted to '}
+          {post.dev === 'true' ? (
+            <a href="/dev/blog/0">Developer Blog</a>
           ) : (
-            <CardBody className="py-2">
-              {post.changelist && <CardText dangerouslySetInnerHTML={{ __html: post.changelist }} />}
-              {post.body && <CardText>{post.body}</CardText>}
-              {(html || post.markdown) &&
-                (post.markdown ? (
+            <a href={`/cube/overview/${post.cube}`}>{post.cubename}</a>
+          )}
+          {' - '}
+          <TimeAgo date={post.date} />
+        </h6>
+      </CardHeader>
+      <div style={scrollStyle}>
+        {post.changelist && (html || post.markdown) ? (
+          <Row className="no-gutters">
+            <Col className="col-12 col-l-5 col-md-4 col-sm-12 blog-post-border">
+              <CardBody className="py-2">
+                <CardText dangerouslySetInnerHTML={{ __html: post.changelist }} />
+              </CardBody>
+            </Col>
+            <Col className="col-l-7 col-m-6">
+              <CardBody className="py-2">
+                {post.markdown ? (
                   <Markdown markdown={post.markdown} limited />
                 ) : (
                   <CardText dangerouslySetInnerHTML={{ __html: html }} />
-                ))}
-            </CardBody>
-          )}
-        </div>
-        <div className="border-top">
-          <CommentsSection parentType="blog" parent={post._id} collapse={false} />
-        </div>
-      </Card>
-      <EditBlogModal isOpen={editOpen} toggle={() => setEditOpen((open) => !open)} post={post} cubeID={post.cube} />
-    </>
+                )}
+              </CardBody>
+            </Col>
+          </Row>
+        ) : (
+          <CardBody className="py-2">
+            {post.changelist && <CardText dangerouslySetInnerHTML={{ __html: post.changelist }} />}
+            {post.body && <CardText>{post.body}</CardText>}
+            {(html || post.markdown) &&
+              (post.markdown ? (
+                <Markdown markdown={post.markdown} limited />
+              ) : (
+                <CardText dangerouslySetInnerHTML={{ __html: html }} />
+              ))}
+          </CardBody>
+        )}
+      </div>
+      <div className="border-top">
+        <CommentsSection parentType="blog" parent={post._id} collapse={false} />
+      </div>
+    </Card>
   );
 };
 

--- a/src/components/EditBlogModal.js
+++ b/src/components/EditBlogModal.js
@@ -1,0 +1,55 @@
+import React, { useCallback, useContext, useState } from 'react';
+import CubeContext from 'contexts/CubeContext';
+import { findUserLinks } from 'markdown/parser';
+import { Button, Input, Label, Modal, ModalBody, ModalFooter, ModalHeader } from 'reactstrap';
+import CSRFForm from 'components/CSRFForm';
+import TextEntry from 'components/TextEntry';
+import PropTypes from 'prop-types';
+import BlogPostPropType from 'proptypes/BlogPostPropType';
+
+const EditBlogModal = ({ isOpen, toggle, post }) => {
+  const { cubeID } = useContext(CubeContext);
+  const [mentions, setMentions] = useState('');
+  const [markdown, setMarkdown] = useState(post ? post.markdown : '');
+  const handleMentions = useCallback(() => {
+    setMentions(findUserLinks(markdown).join(';'));
+  }, [markdown]);
+
+  return (
+    <Modal isOpen={isOpen} toggle={toggle} labelledBy="#blogEditTitle" size="lg">
+      <CSRFForm method="POST" action={`/cube/blog/post/${cubeID}`} onSubmit={handleMentions}>
+        <ModalHeader toggle={toggle} id="blogEditTitle">
+          Edit Blog Post
+        </ModalHeader>
+        <ModalBody>
+          <Label>Title:</Label>
+          <Input maxLength="200" name="title" type="text" defaultValue={post ? post.title : ''} />
+          <Label>Body:</Label>
+          {post && <Input type="hidden" name="id" value={post._id} />}
+          <TextEntry name="markdown" value={markdown} onChange={(e) => setMarkdown(e.target.value)} maxLength={10000} />
+          <Input name="mentions" type="hidden" value={mentions} />
+        </ModalBody>
+        <ModalFooter>
+          <Button color="success" type="submit">
+            Save
+          </Button>
+          <Button color="secondary" onClick={toggle}>
+            Close
+          </Button>
+        </ModalFooter>
+      </CSRFForm>
+    </Modal>
+  );
+};
+
+EditBlogModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  toggle: PropTypes.func.isRequired,
+  post: BlogPostPropType,
+};
+
+EditBlogModal.defaultProps = {
+  post: null,
+};
+
+export default EditBlogModal;

--- a/src/components/EditBlogModal.js
+++ b/src/components/EditBlogModal.js
@@ -1,5 +1,4 @@
-import React, { useCallback, useContext, useState } from 'react';
-import CubeContext from 'contexts/CubeContext';
+import React, { useCallback, useState } from 'react';
 import { findUserLinks } from 'markdown/parser';
 import { Button, Input, Label, Modal, ModalBody, ModalFooter, ModalHeader } from 'reactstrap';
 import CSRFForm from 'components/CSRFForm';
@@ -7,8 +6,7 @@ import TextEntry from 'components/TextEntry';
 import PropTypes from 'prop-types';
 import BlogPostPropType from 'proptypes/BlogPostPropType';
 
-const EditBlogModal = ({ isOpen, toggle, post }) => {
-  const { cubeID } = useContext(CubeContext);
+const EditBlogModal = ({ isOpen, toggle, post, cubeID }) => {
   const [mentions, setMentions] = useState('');
   const [markdown, setMarkdown] = useState(post ? post.markdown : '');
   const handleMentions = useCallback(() => {
@@ -46,6 +44,7 @@ EditBlogModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   toggle: PropTypes.func.isRequired,
   post: BlogPostPropType,
+  cubeID: PropTypes.string.isRequired,
 };
 
 EditBlogModal.defaultProps = {

--- a/src/components/EditBlogModal.js
+++ b/src/components/EditBlogModal.js
@@ -51,7 +51,7 @@ EditBlogModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   toggle: PropTypes.func.isRequired,
   post: BlogPostPropType,
-  cubeID: PropTypes.string.isRequired,
+  cubeID: PropTypes.string.isRequired, // usually equal to post._id, needs to be a separate prop for new posts
 };
 
 EditBlogModal.defaultProps = {

--- a/src/components/EditBlogModal.js
+++ b/src/components/EditBlogModal.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useState } from 'react';
 import { findUserLinks } from 'markdown/parser';
 import { Button, Input, Label, Modal, ModalBody, ModalFooter, ModalHeader } from 'reactstrap';
 import CSRFForm from 'components/CSRFForm';
@@ -9,9 +9,9 @@ import BlogPostPropType from 'proptypes/BlogPostPropType';
 const EditBlogModal = ({ isOpen, toggle, post, cubeID }) => {
   const [mentions, setMentions] = useState('');
   const [markdown, setMarkdown] = useState(post ? post.markdown : '');
-  const handleMentions = useCallback(() => {
+  const handleMentions = () => {
     setMentions(findUserLinks(markdown).join(';'));
-  }, [markdown]);
+  };
 
   return (
     <Modal isOpen={isOpen} toggle={toggle} labelledBy="#blogEditTitle" size="lg">

--- a/src/components/EditBlogModal.js
+++ b/src/components/EditBlogModal.js
@@ -21,8 +21,15 @@ const EditBlogModal = ({ isOpen, toggle, post, cubeID }) => {
         </ModalHeader>
         <ModalBody>
           <Label>Title:</Label>
-          <Input maxLength="200" name="title" type="text" defaultValue={post ? post.title : ''} />
-          <Label>Body:</Label>
+          <Input
+            required
+            minLength={5}
+            maxLength={200}
+            name="title"
+            type="text"
+            defaultValue={post ? post.title : ''}
+          />
+          <Label className="mt-3">Body:</Label>
           {post && <Input type="hidden" name="id" value={post._id} />}
           <TextEntry name="markdown" value={markdown} onChange={(e) => setMarkdown(e.target.value)} maxLength={10000} />
           <Input name="mentions" type="hidden" value={mentions} />

--- a/src/pages/CubeBlogPage.js
+++ b/src/pages/CubeBlogPage.js
@@ -37,7 +37,7 @@ const CubeBlogPage = ({ cube, pages, activePage, posts, loginCallback }) => {
           <h5>No blog posts for this cube.</h5>
         )}
         {pages > 1 && <Paginate count={pages} active={activePage} urlF={(i) => `/cube/blog/${cube._id}/${i}`} />}
-        <EditBlogModal toggle={() => setNewEditOpen((open) => !open)} isOpen={isNewEditOpen} />
+        <EditBlogModal toggle={() => setNewEditOpen((open) => !open)} isOpen={isNewEditOpen} cubeID={cube._id} />
       </CubeLayout>
     </MainLayout>
   );

--- a/src/pages/CubeBlogPage.js
+++ b/src/pages/CubeBlogPage.js
@@ -22,7 +22,7 @@ const CubeBlogPage = ({ cube, pages, activePage, posts, loginCallback }) => {
           <Collapse navbar>
             <Nav navbar>
               <NavItem>
-                <NavLink tag="button" onClick={() => setNewEditOpen(true)}>
+                <NavLink onClick={() => setNewEditOpen(true)} href="#">
                   Create new blog post
                 </NavLink>
               </NavItem>

--- a/src/pages/CubeBlogPage.js
+++ b/src/pages/CubeBlogPage.js
@@ -1,102 +1,19 @@
-import React, { useContext, useState, useCallback } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import CubePropType from 'proptypes/CubePropType';
 
-import {
-  Button,
-  Collapse,
-  Input,
-  Label,
-  Modal,
-  ModalBody,
-  ModalFooter,
-  ModalHeader,
-  Nav,
-  Navbar,
-  NavItem,
-  NavLink,
-} from 'reactstrap';
+import { Collapse, Nav, Navbar, NavItem, NavLink } from 'reactstrap';
 
 import BlogPost from 'components/BlogPost';
-import CSRFForm from 'components/CSRFForm';
-import CubeContext from 'contexts/CubeContext';
+import EditBlogModal from 'components/EditBlogModal';
 import DynamicFlash from 'components/DynamicFlash';
 import Paginate from 'components/Paginate';
-import TextEntry from 'components/TextEntry';
 import CubeLayout from 'layouts/CubeLayout';
 import MainLayout from 'layouts/MainLayout';
 import RenderToRoot from 'utils/RenderToRoot';
-import { findUserLinks } from 'markdown/parser';
-
-const EditBlogModal = ({ isOpen, toggle, markdown, setMarkdown, post }) => {
-  const { cubeID } = useContext(CubeContext);
-  const [mentions, setMentions] = useState('');
-  const handleChangeMarkdown = useCallback((event) => setMarkdown(event.target.value), [setMarkdown]);
-  const handleMentions = useCallback(() => {
-    setMentions(findUserLinks(markdown).join(';'));
-  }, [markdown]);
-
-  return (
-    <Modal isOpen={isOpen} toggle={toggle} labelledBy="#blogEditTitle" size="lg">
-      <CSRFForm method="POST" action={`/cube/blog/post/${cubeID}`} onSubmit={handleMentions}>
-        <ModalHeader toggle={toggle} id="blogEditTitle">
-          Edit Blog Post
-        </ModalHeader>
-        <ModalBody>
-          <Label>Title:</Label>
-          <Input maxLength="200" name="title" type="text" defaultValue={post ? post.title : ''} />
-          <Label>Body:</Label>
-          {post && <Input type="hidden" name="id" value={post._id} />}
-          <TextEntry name="markdown" value={markdown} onChange={handleChangeMarkdown} maxLength={10000} />
-          <Input name="mentions" type="hidden" value={mentions} />
-        </ModalBody>
-        <ModalFooter>
-          <Button color="success" type="submit">
-            Save
-          </Button>
-          <Button color="secondary" onClick={toggle}>
-            Close
-          </Button>
-        </ModalFooter>
-      </CSRFForm>
-    </Modal>
-  );
-};
-
-EditBlogModal.propTypes = {
-  isOpen: PropTypes.bool.isRequired,
-  toggle: PropTypes.func.isRequired,
-  markdown: PropTypes.string.isRequired,
-  setMarkdown: PropTypes.func.isRequired,
-  post: PropTypes.shape({
-    _id: PropTypes.string.isRequired,
-    title: PropTypes.string.isRequired,
-  }),
-};
-
-EditBlogModal.defaultProps = {
-  post: null,
-};
 
 const CubeBlogPage = ({ cube, pages, activePage, posts, loginCallback }) => {
-  const [editPostIndex, setEditPostIndex] = useState(-1);
-  const [editOpen, setEditOpen] = useState(false);
-  const [editMarkdown, setEditMarkdown] = useState('');
-  const toggleEdit = useCallback(() => setEditOpen((open) => !open), []);
-
-  const handleEdit = useCallback(
-    (id) => {
-      const postIndex = posts.findIndex((post) => post._id === id);
-      setEditPostIndex(postIndex);
-      setEditOpen(true);
-      if (postIndex > -1) {
-        setEditMarkdown(posts[postIndex].markdown);
-      }
-    },
-    [posts],
-  );
-
-  const handleNew = useCallback(() => handleEdit(-1), [handleEdit]);
+  const [isNewEditOpen, setNewEditOpen] = useState(false);
 
   return (
     <MainLayout loginCallback={loginCallback}>
@@ -105,7 +22,7 @@ const CubeBlogPage = ({ cube, pages, activePage, posts, loginCallback }) => {
           <Collapse navbar>
             <Nav navbar>
               <NavItem>
-                <NavLink href="#" onClick={handleNew}>
+                <NavLink tag="button" onClick={() => setNewEditOpen(true)}>
                   Create new blog post
                 </NavLink>
               </NavItem>
@@ -115,18 +32,12 @@ const CubeBlogPage = ({ cube, pages, activePage, posts, loginCallback }) => {
         <DynamicFlash />
         {pages > 1 && <Paginate count={pages} active={activePage} urlF={(i) => `/cube/blog/${cube._id}/${i}`} />}
         {posts.length > 0 ? (
-          posts.map((post) => <BlogPost key={post._id} post={post} onEdit={handleEdit} />)
+          posts.map((post) => <BlogPost key={post._id} post={post} />)
         ) : (
           <h5>No blog posts for this cube.</h5>
         )}
         {pages > 1 && <Paginate count={pages} active={activePage} urlF={(i) => `/cube/blog/${cube._id}/${i}`} />}
-        <EditBlogModal
-          isOpen={editOpen}
-          toggle={toggleEdit}
-          post={posts[editPostIndex]}
-          markdown={editMarkdown}
-          setMarkdown={setEditMarkdown}
-        />
+        <EditBlogModal toggle={() => setNewEditOpen((open) => !open)} isOpen={isNewEditOpen} />
       </CubeLayout>
     </MainLayout>
   );

--- a/src/pages/CubeOverviewPage.js
+++ b/src/pages/CubeOverviewPage.js
@@ -289,7 +289,7 @@ const CubeOverview = ({ post, priceOwned, pricePurchase, cube, followed, followe
             </Card>
           </Col>
         </Row>
-        <div className="mb-3">{post && <BlogPost key={post._id} post={post} loggedIn={user !== null} />}</div>
+        <div className="mb-3">{post && <BlogPost key={post._id} post={post} />}</div>
       </CubeLayout>
     </MainLayout>
   );

--- a/src/pages/UserBlogPage.js
+++ b/src/pages/UserBlogPage.js
@@ -19,7 +19,7 @@ const UserBlogPage = ({ followers, following, posts, owner, loginCallback, pages
         <Paginate count={pages} active={parseInt(activePage, 10)} urlF={(i) => `/user/blog/${owner._id}/${i}`} />
       )}
       {posts.length > 0 ? (
-        posts.slice(0).map((post) => <BlogPost key={post._id} post={post} loggedIn />)
+        posts.slice(0).map((post) => <BlogPost key={post._id} post={post} />)
       ) : (
         <p>This user has no blog posts!</p>
       )}


### PR DESCRIPTION
### Issue
Currently, blog posts shown to their owner always show a context menu with, among other things, an `Edit` button. However, aside from the Blog tab on that post's cube, no `onclick` handler was being set for those buttons, meaning it wasn't doing anything in those places, creating confusion.

### Solution (and some other changes)
- moved `EditBlogModal` from `CubeBlogPage.js` into a separate component
- have `BlogPost` manage its own edit modal internally, rather than relying on its caller
- removed `markdown` and `setMarkdown` props from `EditBlogModal`, since the initial value is encapsulated in `post` and no one else should care about the temp value being edited
- removed `onEdit` prop from `BlogPost`, because it's a big boy and can open up its edit modal on its own
- cleaned up some unused parameters included in component calls
- set minimum length on post title so people don't keep losing their posts because of us being bad at UX design
- added some margin below the title input so it isn't smothered by the body label

### Screenshot
The only visual change in this PR is the added margin between title and body
![editmodal](https://user-images.githubusercontent.com/38463785/123627548-adf4ca80-d801-11eb-8595-1304124e5e7b.png)

### Additional notes
- This change means that a separate (hidden) modal is rendered for every shown post instead of only one modal per page. I don't think this will noticeably impact performance, since a) the modal is only rendered for editable posts, b) you won't ever have more than 30 editable posts on the same page (the only non-paginated place for posts is the feed, where nothing you see is editable by you), and c) the modal is a reasonably light component.
- On submission, the page always redirects to the appropriate cube's `Blog` tab, regardless of where the form was submitted from. We could devise some system of passing URLs into the modal and then redirecting based on that, but even if we did actually want to have that behavior (which I'm not sure about), the added complexity didn't feel worth delaying this PR for.
- A possible alternative would be to keep the current code and simply remove the ability to edit from all other pages. I don't like that alternative.