### PR TITLE
Created useMount hook

### DIFF
--- a/src/components/Advertisment.js
+++ b/src/components/Advertisment.js
@@ -1,7 +1,8 @@
-import React, { useEffect, useContext } from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 
 import AdsContext from 'contexts/AdsContext';
+import useMount from 'hooks/UseMount';
 
 const mediaTypes = {
   desktop: '(min-width: 1025px)',
@@ -41,7 +42,7 @@ const Advertisment = ({
 }) => {
   const adsEnabled = useContext(AdsContext);
 
-  useEffect(() => {
+  useMount(() => {
     if (window.nitroAds) {
       if (format === 'sticky-stack') {
         window.nitroAds.createAd(placementId, {

--- a/src/hooks/UseMount.js
+++ b/src/hooks/UseMount.js
@@ -1,0 +1,7 @@
+import { useEffect } from 'react';
+
+// hook that will run only when a component is mounted, and not after subsequent re-renders
+// eslint-disable-next-line react-hooks/exhaustive-deps
+const useMount = (fun) => useEffect(fun, []);
+
+export default useMount;


### PR DESCRIPTION
Replaces #2134. 

This PR creates a hook that serves as an equivalent to `componentDidMount` for purely functional components. It also applies the hook to the `Advertisment` component, making sure that the Nitro ad-loading code is only executed once per page.