### PR TITLE
Featured queue timeout hotfix

### DIFF
--- a/serverjs/featuredQueue.js
+++ b/serverjs/featuredQueue.js
@@ -2,11 +2,13 @@ const FeaturedCubes = require('../models/featuredCubes');
 const Cube = require('../models/cube');
 const Patron = require('../models/patron');
 
+const TRY_COUNT = 5;
 // the return value of fn must be awaitable
 async function updateFeatured(fn) {
   let replaced = null;
   let ret;
-  while (!replaced) {
+  let i;
+  for (i = 0; !replaced && i < TRY_COUNT; i++) {
     // eslint-disable-next-line no-await-in-loop
     const featured = await FeaturedCubes.findOne({ singleton: true }).lean();
     const stamp = featured.timestamp;
@@ -20,7 +22,7 @@ async function updateFeatured(fn) {
     // eslint-disable-next-line no-await-in-loop
     replaced = await FeaturedCubes.findOneAndReplace({ singleton: true, timestamp: stamp }, featured);
   }
-  return { ok: true, return: ret };
+  return i < TRY_COUNT ? { ok: true, return: ret } : { ok: false, message: 'Timeout exceeded. Please try again.' };
 }
 
 function canBeFeatured(patron) {


### PR DESCRIPTION
There are reports of users getting timeout errors when attempting to add cubes to the featured queue. However, adding cubes from the admin panel works fine. 

To help isolate the issue and pinpoint a potential source of timeouts, this PR adds a limit on how many times a queue modification can be attempted.