### PR TITLE
Added banned: and restricted: filters

### DIFF
--- a/nearley/cardFilters.ne
+++ b/nearley/cardFilters.ne
@@ -46,7 +46,9 @@ import {
   cardCost,
   cardLayout,
   cardDevotion,
-  cardLegalIn
+  cardLegalIn,
+  cardBannedIn,
+  cardRestrictedIn
 } from 'utils/Card';
 %} # %}
 
@@ -95,6 +97,8 @@ condition -> (
   | castableCostCondition
   | devotionCondition
   | legalityCondition
+  | bannedCondition
+  | restrictedCondition
   | layoutCondition
   | collectorNumberCondition
 ) {% ([[condition]]) => condition %}
@@ -129,6 +133,10 @@ tagCondition -> ("tag"i | "tags"i) stringSetElementOpValue {% ([, valuePred]) =>
 finishCondition -> ("fin"i | "finish"i) finishOpValue {% ([, valuePred]) => genericCondition('finish', cardFinish, valuePred) %}
 
 legalityCondition -> ("leg"i | "legal"i | "legality"i) legalityOpValue {% ([, valuePred]) => genericCondition('legality', cardLegalIn, valuePred) %}
+
+bannedCondition -> ("ban"i | "banned"i) legalityOpValue {% ([, valuePred]) => genericCondition('legality', cardBannedIn, valuePred) %}
+
+restrictedCondition -> "restricted"i legalityOpValue {% ([, valuePred]) => genericCondition('legality', cardRestrictedIn, valuePred) %}
 
 priceCondition -> ("p"i | "usd"i | "price"i) dollarOpValue {% ([, valuePred]) => genericCondition('price', cardPrice, valuePred) %}
 

--- a/src/utils/Card.js
+++ b/src/utils/Card.js
@@ -160,10 +160,14 @@ export const cardOracleId = (card) => card.details.oracle_id;
 
 export const cardLegalities = (card) => card.details.legalities;
 
-export const cardLegalIn = (card) => {
+const cardLegalityFilter = (card, legality) => {
   const legalities = cardLegalities(card);
-  return Object.keys(legalities).filter((format) => legalities[format] === 'legal');
+  return Object.keys(legalities).filter((format) => legalities[format] === legality);
 };
+
+export const cardLegalIn = (card) => cardLegalityFilter(card, 'legal');
+export const cardBannedIn = (card) => cardLegalityFilter(card, 'banned');
+export const cardRestrictedIn = (card) => cardLegalityFilter(card, 'restricted');
 
 export const cardColors = (card) => card.details.colors;
 


### PR DESCRIPTION
This PR adds the `banned:` and `restricted:` card filters to complement the existing `legal:` filter.