### PR TITLE
Ensure ads are only loaded once per page

### DIFF
--- a/src/components/Advertisment.js
+++ b/src/components/Advertisment.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useContext } from 'react';
+import React, { useEffect, useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import AdsContext from 'contexts/AdsContext';
@@ -40,9 +40,11 @@ const Advertisment = ({
   railCollisionWhitelist,
 }) => {
   const adsEnabled = useContext(AdsContext);
+  const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
-    if (window.nitroAds) {
+    if (!loaded && window.nitroAds) {
+      setLoaded(true);
       if (format === 'sticky-stack') {
         window.nitroAds.createAd(placementId, {
           format,
@@ -109,7 +111,26 @@ const Advertisment = ({
         });
       }
     }
-  });
+  }, [
+    loaded,
+    format,
+    placementId,
+    adsEnabled,
+    refreshLimit,
+    refreshTime,
+    media,
+    size,
+    enabled,
+    wording,
+    position,
+    stickyStackLimit,
+    stickyStackSpace,
+    stickyStackOffset,
+    rail,
+    railOffsetTop,
+    railOffsetBottom,
+    railCollisionWhitelist,
+  ]);
 
   return <div className="advertisement-div" id={placementId} />;
 };


### PR DESCRIPTION
Issue: Some component updates would cause the `useEffect` hook of the nitropay ads to re-initialize the ads. This is unintended, and can lead to laggy and buggy behavior.

Fix: Add a flag that ensure the ad component only gets initialized once