### PR TITLE
Adds 'Add', 'Remove', and Total Size to Edit View

### DIFF
--- a/src/components/EditCollapse.js
+++ b/src/components/EditCollapse.js
@@ -78,6 +78,10 @@ const EditCollapse = ({ ...props }) => {
   const { cube, cubeID } = useContext(CubeContext);
   const { toggleShowMaybeboard } = useContext(DisplayContext);
 
+  const additions = changes.filter((change) => change.add || change.replace).length;
+  const removals = changes.filter((change) => change.remove || change.replace).length;
+  const newTotal = cube.cards.length + additions - removals;
+
   const handleChange = useCallback(
     (event) => {
       return {
@@ -244,7 +248,16 @@ const EditCollapse = ({ ...props }) => {
         <CSRFForm method="POST" action={`/cube/edit/${cubeID}`} onSubmit={handleMentions}>
           <Row>
             <Col>
-              <h6>Changelist</h6>
+              <h6>
+                <Row>
+                  <Col>Changelist</Col>
+                  <Col className="col-sm-auto">
+                    <div className="text-secondary">
+                      +{additions}, -{removals}, {newTotal} Total
+                    </div>
+                  </Col>
+                </Row>
+              </h6>
               <div className="changelist-container mb-2">
                 <Changelist />
               </div>


### PR DESCRIPTION
<img width="708" alt="Screen Shot 2021-08-28 at 1 45 38 PM" src="https://user-images.githubusercontent.com/622613/131226670-72779ce6-bcc7-47f3-baa8-6f5ec949e9c7.png">

Open to any feedback. This space is getting a little complex and this could maybe be more clear. I think it's helpful to have these counts. I usually end up doing some manual counting to make sure I've entered the cards I expected or haven't inadvertently altered the cube size.