### PR TITLE
Fixing URL link formats

### DIFF
--- a/src/components/CubeSearchNavBar.js
+++ b/src/components/CubeSearchNavBar.js
@@ -105,7 +105,7 @@ const AdvancedSearchModal = ({ isOpen, toggle }) => {
     }
 
     if (queryText.length > 0) {
-      window.location.href = `/search/${queryText.trim()}/0`;
+      window.location.href = `/search/${encodeURIComponent(queryText.trim())}/0`;
     } else {
       window.location.href = '/search';
     }
@@ -213,7 +213,7 @@ const CubeSearchNavBar = ({ query, order, title }) => {
   const handleSubmit = (event) => {
     event.preventDefault();
     if (queryText && queryText.length > 0) {
-      window.location.href = `/search/${queryText}/0?order=${searchOrder}`;
+      window.location.href = `/search/${encodeURIComponent(queryText)}/0?order=${searchOrder}`;
     } else {
       window.location.href = `/search`;
     }

--- a/src/pages/CardPage.js
+++ b/src/pages/CardPage.js
@@ -44,7 +44,13 @@ import RenderToRoot from 'utils/RenderToRoot';
 import Tab from 'components/Tab';
 
 import { cardPrice, cardFoilPrice, cardPriceEur, cardTix, cardElo, cardPopularity, cardCubeCount } from 'utils/Card';
-import { getTCGLink, getCardMarketLink, getCardHoarderLink, getCardKingdomLink } from 'utils/Affiliate';
+import {
+  getTCGLink,
+  getCardMarketLink,
+  getCardHoarderLink,
+  getCardKingdomLink,
+  nameToDashedUrlComponent,
+} from 'utils/Affiliate';
 import { ArrowSwitchIcon, CheckIcon, ClippyIcon } from '@primer/octicons-react';
 
 const AutocardA = withAutocard('a');
@@ -523,7 +529,7 @@ const CardPage = ({ card, data, versions, related, loginCallback }) => {
                         outline
                         color="success"
                         block
-                        href={`https://edhrec.com/cards/${card.name}`}
+                        href={`https://edhrec.com/cards/${nameToDashedUrlComponent(card.name)}`}
                         target="_blank"
                       >
                         View on EDHRec

--- a/src/utils/Affiliate.js
+++ b/src/utils/Affiliate.js
@@ -28,6 +28,8 @@ const ck = (str) =>
     .replace(/[:,."']/g, '')
     .toLowerCase();
 
+export const nameToDashedUrlComponent = ck;
+
 export const getCardKingdomLink = (card) =>
   `https://www.cardkingdom.com/mtg/${ck(card.details.set_name)}/${ck(
     card.details.name,


### PR DESCRIPTION
This PR addresses two issues:
1. When searching for cubes, the query sent wasn't properly escaped. This problem was especially apparent for split cards, where using the unescaped `//` separator resulted in a 404 redirect.
2. The links to EDHREC were using an unmodified card name, when the site instead expects a lower-case "dash escaped" version instead. This discrepancy was resolved.