### PR TITLE
Adding firstprint option to "is:" filter

### DIFF
--- a/nearley/cardFilters.ne
+++ b/nearley/cardFilters.ne
@@ -177,7 +177,7 @@ notCondition -> "not"i isOpValue {% ([, valuePred]) => negated(genericCondition(
 isOpValue -> ":" isValue {% ([, category]) => CARD_CATEGORY_DETECTORS[category] %}
 
 isValue -> (
-    "gold"i | "twobrid"i | "hybrid"i | "phyrexian"i | "promo"i | "reprint"i | "digital"i | "reasonable"i | "dfc"i | "mdfc"i |"tdfc"i
+    "gold"i | "twobrid"i | "hybrid"i | "phyrexian"i | "promo"i | "reprint"i | "firstprint"i | "digital"i | "reasonable"i | "dfc"i | "mdfc"i |"tdfc"i
   | "meld"i | "transform"i | "split"i | "flip"i | "leveler"i | "commander"i | "spell"i | "permanent"i | "historic"i
   | "vanilla"i | "modal"i | "fullart"i | "foil"i | "nonfoil"i
   | "bikeland"i | "cycleland"i | "bicycleland"i | "bounceland"i | "karoo"i | "canopyland"i | "canland"i | "fetchland"i

--- a/nearley/cardFilters.ne
+++ b/nearley/cardFilters.ne
@@ -177,7 +177,8 @@ notCondition -> "not"i isOpValue {% ([, valuePred]) => negated(genericCondition(
 isOpValue -> ":" isValue {% ([, category]) => CARD_CATEGORY_DETECTORS[category] %}
 
 isValue -> (
-    "gold"i | "twobrid"i | "hybrid"i | "phyrexian"i | "promo"i | "reprint"i | "firstprint"i | "digital"i | "reasonable"i | "dfc"i | "mdfc"i |"tdfc"i
+    "gold"i | "twobrid"i | "hybrid"i | "phyrexian"i | "promo"i | "reprint"i | "firstprint"i | "firstprinting"i | "digital"i | "reasonable"i 
+  | "dfc"i | "mdfc"i |"tdfc"i
   | "meld"i | "transform"i | "split"i | "flip"i | "leveler"i | "commander"i | "spell"i | "permanent"i | "historic"i
   | "vanilla"i | "modal"i | "fullart"i | "foil"i | "nonfoil"i
   | "bikeland"i | "cycleland"i | "bicycleland"i | "bounceland"i | "karoo"i | "canopyland"i | "canland"i | "fetchland"i

--- a/src/utils/Card.js
+++ b/src/utils/Card.js
@@ -221,6 +221,7 @@ export const CARD_CATEGORY_DETECTORS = {
   phyrexian: (details) => details.parsed_cost.some((symbol) => symbol.includes('-p')),
   promo: (details) => details.promo,
   reprint: (details) => details.reprint,
+  firstprint: (details) => !details.reprint,
   digital: (details) => details.digital,
   reasonable: (details) =>
     !details.promo &&
@@ -279,7 +280,7 @@ export const CARD_CATEGORY_DETECTORS = {
   battleland: (details) => LandCategories.TANGO.includes(details.name),
 
   // Others from Scryfall:
-  //   reserved, firstprint, new, old, hires,
+  //   reserved, new, old, hires,
   //   spotlight, unique, masterpiece,
   //   funny,
   //   booster, datestamped, prerelease, planeswalker_deck,

--- a/src/utils/Card.js
+++ b/src/utils/Card.js
@@ -222,6 +222,7 @@ export const CARD_CATEGORY_DETECTORS = {
   promo: (details) => details.promo,
   reprint: (details) => details.reprint,
   firstprint: (details) => !details.reprint,
+  firstprinting: (details) => !details.reprint,
   digital: (details) => details.digital,
   reasonable: (details) =>
     !details.promo &&


### PR DESCRIPTION
Small update to #1706, giving a different filter option that scryfall supports.