### PR TITLE
QR code update

### DIFF
--- a/src/components/QRCodeModal.js
+++ b/src/components/QRCodeModal.js
@@ -5,18 +5,31 @@ import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from 'reactstrap';
 
 import QRCode from 'react-qr-code';
 
+const saveAsPng = (cubeName) => {
+  const svg = document.getElementById('qr-code');
+  const a = document.createElement('a');
+
+  const data = new XMLSerializer().serializeToString(svg);
+  const svgBlob = new Blob([data], { type: 'image/svg+xml' });
+  a.href = window.URL.createObjectURL(svgBlob);
+  a.download = `${cubeName}.svg`;
+  a.click();
+};
+
 const QRCodeModal = ({ isOpen, toggle, link, title }) => (
   <Modal size="md" isOpen={isOpen} toggle={toggle}>
     <ModalHeader toggle={toggle}>{title}</ModalHeader>
     <ModalBody>
       <div className="centered">
         <div className="p-3 qr-code-area">
-          <QRCode value={link} />
+          <QRCode id="qr-code" value={link} />
         </div>
       </div>
     </ModalBody>
     <ModalFooter>
-      <Button color="success">Download</Button>
+      <Button color="success" onClick={() => saveAsPng('qr-code')}>
+        Download
+      </Button>
       <Button color="secondary" onClick={toggle}>
         Close
       </Button>

--- a/src/components/QRCodeModal.js
+++ b/src/components/QRCodeModal.js
@@ -5,20 +5,20 @@ import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from 'reactstrap';
 
 import QRCode from 'react-qr-code';
 
-const saveAsPng = (cubeName) => {
+const saveQRImage = (cubeName) => {
   const svg = document.getElementById('qr-code');
-  const a = document.createElement('a');
-
   const data = new XMLSerializer().serializeToString(svg);
   const svgBlob = new Blob([data], { type: 'image/svg+xml' });
+
+  const a = document.createElement('a');
   a.href = window.URL.createObjectURL(svgBlob);
-  a.download = `${cubeName}.svg`;
+  a.download = `QR-${cubeName.replace(/\s/g, '_')}.svg`;
   a.click();
 };
 
-const QRCodeModal = ({ isOpen, toggle, link, title }) => (
+const QRCodeModal = ({ isOpen, toggle, link, cubeName }) => (
   <Modal size="md" isOpen={isOpen} toggle={toggle}>
-    <ModalHeader toggle={toggle}>{title}</ModalHeader>
+    <ModalHeader toggle={toggle}>Link to {cubeName}</ModalHeader>
     <ModalBody>
       <div className="centered">
         <div className="p-3 qr-code-area">
@@ -27,7 +27,7 @@ const QRCodeModal = ({ isOpen, toggle, link, title }) => (
       </div>
     </ModalBody>
     <ModalFooter>
-      <Button color="success" onClick={() => saveAsPng('qr-code')}>
+      <Button color="success" onClick={() => saveQRImage(cubeName)}>
         Download
       </Button>
       <Button color="secondary" onClick={toggle}>
@@ -41,7 +41,7 @@ QRCodeModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   toggle: PropTypes.func.isRequired,
   link: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired,
+  cubeName: PropTypes.string.isRequired,
 };
 
 export default QRCodeModal;

--- a/src/components/QRCodeModal.js
+++ b/src/components/QRCodeModal.js
@@ -1,18 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Modal, ModalBody, ModalHeader } from 'reactstrap';
+import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from 'reactstrap';
 
 import QRCode from 'react-qr-code';
 
 const QRCodeModal = ({ isOpen, toggle, link, title }) => (
   <Modal size="md" isOpen={isOpen} toggle={toggle}>
     <ModalHeader toggle={toggle}>{title}</ModalHeader>
-    <ModalBody className="qr-code-area">
+    <ModalBody>
       <div className="centered">
-        <QRCode value={link} />
+        <div className="p-3 qr-code-area">
+          <QRCode value={link} />
+        </div>
       </div>
     </ModalBody>
+    <ModalFooter>
+      <Button color="success">Download</Button>
+      <Button color="secondary" onClick={toggle}>
+        Close
+      </Button>
+    </ModalFooter>
   </Modal>
 );
 

--- a/src/pages/CubeOverviewPage.js
+++ b/src/pages/CubeOverviewPage.js
@@ -208,7 +208,7 @@ const CubeOverview = ({ post, priceOwned, pricePurchase, cube, followed, followe
                   • <a href={`/cube/rss/${cubeState._id}`}>RSS</a> •{' '}
                   <QRCodeModalLink
                     href="#"
-                    modalProps={{ link: `https://cubecobra.com/c/${cube._id}`, title: `Link to ${cube.name}` }}
+                    modalProps={{ link: `https://cubecobra.com/c/${cube._id}`, cubeName: cube.name }}
                   >
                     QR Code
                   </QRCodeModalLink>

--- a/src/pages/CubeOverviewPage.js
+++ b/src/pages/CubeOverviewPage.js
@@ -19,7 +19,7 @@ import {
   UncontrolledCollapse,
 } from 'reactstrap';
 
-import { LinkExternalIcon, QuestionIcon, ShareAndroidIcon } from '@primer/octicons-react';
+import { LinkExternalIcon, QuestionIcon } from '@primer/octicons-react';
 
 import { csrfFetch } from 'utils/CSRF';
 import { getCubeId, getCubeDescription } from 'utils/Util';
@@ -156,14 +156,6 @@ const CubeOverview = ({ post, priceOwned, pricePurchase, cube, followed, followe
                   <Col>
                     <h3>{cubeState.name}</h3>
                   </Col>
-                  <div className="float-right" style={{ paddingTop: 3, marginRight: '0.25rem' }}>
-                    <QRCodeModalLink
-                      href="#"
-                      modalProps={{ link: `https://cubecobra.com/c/${cube._id}`, title: `Link to ${cube.name}` }}
-                    >
-                      QR Code <ShareAndroidIcon size={16} />
-                    </QRCodeModalLink>
-                  </div>
                 </Row>
                 <Row>
                   <Col>
@@ -213,7 +205,13 @@ const CubeOverview = ({ post, priceOwned, pricePurchase, cube, followed, followe
                     Designed by
                     <a href={`/user/view/${cubeState.owner}`}> {cubeState.owner_name}</a>
                   </i>{' '}
-                  • <a href={`/cube/rss/${cubeState._id}`}>RSS</a>
+                  • <a href={`/cube/rss/${cubeState._id}`}>RSS</a> •{' '}
+                  <QRCodeModalLink
+                    href="#"
+                    modalProps={{ link: `https://cubecobra.com/c/${cube._id}`, title: `Link to ${cube.name}` }}
+                  >
+                    QR Code
+                  </QRCodeModalLink>
                 </h6>
                 <p>
                   <a href={`https://luckypaper.co/resources/cube-map/?cube=${cubeState._id}`}>


### PR DESCRIPTION
This PR implements changes to the QR code modal that I mentioned in #2116. In particular,
- the modal has a footer with a Close button and a Download button that lets you save the svg,
- the link was moved from the top to below the picture alongside the other links,
- modal background in dark mode was adjusted,
- the share icon was removed from the link, as it now clashed visually with the surrounding elements.

### Screenshots
#### Desktop
![qr-modal](https://user-images.githubusercontent.com/38463785/123801762-1a42fd00-d8da-11eb-9e63-e5f05b9f41f4.png)
![qr-modal-light](https://user-images.githubusercontent.com/38463785/123801770-1c0cc080-d8da-11eb-8307-d38f3d4ac3fe.png)
![qr-overview](https://user-images.githubusercontent.com/38463785/123801777-1dd68400-d8da-11eb-9ab6-d3cd42e735d4.png)
#### Mobile
![qr-modal-m](https://user-images.githubusercontent.com/38463785/123801774-1ca55700-d8da-11eb-9a6d-0579947f8744.png)
![qr-over-m](https://user-images.githubusercontent.com/38463785/123801776-1d3ded80-d8da-11eb-82c2-d98e9181272c.png)

