### PR TITLE
Send notifications on cube cleanup

### DIFF
--- a/jobs/clear_old_drafts.js
+++ b/jobs/clear_old_drafts.js
@@ -49,7 +49,7 @@ try {
         await Draft.deleteMany({ _id: { $in: toDelete } });
       }
     }
-    mongoose.disconnect();
+    await mongoose.disconnect();
     process.exit(0);
   })();
 } catch (err) {

--- a/jobs/download_cubes.js
+++ b/jobs/download_cubes.js
@@ -82,7 +82,7 @@ try {
 
       console.log(`Finished: ${Math.min(count, i + batchSize)} of ${count} cubes`);
     }
-    mongoose.disconnect();
+    await mongoose.disconnect();
 
     const params = {
       Bucket: 'cubecobra',

--- a/jobs/download_decks.js
+++ b/jobs/download_decks.js
@@ -73,7 +73,7 @@ try {
       await s3.upload(params).promise();
       console.log(`Finished: ${Math.min(count, i + batchSize)} of ${count} decks`);
     }
-    mongoose.disconnect();
+    await mongoose.disconnect();
 
     const params = {
       Bucket: 'cubecobra',

--- a/jobs/download_drafts.js
+++ b/jobs/download_drafts.js
@@ -122,7 +122,7 @@ const writeToS3 = async (fileName, body) => {
       }
       console.log(`Finished: ${Math.min(count, i + batchSize)} of ${count} decks`);
     }
-    mongoose.disconnect();
+    await mongoose.disconnect();
     console.log('done');
     process.exit();
   });

--- a/jobs/populate_analytics.js
+++ b/jobs/populate_analytics.js
@@ -446,7 +446,7 @@ const run = async () => {
     },
   );
 
-  cubeCursor.close();
+  await cubeCursor.close();
   winston.info('Finished: all cubes');
 
   // process all deck objects
@@ -468,7 +468,7 @@ const run = async () => {
     },
   );
 
-  deckCursor.close();
+  await deckCursor.close();
   winston.info('Finished: all decks');
 
   // save card models

--- a/jobs/populate_embeddings.js
+++ b/jobs/populate_embeddings.js
@@ -52,7 +52,7 @@ const updateEmbeddings = async (names, embeddings) => {
       }
     }
 
-    mongoose.disconnect();
+    await mongoose.disconnect();
     console.log('done');
     process.exit();
   });


### PR DESCRIPTION
When a cube is cleaned up through the `clean_cubes` job, invalid cards may end up being removed. If a card in a list is corrupted and subsequently cleaned up this way, it ends up disappearing from the list without a trace or knowledge of the user. This became apparent during a recent issue where Scryfall changed IDs for some of their cards, which ended up corrupting cube lists containing those cards. Owners of these cubes had no way of knowing this occurred unless they noticed something was missing themselves.

This PR creates a notification that's sent to any user whose cube contained invalid cards. While they still won't know which cards were removed due to the fundamental nature of invalid cards, now at least they'll be informed that a change occurred in their list and can go remedy it if necessary.

There are no notifications for non-destructive card alterations, such as fixing an invalid tag or status, as those seem inconsequential enough to warrant them.

The PR also fixes a few inconsistencies in jobs where async functions weren't being awaited.