### PR TITLE
Fixed "Cannot read 'cards' of null"

### DIFF
--- a/routes/cube/api.js
+++ b/routes/cube/api.js
@@ -452,7 +452,9 @@ router.post('/redraft/:id/:seat', async (req, res) => {
     let eloOverrideDict = {};
     if (cube.useCubeElo) {
       const analytic = await CubeAnalytic.findOne({ cube: cube._id });
-      eloOverrideDict = fromEntries(analytic.cards.map((c) => [c.cardName, c.elo]));
+      if (analytic) {
+        eloOverrideDict = fromEntries(analytic.cards.map((c) => [c.cardName, c.elo]));
+      }
     }
 
     draft = await Draft.findById(draft._id).lean();

--- a/routes/cube/deck.js
+++ b/routes/cube/deck.js
@@ -342,7 +342,9 @@ router.get('/deckbuilder/:id', async (req, res) => {
     let eloOverrideDict = {};
     if (cube.useCubeElo) {
       const analytic = await CubeAnalytic.findOne({ cube: cube._id });
-      eloOverrideDict = util.fromEntries(analytic.cards.map((c) => [c.cardName, c.elo]));
+      if (analytic) {
+        eloOverrideDict = util.fromEntries(analytic.cards.map((c) => [c.cardName, c.elo]));
+      }
     }
 
     // add details to cards
@@ -449,7 +451,9 @@ router.get('/rebuild/:id/:index', ensureAuth, async (req, res) => {
     let eloOverrideDict = {};
     if (cube.useCubeElo) {
       const analytic = await CubeAnalytic.findOne({ cube: cube._id });
-      eloOverrideDict = util.fromEntries(analytic.cards.map((c) => [c.cardName, c.elo]));
+      if (analytic) {
+        eloOverrideDict = util.fromEntries(analytic.cards.map((c) => [c.cardName, c.elo]));
+      }
     }
 
     const cardsArray = [];
@@ -548,7 +552,9 @@ router.post('/editdeck/:id', ensureAuth, async (req, res) => {
     let eloOverrideDict = {};
     if (cube.useCubeElo) {
       const analytic = await CubeAnalytic.findOne({ cube: cube._id });
-      eloOverrideDict = util.fromEntries(analytic.cards.map((c) => [c.cardName, c.elo]));
+      if (analytic) {
+        eloOverrideDict = util.fromEntries(analytic.cards.map((c) => [c.cardName, c.elo]));
+      }
     }
     const cardsArray = [];
     for (const card of deck.toObject().cards) {
@@ -603,7 +609,9 @@ router.post('/submitdeck/:id', body('skipDeckbuilder').toBoolean(), async (req, 
     let eloOverrideDict = {};
     if (cube.useCubeElo) {
       const analytic = await CubeAnalytic.findOne({ cube: cube._id });
-      eloOverrideDict = util.fromEntries(analytic.cards.map((c) => [c.cardName, c.elo]));
+      if (analytic) {
+        eloOverrideDict = util.fromEntries(analytic.cards.map((c) => [c.cardName, c.elo]));
+      }
     }
     const cards = draft.cards.map((c) => {
       const newCard = { ...c, details: carddb.cardFromId(c.cardID) };
@@ -697,7 +705,9 @@ router.post('/submitgriddeck/:id', body('skipDeckbuilder').toBoolean(), async (r
     let eloOverrideDict = {};
     if (cube.useCubeElo) {
       const analytic = await CubeAnalytic.findOne({ cube: cube._id });
-      eloOverrideDict = util.fromEntries(analytic.cards.map((c) => [c.cardName, c.elo]));
+      if (analytic) {
+        eloOverrideDict = util.fromEntries(analytic.cards.map((c) => [c.cardName, c.elo]));
+      }
     }
     const cards = draft.cards.map((c) => {
       const newCard = { ...c, details: carddb.cardFromId(c.cardID) };
@@ -944,7 +954,9 @@ router.get('/:id', async (req, res) => {
     let eloOverrideDict = {};
     if (cube.useCubeElo) {
       const analytic = await CubeAnalytic.findOne({ cube: cube._id });
-      eloOverrideDict = util.fromEntries(analytic.cards.map((c) => [c.cardName, c.elo]));
+      if (analytic) {
+        eloOverrideDict = util.fromEntries(analytic.cards.map((c) => [c.cardName, c.elo]));
+      }
     }
 
     for (const card of deck.cards) {

--- a/routes/cube/index.js
+++ b/routes/cube/index.js
@@ -1309,7 +1309,9 @@ router.get('/griddraft/:id', async (req, res) => {
     let eloOverrideDict = {};
     if (cube.useCubeElo) {
       const analytic = await CubeAnalytic.findOne({ cube: cube._id });
-      eloOverrideDict = fromEntries(analytic.cards.map((c) => [c.cardName, c.elo]));
+      if (analytic) {
+        eloOverrideDict = fromEntries(analytic.cards.map((c) => [c.cardName, c.elo]));
+      }
     }
 
     // insert card details everywhere that needs them
@@ -1367,7 +1369,9 @@ router.get('/draft/:id', async (req, res) => {
     let eloOverrideDict = {};
     if (cube.useCubeElo) {
       const analytic = await CubeAnalytic.findOne({ cube: cube._id });
-      eloOverrideDict = fromEntries(analytic.cards.map((c) => [c.cardName, c.elo]));
+      if (analytic) {
+        eloOverrideDict = fromEntries(analytic.cards.map((c) => [c.cardName, c.elo]));
+      }
     }
 
     // insert card details everywhere that needs them


### PR DESCRIPTION
Fixes #2164.

As #2115 correctly identified, the issue lied in the cube analytics object not existing for new cubes, causing a null reference exception when the first draft was attempted with "Use cube elo" enabled. Unfortunately, there were still other places that loaded the analytics object that #2115 didn't add a guard to, causing this error to persist. This PR guards all the remaining usages so that this cannot happen anymore.