### PR TITLE
Fix deckdelete owner check

### DIFF
--- a/routes/cube/deck.js
+++ b/routes/cube/deck.js
@@ -302,7 +302,7 @@ router.delete('/deletedeck/:id', ensureAuth, async (req, res) => {
     const deck = await Deck.findById(req.params.id);
     const deckOwner = (await User.findById(deck.seats[0].userid)) || {};
 
-    if (!deckOwner._id.equals(req.user._id) && !deck.cubeOwner === req.user._id) {
+    if (!req.user._id.equals(deckOwner._id) && !req.user._id.equals(deck.cubeOwner)) {
       req.flash('danger', 'Unauthorized');
       return res.redirect('/404');
     }


### PR DESCRIPTION
A user on Discord reported that deleting a deck they didn't draft from a cube they own resulted in a 500 error response. Upon further investigation, I found out that this was caused by the way that the delete route checked for owners.

When an anonymous user drafts the deck, the `deckOwner` variable will be declared as `{}`, and therefore `deckOwner._id` is undefined. Trying to call `.equals` on that undefined value then results in a crash.

The same check contains a second error in the following comparison. Assuming a cube has an owner (which every cube does), `!deck.cubeOwner === req.user._id` is equivalent to `false === req.user._id`. Because an `_id` is an ObjectId object and not a boolean, this strict comparison fails, meaning any logged in user is theoretically able to delete any deck from any cube.

This PR rewrites the check to address those two issues.