### PR TITLE
Added noscript tag

### DIFF
--- a/views/main.pug
+++ b/views/main.pug
@@ -50,6 +50,9 @@ html(lang='en')
 				#autocardTags.row.no-gutters.p-1
 		include dynamic_flash
 		#react-root !{reactHTML}
+		noscript
+			div.centered
+				p.mt-3.mx-2 Cube Cobra requires javascript to work. To use the site, please enable javascript in your browser.
 		
 		if node_env === 'production'
 			script(src='https://code.jquery.com/jquery-3.4.1.slim.min.js', integrity='sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n', crossorigin='anonymous')


### PR DESCRIPTION
This PR adds a `<noscript>` tag to the main view that shows a message to users with JavaScript disabled instead of just an empty screen.

#### Desktop
![noscript](https://user-images.githubusercontent.com/38463785/124182206-1532a900-daa6-11eb-936b-303e694cf8ba.png)
#### Mobile
![noscript-m](https://user-images.githubusercontent.com/38463785/124182209-1663d600-daa6-11eb-8223-d991ff166a7e.png)
