### PR TITLE
Import fix

### DIFF
--- a/models/migrations/draftMigrations.js
+++ b/models/migrations/draftMigrations.js
@@ -2,7 +2,7 @@ const { cleanCards } = require('./cleanCards');
 const Cube = require('../cube');
 const { addBasics, createPool } = require('../../routes/cube/helper');
 const { flatten, mapNonNull, toNonNullArray } = require('../../serverjs/util');
-const { cardsAreEquivalent } = require('../../src/utils/Card');
+const { cardsAreEquivalent } = require('../../dist/utils/Card');
 
 const dedupeCardObjects = async (draft) => {
   if (!draft) return null;

--- a/models/migrations/gridDraftMigrations.js
+++ b/models/migrations/gridDraftMigrations.js
@@ -2,7 +2,7 @@ const Cube = require('../cube');
 const { addBasics, createPool } = require('../../routes/cube/helper');
 const { flatten, mapNonNull } = require('../../serverjs/util');
 const { cleanCards } = require('./cleanCards');
-const { cardsAreEquivalent } = require('../../src/utils/Card');
+const { cardsAreEquivalent } = require('../../dist/utils/Card');
 
 const dedupeCardObjects = async (gridDraft) => {
   if (!gridDraft) return null;


### PR DESCRIPTION
#2151 introduced an import into the migration scripts that loaded a non-babelized file from `src`, which crashed the server on start. This PR redirects that import into the translated file in `dist` instead.