### PR TITLE
Patreon API null guard

### DIFF
--- a/routes/patreon_routes.js
+++ b/routes/patreon_routes.js
@@ -175,7 +175,7 @@ router.get('/redirect', ensureAuth, (req, res) => {
         return res.redirect('/user/account?nav=patreon');
       }
 
-      if (!pledges[0].relationships.reward) {
+      if (!pledges[0].relationships.reward || !pledges[0].relationships.reward.data) {
         newPatron.level = 'Patron';
       } else {
         const rewardId = pledges[0].relationships.reward.data.id;
@@ -208,7 +208,13 @@ router.get('/redirect', ensureAuth, (req, res) => {
       user.patron = newPatron._id;
       await user.save();
 
-      req.flash('success', `Your Patreon account has succesfully been linked.`);
+      if (newPatron.level === 'Patron') {
+        req.flash(
+          'warning',
+          "Your pledge isn't tied to any support tiers. Please choose an eligible tier on Patreon to get access to all your rewards.",
+        );
+      }
+      req.flash('success', `Your Patreon account has successfully been linked.`);
       return res.redirect('/user/account?nav=patreon');
     })
     .catch((err) => {

--- a/routes/patreon_routes.js
+++ b/routes/patreon_routes.js
@@ -211,7 +211,7 @@ router.get('/redirect', ensureAuth, (req, res) => {
       if (newPatron.level === 'Patron') {
         req.flash(
           'warning',
-          "Your pledge isn't tied to any support tiers. Please choose an eligible tier on Patreon to get access to all your rewards.",
+          "Your pledge isn't tied to any support tiers. Choose an eligible tier on Patreon to get access to all your rewards.",
         );
       }
       req.flash('success', `Your Patreon account has successfully been linked.`);


### PR DESCRIPTION
A user reported getting a `Cannot read property 'id' of null` when linking their patreon account. This was caused by them not having selected a reward tier on Patreon ("My Patreon subscription was older than the tiers so I guess I never had a tier selected"). Selecting the appropriate tier fixed the issue.

The only way I can see that error happening is if Patreon somehow returns a `reward` object that has no `data` property. Since Patreon's API is certifiably terrible, I don't know how or when that happens, so I just included that check in the guard so we don't get these exceptions. I also added a message for users linking without a selected tier (and fixed a typo).