### PR TITLE
Fix CSRF protection on tools routes

### DIFF
--- a/routes/tools_routes.js
+++ b/routes/tools_routes.js
@@ -12,7 +12,7 @@ const { makeFilter, filterCardsDetails } = require('../dist/filtering/FilterCard
 const generateMeta = require('../serverjs/meta.js');
 const util = require('../serverjs/util.js');
 const { render } = require('../serverjs/render');
-const { ensureAuth } = require('./middleware');
+const { ensureAuth, csrfProtection } = require('./middleware');
 
 const CardHistory = require('../models/cardHistory');
 const Cube = require('../models/cube');
@@ -21,6 +21,8 @@ const Blog = require('../models/blog');
 const { buildIdQuery } = require('../serverjs/cubefn.js');
 
 const router = express.Router();
+
+router.use(csrfProtection);
 
 /* Minimum number of picks for data to show up in Top Cards list. */
 const MIN_PICKS = 100;


### PR DESCRIPTION
Fixes #2138

Tools routes was missing CSRF protection

This didn't matter for a tools page calling API routes for a tools route, but it did break tools pages calling API routes on CSRF protected non-tools routes, like a card page calling the add to cube API.