### PR TITLE
Fix +2 mace breaking filters

### DIFF
--- a/src/filtering/FuncOperations.js
+++ b/src/filtering/FuncOperations.js
@@ -67,7 +67,7 @@ export const nameStringOperation = (op, value) => {
   const strOp = stringOperation(op, value);
   return (fieldValue, card) => {
     let expandedValue = fieldValue
-      .replace(new RegExp(card.details.name, 'g'), NAME_PLACEHOLDER)
+      .replace(new RegExp(card.details.name.replace('+', '\\+'), 'g'), NAME_PLACEHOLDER)
       .replace(NAME_ALIAS, NAME_PLACEHOLDER);
     const shorthand = getShorthand(card.details);
     if (shorthand) {

--- a/src/filtering/FuncOperations.js
+++ b/src/filtering/FuncOperations.js
@@ -67,7 +67,7 @@ export const nameStringOperation = (op, value) => {
   const strOp = stringOperation(op, value);
   return (fieldValue, card) => {
     let expandedValue = fieldValue
-      .replace(new RegExp(card.details.name.replace('+', '\\+'), 'g'), NAME_PLACEHOLDER)
+      .replace(new RegExp(card.details.name.replace(/+/g, '\\+'), 'g'), NAME_PLACEHOLDER)
       .replace(NAME_ALIAS, NAME_PLACEHOLDER);
     const shorthand = getShorthand(card.details);
     if (shorthand) {

--- a/src/filtering/FuncOperations.js
+++ b/src/filtering/FuncOperations.js
@@ -67,7 +67,7 @@ export const nameStringOperation = (op, value) => {
   const strOp = stringOperation(op, value);
   return (fieldValue, card) => {
     let expandedValue = fieldValue
-      .replace(new RegExp(card.details.name.replace(/+/g, '\\+'), 'g'), NAME_PLACEHOLDER)
+      .replace(new RegExp(card.details.name.replace(/\+/g, '\\+'), 'g'), NAME_PLACEHOLDER)
       .replace(NAME_ALIAS, NAME_PLACEHOLDER);
     const shorthand = getShorthand(card.details);
     if (shorthand) {


### PR DESCRIPTION
The problem: using filters when +2 mace is in the available pool causes the parser to crash.

The cause: when replacing the name in the oracle text with a placeholder, we treat the name as a regular expression, where `+` has special meaning

The solution: Treat any `+`'s in card names as string literals