### PR TITLE
Fixing React warnings

### DIFF
--- a/src/components/AddToCubeModal.js
+++ b/src/components/AddToCubeModal.js
@@ -124,9 +124,16 @@ const AddToCubeModal = ({ card, isOpen, toggle, hideAnalytics, cubeContext }) =>
           <InputGroupAddon addonType="prepend">
             <InputGroupText>Cube: </InputGroupText>
           </InputGroupAddon>
-          <CustomInput type="select" value={selectedCube} onChange={(event) => setSelectedCube(event.target.value)}>
+          <CustomInput
+            id="selected-cube-input"
+            type="select"
+            value={selectedCube}
+            onChange={(event) => setSelectedCube(event.target.value)}
+          >
             {cubes.map((cube) => (
-              <option value={cube._id}>{cube.name}</option>
+              <option key={cube._id} value={cube._id}>
+                {cube.name}
+              </option>
             ))}
           </CustomInput>
         </InputGroup>

--- a/src/components/BlogPost.js
+++ b/src/components/BlogPost.js
@@ -91,7 +91,7 @@ const BlogPost = ({ post, noScroll }) => {
 };
 
 BlogPost.propTypes = {
-  post: PropTypes.arrayOf(BlogPostPropType).isRequired,
+  post: BlogPostPropType.isRequired,
   noScroll: PropTypes.bool,
 };
 

--- a/src/components/Comment.js
+++ b/src/components/Comment.js
@@ -148,9 +148,9 @@ const Comment = ({ comment, index, depth, noReplies, editComment }) => {
               )}
             </div>
             <Collapse isOpen={!isEdit}>
-              <p className="mb-0">
+              <div className="mb-0">
                 <Markdown markdown={comment.content} limited />
