### PR TITLE
Accept "TRUE" for maybeboard to support Excel edit

### DIFF
--- a/serverjs/cubefn.js
+++ b/serverjs/cubefn.js
@@ -283,7 +283,7 @@ function CSVtoCards(csvString, carddb) {
         const nonPromo = potentialIds.find(carddb.reasonableId);
         const first = potentialIds[0];
         card.cardID = matchingSetAndNumber || matchingSet || nonPromo || first;
-        if (maybeboard === 'true') {
+        if (maybeboard.toLowerCase() === 'true') {
           newMaybe.push(card);
         } else {
           newCards.push(card);


### PR DESCRIPTION
If you open a .csv file in Excel, it turns cells with "true" into "TRUE".

This led to the issue that if you did an export->edit->import, all your maybeboard cards would be moved to the actual cube. 

Parsing "true" in any capitalization solves this issue. 