### PR TITLE
Bulk Upload fix

### DIFF
--- a/__tests__/serverjs/cubefn.test.js
+++ b/__tests__/serverjs/cubefn.test.js
@@ -212,7 +212,7 @@ describe('CSVtoCards', () => {
     expectSame(newCards[0], expectedCard);
     expect(newMaybe.length).toBe(1);
     expectSame(newMaybe[0], expectedMaybe);
-    expect(missing).toBe('');
+    expect(missing).toEqual([]);
   });
 });
 

--- a/routes/cube/helper.js
+++ b/routes/cube/helper.js
@@ -75,7 +75,7 @@ async function updateCubeAndBlog(req, res, cube, changelog, added, missing) {
 
 async function bulkUpload(req, res, list, cube) {
   const lines = list.match(/[^\r\n]+/g);
-  let missing = '';
+  let missing = [];
   const added = [];
   let changelog = '';
   if (lines) {
@@ -125,7 +125,7 @@ async function bulkUpload(req, res, list, cube) {
             changelog += addCardHtml(details);
           }
         } else {
-          missing += `${item}\n`;
+          missing.push(item);
         }
       }
     }

--- a/routes/cube/index.js
+++ b/routes/cube/index.js
@@ -849,7 +849,7 @@ router.post('/importcubetutor/:id', ensureAuth, body('cubeid').toInt(), flashVal
     });
 
     const added = [];
-    let missing = '';
+    const missing = [];
     let changelog = '';
     for (const card of cards) {
       const potentialIds = carddb.allVersions(card);
@@ -863,10 +863,10 @@ router.post('/importcubetutor/:id', ensureAuth, body('cubeid').toInt(), flashVal
           util.addCardToCube(cube, details, card.tags);
           changelog += addCardHtml(details);
         } else {
-          missing += `${card.name}\n`;
+          missing.push(card.name);
         }
       } else {
-        missing += `${card.name}\n`;
+        missing.push(card.name);
       }
     }
 
@@ -942,7 +942,7 @@ router.post('/bulkreplacefile/:id', ensureAuth, async (req, res) => {
     const lines = items.match(/[^\r\n]+/g);
     if (lines) {
       let changelog = '';
-      let missing = '';
+      let missing = [];
       const added = [];
       let newCards = [];
       let newMaybe = [];

--- a/serverjs/cubefn.js
+++ b/serverjs/cubefn.js
@@ -231,7 +231,7 @@ async function getCardElo(cardname, round) {
 function CSVtoCards(csvString, carddb) {
   let { data } = Papa.parse(csvString.trim(), { header: true });
   data = data.map((row) => Object.fromEntries(Object.entries(row).map(([key, value]) => [key.toLowerCase(), value])));
-  let missing = '';
+  const missing = [];
   const newCards = [];
   const newMaybe = [];
   for (const {
@@ -289,7 +289,7 @@ function CSVtoCards(csvString, carddb) {
           newCards.push(card);
         }
       } else {
-        missing += `${card.name}\n`;
+        missing.push(card.name);
       }
     }
   }

--- a/src/pages/BulkUploadPage.js
+++ b/src/pages/BulkUploadPage.js
@@ -105,7 +105,7 @@ const BulkUploadPageRaw = ({ cubeID, missing, blogpost, cube }) => {
 
 BulkUploadPageRaw.propTypes = {
   cubeID: PropTypes.string.isRequired,
-  missing: PropTypes.string.isRequired,
+  missing: PropTypes.arrayOf(PropTypes.string).isRequired,
   blogpost: PropTypes.shape({
     title: PropTypes.string.isRequired,
     html: PropTypes.string.isRequired,

--- a/src/pages/BulkUploadPage.js
+++ b/src/pages/BulkUploadPage.js
@@ -60,7 +60,7 @@ const BulkUploadPageRaw = ({ cubeID, missing, blogpost, cube }) => {
           </p>
           <Row>
             <Col>
-              {missing.split('\n').map((card, index) => (
+              {missing.map((card, index) => (
                 <Fragment key={/* eslint-disable-line react/no-array-index-key */ index}>
                   {card}
                   <br />


### PR DESCRIPTION
Fixes #2145 (along with #2147).

The current logic for parsing bulk upload TXT files is some wild stuff. This PR rewrites it to simplify things and fix some issues. For instance, instead of pushing objects into an array we're currently iterating through (which is a no-no) and then doing some weird shenanigans to determine card counts and set codes, the code now does only one pass through the input list, splits it with a single regex, then chooses the appropriate version. Just be glad no one tried to bulk upload "Borrowing 100,000 Arrows" before now.

Aside from bugfixes, the only functional changes in this PR are that set codes now ignore case, and that missing cards are displayed as the whole line, instead of weirdly split. I also changed `missing` to be an array instead of a string, since we were stringifying elements into it only to split them again on render.