-              </p>
+              </div>
             </Collapse>
             <CommentEntry
               submit={(res) => {

--- a/src/components/CubeListNavbar.js
+++ b/src/components/CubeListNavbar.js
@@ -457,7 +457,7 @@ const CubeListNavbar = ({
                 <DropdownItem divider />
                 <DropdownItem toggle={false} onClick={() => setIsSortUsed((is) => !is)}>
                   <FormGroup check style={{ display: 'flex' }}>
-                    <Input type="checkbox" checked={isSortUsed} /> Use Sort
+                    <Input type="checkbox" checked={isSortUsed} onChange={() => {}} /> Use Sort
                     <Tooltip text="Order export using current sort options." wrapperTag="span" className="ml-auto mr-0">
                       <QuestionIcon size={16} />
                     </Tooltip>
@@ -465,7 +465,7 @@ const CubeListNavbar = ({
                 </DropdownItem>
                 <DropdownItem toggle={false} onClick={() => setIsFilterUsed((is) => !is)}>
                   <FormGroup check style={{ display: 'flex' }}>
-                    <Input type="checkbox" checked={isFilterUsed} /> Use Filter
+                    <Input type="checkbox" checked={isFilterUsed} onChange={() => {}} /> Use Filter
                     <Tooltip
                       text="Include in export only cards matching current filter."
                       wrapperTag="span"
@@ -521,7 +521,7 @@ CubeListNavbar.propTypes = {
   sorts: PropTypes.arrayOf(PropTypes.string),
   setSorts: PropTypes.func.isRequired,
   defaultSorts: PropTypes.arrayOf(PropTypes.string).isRequired,
-  cubeDefaultShowUnsorted: PropTypes.bool.isRequired,
+  cubeDefaultShowUnsorted: PropTypes.bool,
   defaultFilterText: PropTypes.string.isRequired,
   filter: PropTypes.func,
   setFilter: PropTypes.func.isRequired,
@@ -533,6 +533,7 @@ CubeListNavbar.defaultProps = {
   sorts: null,
   filter: null,
   className: null,
+  cubeDefaultShowUnsorted: false,
 };
 
 export default CubeListNavbar;

--- a/src/components/CubeOverviewModal.js
+++ b/src/components/CubeOverviewModal.js
@@ -211,7 +211,8 @@ class CubeOverviewModal extends Component {
   }
 
   render() {
-    const { cube, cubeID, tags, isOpen } = this.state;
+    const { cube, tags, isOpen } = this.state;
+    const cubeID = getCubeId(cube);
     return (
       <>
         <a className="nav-link" href="#" onClick={this.open}>

--- a/src/components/Feed.js
+++ b/src/components/Feed.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 
 import InfiniteScroll from 'react-infinite-scroll-component';
 
@@ -59,7 +60,7 @@ const Feed = ({ items }) => {
 };
 
 Feed.propTypes = {
-  items: BlogPostPropType.isRequired,
+  items: PropTypes.arrayOf(BlogPostPropType).isRequired,
 };
 
 export default Feed;

--- a/src/components/FilterCollapse.js
+++ b/src/components/FilterCollapse.js
@@ -357,7 +357,9 @@ class FilterCollapse extends Component {
     this.handleApply = this.handleApply.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
     this.handleReset = this.handleReset.bind(this);
+  }
 
+  componentDidMount() {
     if (this.props.defaultFilterText) this.updateFilters();
   }
 

--- a/src/components/FoilOverlay.js
+++ b/src/components/FoilOverlay.js
@@ -1,22 +1,26 @@
 import React from 'react';
 
-const FoilOverlay = (Tag) => (props) => {
-  let finish = 'Non-foil';
-  if (Object.hasOwnProperty.call(props, 'finish')) {
-    finish = props.finish;
-  } else if (Object.hasOwnProperty.call(props, 'card') && Object.hasOwnProperty.call(props.card, 'finish')) {
-    finish = props.card.finish;
-  }
-  return (
-    <div className="position-relative">
-      {finish !== 'Foil' ? (
-        ''
-      ) : (
-        <img src="/content/foilOverlay.png" className="foilOverlay card-border" width="100%" alt="Foil overlay" />
-      )}
-      <Tag {...props} />
-    </div>
-  );
-};
+const FoilOverlay =
+  (Tag) =>
+  ({ wrapperTag, ...props }) => {
+    let finish = 'Non-foil';
+    if (Object.hasOwnProperty.call(props, 'finish')) {
+      finish = props.finish;
+    } else if (Object.hasOwnProperty.call(props, 'card') && Object.hasOwnProperty.call(props.card, 'finish')) {
+      finish = props.card.finish;
+    }
+
+    const WrapperTag = wrapperTag ?? 'div';
+    return (
+      <WrapperTag className="position-relative">
+        {finish !== 'Foil' ? (
+          ''
+        ) : (
+          <img src="/content/foilOverlay.png" className="foilOverlay card-border" width="100%" alt="Foil overlay" />
+        )}
+        <Tag {...props} />
+      </WrapperTag>
+    );
+  };
 
 export default FoilOverlay;

--- a/src/components/LoadingButton.js
+++ b/src/components/LoadingButton.js
@@ -7,6 +7,7 @@ const LoadingButton = ({ onClick, loading, ...props }) => {
 
   const handleClick = useCallback(
     async (event) => {
+      if (!onClick) return;
       setLoading(true);
       await onClick(event);
       setLoading(false);
@@ -26,11 +27,12 @@ const LoadingButton = ({ onClick, loading, ...props }) => {
   );
 };
 LoadingButton.propTypes = {
-  onClick: PropTypes.func.isRequired,
+  onClick: PropTypes.func,
   loading: PropTypes.bool,
 };
 LoadingButton.defaultProps = {
   loading: null,
+  onClick: null,
 };
 
 export default LoadingButton;

--- a/src/components/Markdown.js
+++ b/src/components/Markdown.js
@@ -111,11 +111,11 @@ const renderCardImage = (node) => {
   const idURL = encodeURIComponent(node.id);
   const details = { image_normal: `/tool/cardimage/${idURL}` };
   if (node.dfc) details.image_flip = `/tool/cardimageflip/${idURL}`;
-
+  const tag = node.inParagraph ? 'span' : 'div';
   return (
-    <Col className="card-image" xs="6" md="4" lg="3">
+    <Col className="card-image d-block" xs="6" md="4" lg="3" tag={tag}>
       <a href={`/tool/card/${idURL}`} target="_blank" rel="noopener noreferrer">
-        <FoilCardImage autocard card={{ details }} className="clickable" />
+        <FoilCardImage autocard card={{ details }} className="clickable" wrapperTag={tag} />
       </a>
     </Col>
   );
@@ -123,7 +123,11 @@ const renderCardImage = (node) => {
 
 const renderCentering = (node) => <div className="centered-markdown">{node.children}</div>;
 
-const renderCardrow = (node) => <Row className="cardRow">{node.children}</Row>;
+const renderCardrow = (node) => (
+  <Row className="cardRow" tag={node.inParagraph ? 'span' : 'div'}>
+    {node.children}
+  </Row>
+);
 
 const RENDERERS = {
   // overridden defaults

--- a/src/components/Maybeboard.js
+++ b/src/components/Maybeboard.js
@@ -215,10 +215,10 @@ const Maybeboard = ({ filter, ...props }) => {
           </Row>
         </Form>
       )}
-      {maybeboard.length === 0 ? (
+      {filteredMaybeboard.length === 0 ? (
         <h5 className="mt-3">
           No cards in maybeboard
-          {filter && filter.length > 0 ? ' matching filter.' : '.'}
+          {filter ? ' matching filter.' : '.'}
         </h5>
       ) : (
         <TableView className="mt-3" cards={filteredMaybeboard} rowTag={MaybeboardListItem} noGroupModal {...props} />
@@ -229,7 +229,11 @@ const Maybeboard = ({ filter, ...props }) => {
 };
 
 Maybeboard.propTypes = {
-  filter: PropTypes.arrayOf(PropTypes.array).isRequired,
+  filter: PropTypes.func,
+};
+
+Maybeboard.defaultProps = {
+  filter: null,
 };
 
 export default Maybeboard;

--- a/src/components/TextBadge.js
+++ b/src/components/TextBadge.js
@@ -16,7 +16,7 @@ const TextBadge = ({ name, className, children, fill }) => (
 
 TextBadge.propTypes = {
   name: PropTypes.string,
-  className: PropTypes.string.isRequired,
+  className: PropTypes.string,
   children: PropTypes.node.isRequired,
   fill: PropTypes.bool,
 };
@@ -24,6 +24,7 @@ TextBadge.propTypes = {
 TextBadge.defaultProps = {
   name: 'textBade',
   fill: false,
+  className: undefined,
 };
 
 export default TextBadge;

--- a/src/components/TextField.js
+++ b/src/components/TextField.js
@@ -15,9 +15,13 @@ const TextField = ({ name, humanName, placeholder, value, onChange, ...props }) 
 TextField.propTypes = {
   name: PropTypes.string.isRequired,
   humanName: PropTypes.string.isRequired,
-  placeholder: PropTypes.string.isRequired,
+  placeholder: PropTypes.string,
   value: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
+};
+
+TextField.defaultProps = {
+  placeholder: undefined,
 };
 
 export default TextField;

--- a/src/markdown/cardlink/index.js
+++ b/src/markdown/cardlink/index.js
@@ -3,7 +3,7 @@ import syntax from 'markdown/cardlink/micromark-cardlink';
 import { fromMarkdown } from 'markdown/cardlink/mdast-cardlink';
 import { add } from 'markdown/utils';
 
-function oncard(node) {
+function oncard(node, index, parent) {
   if (node.value[0] === '!') {
     node.value = node.value.substring(1);
     node.type = 'cardimage';
@@ -17,6 +17,10 @@ function oncard(node) {
   if (node.value[0] === '!' && node.type !== 'cardimage') {
     node.value = node.value.substring(1);
     node.type = 'cardimage';
+  }
+
+  if (node.type === 'cardimage' && (parent.type === 'paragraph' || parent.inParagraph)) {
+    node.inParagraph = true;
   }
 
   [node.name, node.id] = node.value.split('|');

--- a/src/markdown/cardrow/index.js
+++ b/src/markdown/cardrow/index.js
@@ -1,11 +1,17 @@
+import visit from 'unist-util-visit';
 import syntax from 'markdown/cardrow/micromark-cardrow';
 import { fromMarkdown } from 'markdown/cardrow/mdast-cardrow';
 import { add } from 'markdown/utils';
+
+function oncardrow(node, index, parent) {
+  node.inParagraph = parent.type === 'paragraph';
+}
 
 function cardrow() {
   const data = this.data();
   add(data, 'micromarkExtensions', syntax);
   add(data, 'fromMarkdownExtensions', fromMarkdown);
+  return (tree) => visit(tree, 'cardrow', oncardrow);
 }
 
 export default cardrow;

--- a/src/pages/CardPage.js
+++ b/src/pages/CardPage.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import CardPricePropType from 'proptypes/CardPricePropType';
-import CardDataPointPropType from 'proptypes/CardDataPointPropType';
+import CardHistoryPropType, { HistoryPropType } from 'proptypes/CardHistoryPropType';
 
 import {
   Card,
@@ -152,7 +152,7 @@ const Graph = ({ data, yFunc, unit, yRange }) => {
 };
 
 Graph.propTypes = {
-  data: PropTypes.arrayOf(CardDataPointPropType).isRequired,
+  data: HistoryPropType.isRequired,
   yFunc: PropTypes.func.isRequired,
   unit: PropTypes.string.isRequired,
   yRange: PropTypes.arrayOf(PropTypes.number),
@@ -357,9 +357,7 @@ const CardPage = ({ card, data, versions, related, loginCallback }) => {
                   <hr />
                   <div className="my-0">
                     {card.oracle_text.split('\n').map((text) => (
-                      <p key={`oracle-text-${text}`}>
-                        <Markdown markdown={text} />
-                      </p>
+                      <Markdown markdown={text} key={text} />
                     ))}
                   </div>
                   <Row>
@@ -746,15 +744,12 @@ CardPage.propTypes = {
     oracle_id: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,
     artist: PropTypes.string.isRequired,
-    loyalty: PropTypes.string.isRequired,
-    power: PropTypes.string.isRequired,
-    toughness: PropTypes.shape({}).isRequired,
+    loyalty: PropTypes.string,
+    power: PropTypes.string,
+    toughness: PropTypes.string,
     prices: CardPricePropType.isRequired,
   }).isRequired,
-  data: PropTypes.shape({
-    history: PropTypes.arrayOf(CardDataPointPropType).isRequired,
-    current: CardDataPointPropType,
-  }).isRequired,
+  data: CardHistoryPropType.isRequired,
   related: PropTypes.shape({
     top: PropTypes.arrayOf(
       PropTypes.shape({

--- a/src/pages/CardSearchPage.js
+++ b/src/pages/CardSearchPage.js
@@ -125,7 +125,12 @@ const CardSearchPage = ({ loginCallback }) => {
               <InputGroupAddon addonType="prepend">
                 <InputGroupText>Sort: </InputGroupText>
               </InputGroupAddon>
-              <CustomInput type="select" value={sort} onChange={(event) => updateSort(event.target.value)}>
+              <CustomInput
+                id="card-sort-input"
+                type="select"
+                value={sort}
+                onChange={(event) => updateSort(event.target.value)}
+              >
                 {ORDERED_SORTS.map((s) => (
                   <option value={s}>{s}</option>
                 ))}
@@ -137,7 +142,12 @@ const CardSearchPage = ({ loginCallback }) => {
               <InputGroupAddon addonType="prepend">
                 <InputGroupText>Direction: </InputGroupText>
               </InputGroupAddon>
-              <CustomInput type="select" value={direction} onChange={(event) => updateDirection(event.target.value)}>
+              <CustomInput
+                id="card-direction-input"
+                type="select"
+                value={direction}
+                onChange={(event) => updateDirection(event.target.value)}
+              >
                 <option value="ascending">Ascending</option>
                 <option value="descending">Descending</option>
               </CustomInput>
@@ -148,7 +158,12 @@ const CardSearchPage = ({ loginCallback }) => {
               <InputGroupAddon addonType="prepend">
                 <InputGroupText>Distinct: </InputGroupText>
               </InputGroupAddon>
-              <CustomInput type="select" value={distinct} onChange={(event) => updateDistinct(event.target.value)}>
+              <CustomInput
+                id="card-distinct-input"
+                type="select"
+                value={distinct}
+                onChange={(event) => updateDistinct(event.target.value)}
+              >
                 <option value="names">Names</option>
                 <option value="printings">Printings</option>
               </CustomInput>

--- a/src/pages/CubeDeckPage.js
+++ b/src/pages/CubeDeckPage.js
@@ -61,7 +61,7 @@ const CubeDeckPage = ({ cube, deck, draft, loginCallback }) => {
   return (
     <MainLayout loginCallback={loginCallback}>
       <CubeLayout cube={cube} activeLink="playtest">
-        <DisplayContextProvider>
+        <DisplayContextProvider cubeID={cube._id}>
           <Navbar expand="md" light className="usercontrols mb-3">
             <div className="view-style-select pr-2">
               <Label className="sr-only" for="viewSelect">

--- a/src/pages/CubeListPage.js
+++ b/src/pages/CubeListPage.js
@@ -25,6 +25,7 @@ import CubeLayout from 'layouts/CubeLayout';
 import MainLayout from 'layouts/MainLayout';
 import RenderToRoot from 'utils/RenderToRoot';
 import useQueryParam from 'hooks/useQueryParam';
+import CardPropType from 'proptypes/CardPropType';
 
 const CubeListPageRaw = ({
   defaultFilterText,
@@ -139,7 +140,7 @@ CubeListPageRaw.propTypes = {
   defaultSecondarySort: PropTypes.string.isRequired,
   defaultTertiarySort: PropTypes.string.isRequired,
   defaultQuaternarySort: PropTypes.string.isRequired,
-  defaultShowUnsorted: PropTypes.bool.isRequired,
+  defaultShowUnsorted: PropTypes.string.isRequired,
 };
 
 const CubeListPage = ({
@@ -172,13 +173,15 @@ const CubeListPage = ({
 
 CubeListPage.propTypes = {
   cube: PropTypes.shape({
-    cards: PropTypes.arrayOf(PropTypes.object).isRequired,
-    tag_colors: PropTypes.shape({
-      tag: PropTypes.string.isRequired,
-      color: PropTypes.oneOf(TAG_COLORS.map(([, c]) => c)),
-    }),
+    cards: PropTypes.arrayOf(CardPropType).isRequired,
+    tag_colors: PropTypes.arrayOf(
+      PropTypes.shape({
+        tag: PropTypes.string.isRequired,
+        color: PropTypes.oneOf(TAG_COLORS.map(([, c]) => c)),
+      }),
+    ),
     default_sorts: PropTypes.arrayOf(PropTypes.string).isRequired,
-    maybe: PropTypes.object.isRequired,
+    maybe: PropTypes.arrayOf(CardPropType).isRequired,
     _id: PropTypes.string.isRequired,
     owner: PropTypes.string.isRequired,
   }).isRequired,
@@ -189,7 +192,7 @@ CubeListPage.propTypes = {
   defaultSecondarySort: PropTypes.string.isRequired,
   defaultTertiarySort: PropTypes.string.isRequired,
   defaultQuaternarySort: PropTypes.string.isRequired,
-  defaultShowUnsorted: PropTypes.bool.isRequired,
+  defaultShowUnsorted: PropTypes.string.isRequired,
   loginCallback: PropTypes.string,
 };
 

--- a/src/proptypes/ArticlePropType.js
+++ b/src/proptypes/ArticlePropType.js
@@ -4,7 +4,7 @@ const ArticlePropType = PropTypes.shape({
   _id: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   body: PropTypes.string.isRequired,
-  date: PropTypes.string.isRequired,
+  date: PropTypes.instanceOf(Date).isRequired,
   owner: PropTypes.string.isRequired,
   username: PropTypes.string.isRequired,
   status: PropTypes.string.isRequired,

--- a/src/proptypes/CardDataPointPropType.js
+++ b/src/proptypes/CardDataPointPropType.js
@@ -3,17 +3,17 @@ import CardPricePropType from 'proptypes/CardPricePropType';
 
 const CardDataPointPropType = PropTypes.shape({
   prices: PropTypes.arrayOf(CardPricePropType).isRequired,
-  vintage: PropTypes.bool.isRequired,
-  legacy: PropTypes.bool.isRequired,
-  modern: PropTypes.bool.isRequired,
-  standard: PropTypes.bool.isRequired,
-  pauper: PropTypes.bool.isRequired,
-  peasant: PropTypes.bool.isRequired,
-  size180: PropTypes.number.isRequired,
-  size360: PropTypes.number.isRequired,
-  size450: PropTypes.number.isRequired,
-  size540: PropTypes.number.isRequired,
-  size720: PropTypes.number.isRequired,
+  vintage: PropTypes.arrayOf(PropTypes.number).isRequired,
+  legacy: PropTypes.arrayOf(PropTypes.number).isRequired,
+  modern: PropTypes.arrayOf(PropTypes.number).isRequired,
+  standard: PropTypes.arrayOf(PropTypes.number).isRequired,
+  pauper: PropTypes.arrayOf(PropTypes.number).isRequired,
+  peasant: PropTypes.arrayOf(PropTypes.number).isRequired,
+  size180: PropTypes.arrayOf(PropTypes.number).isRequired,
+  size360: PropTypes.arrayOf(PropTypes.number).isRequired,
+  size450: PropTypes.arrayOf(PropTypes.number).isRequired,
+  size540: PropTypes.arrayOf(PropTypes.number).isRequired,
+  size720: PropTypes.arrayOf(PropTypes.number).isRequired,
   total: PropTypes.arrayOf(PropTypes.number).isRequired,
 });
 

--- a/src/proptypes/CardHistoryPropType.js
+++ b/src/proptypes/CardHistoryPropType.js
@@ -1,0 +1,26 @@
+import PropTypes from 'prop-types';
+import CardDataPointPropType from 'proptypes/CardDataPointPropType';
+
+export const HistoryPropType = PropTypes.arrayOf(
+  PropTypes.shape({
+    date: PropTypes.string.isRequired,
+    data: CardDataPointPropType.isRequired,
+  }),
+);
+
+const CardHistoryPropType = PropTypes.shape({
+  cardName: PropTypes.string.isRequired,
+  oracleId: PropTypes.string.isRequired,
+  versions: PropTypes.arrayOf(PropTypes.string).isRequired,
+  current: CardDataPointPropType,
+  cubedWith: PropTypes.shape({
+    synergistic: PropTypes.arrayOf(PropTypes.string).isRequired,
+    top: PropTypes.arrayOf(PropTypes.string).isRequired,
+    creatures: PropTypes.arrayOf(PropTypes.string).isRequired,
+    spells: PropTypes.arrayOf(PropTypes.string).isRequired,
+    other: PropTypes.arrayOf(PropTypes.string).isRequired,
+  }),
+  history: HistoryPropType.isRequired,
+});
+
+export default CardHistoryPropType;

--- a/src/proptypes/CubeAnalyticPropType.js
+++ b/src/proptypes/CubeAnalyticPropType.js
@@ -1,22 +1,18 @@
 import PropTypes from 'prop-types';
-import CardPropType from 'proptypes/CardPropType';
 
-const CubePropType = PropTypes.shape({
-  _id: PropTypes.string.isRequired,
-  shortID: PropTypes.string,
-  name: PropTypes.string,
-  card_count: PropTypes.number,
-  cards: PropTypes.arrayOf(CardPropType),
-  type: PropTypes.string,
-  overrideCategory: PropTypes.bool,
-  categoryOverride: PropTypes.string,
-  categoryPrefixes: PropTypes.arrayOf(PropTypes.string),
-  image_name: PropTypes.string,
-  image_artist: PropTypes.string,
-  image_uri: PropTypes.string,
-  owner: PropTypes.string,
-  owner_name: PropTypes.string,
-  disableNotifications: PropTypes.bool,
+const CubeAnalyticPropType = PropTypes.shape({
+  cube: PropTypes.string.isRequired,
+  cards: PropTypes.arrayOf(
+    PropTypes.shape({
+      cardName: PropTypes.string,
+      picks: PropTypes.number,
+      passes: PropTypes.number,
+      elo: PropTypes.number,
+      mainboards: PropTypes.number,
+      sideboards: PropTypes.number,
+    }),
+  ).isRequired,
+  useCubeElo: PropTypes.bool,
 });
 
-export default CubePropType;
+export default CubeAnalyticPropType;

--- a/src/proptypes/CubePropType.js
+++ b/src/proptypes/CubePropType.js
@@ -1,18 +1,22 @@
 import PropTypes from 'prop-types';
+import CardPropType from 'proptypes/CardPropType';
 
 const CubePropType = PropTypes.shape({
-  cube: PropTypes.string.isRequired,
-  cards: PropTypes.arrayOf(
-    PropTypes.shape({
-      cardName: PropTypes.string,
-      picks: PropTypes.number,
-      passes: PropTypes.number,
-      elo: PropTypes.number,
-      mainboards: PropTypes.number,
-      sideboards: PropTypes.number,
-    }),
-  ).isRequired,
-  useCubeElo: PropTypes.bool,
+  _id: PropTypes.string.isRequired,
+  shortID: PropTypes.string,
+  name: PropTypes.string,
+  card_count: PropTypes.number,
+  cards: PropTypes.arrayOf(CardPropType),
+  type: PropTypes.string,
+  overrideCategory: PropTypes.bool,
+  categoryOverride: PropTypes.string,
+  categoryPrefixes: PropTypes.arrayOf(PropTypes.string),
+  image_name: PropTypes.string,
+  image_artist: PropTypes.string,
+  image_uri: PropTypes.string,
+  owner: PropTypes.string,
+  owner_name: PropTypes.string,
+  disableNotifications: PropTypes.bool,
 });
 
 export default CubePropType;

--- a/src/proptypes/PodcastPropType.js
+++ b/src/proptypes/PodcastPropType.js
@@ -4,10 +4,8 @@ import PropTypes from 'prop-types';
 const PodcastPropType = PropTypes.shape({
   _id: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
-  rss: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
-  date: PropTypes.string.isRequired,
-  status: PropTypes.string.isRequired,
+  date: PropTypes.instanceOf(Date).isRequired,
   owner: PropTypes.string.isRequired,
   source: PropTypes.string.isRequired,
   username: PropTypes.string.isRequired,

--- a/src/proptypes/VideoPropType.js
+++ b/src/proptypes/VideoPropType.js
@@ -4,7 +4,7 @@ const VideoPropType = PropTypes.shape({
   _id: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   body: PropTypes.string.isRequired,
-  date: PropTypes.string.isRequired,
+  date: PropTypes.instanceOf(Date).isRequired,
   status: PropTypes.string.isRequired,
   owner: PropTypes.string.isRequired,
   username: PropTypes.string.isRequired,

--- a/src/utils/BlankCardHistory.js
+++ b/src/utils/BlankCardHistory.js
@@ -16,13 +16,14 @@ function getBlankCardHistory(id) {
       size540: [0, 0],
       size720: [0, 0],
       pauper: [0, 0],
+      peasant: [0, 0],
       legacy: [0, 0],
       modern: [0, 0],
       standard: [0, 0],
       vintage: [0, 0],
       cubes: 0,
       prices: cardVersions.map((cardId) => {
-        return { ...carddb.cardFromId(cardId), version: carddb.cardFromId(cardId)._id };
+        return { ...carddb.cardFromId(cardId).prices, version: carddb.cardFromId(cardId)._id };
       }),
     },
     cubedWith: {
@@ -43,6 +44,7 @@ function getBlankCardHistory(id) {
           size540: [0, 0],
           size720: [0, 0],
           pauper: [0, 0],
+          peasant: [0, 0],
           legacy: [0, 0],
           modern: [0, 0],
           standard: [0, 0],


### PR DESCRIPTION
Continues work on #1872.

This PR resolves some common React warnings appearing in browser console. Most of these are just adjustments to proptype definitions to match reality more closely. One other notable change is a slight update to how Markdown card images are rendered in order to avoid DOM validation warnings. All changes should be non-functional.