### PR TITLE
#2191 hotfix

### DIFF
--- a/src/components/EditCollapse.js
+++ b/src/components/EditCollapse.js
@@ -18,6 +18,7 @@ import {
   InputGroupText,
 } from 'reactstrap';
 
+import Query from 'utils/Query';
 import { encodeName } from 'utils/Card';
 import { findUserLinks } from 'markdown/parser';
 
@@ -83,7 +84,7 @@ const EditCollapse = ({ cubeView, ...props }) => {
   const removals = changes.filter((change) => change.remove || change.replace).length;
   const newTotal = cube.cards.length + additions - removals;
 
-  const scaleParams = new URLSearchParams(window.location.search).get('scale');
+  const scaleParams = Query.get('scale', 'medium');
 
   const handleChange = useCallback(
     (event) => {


### PR DESCRIPTION
In #2191, there is a slight bug where if the query parameter for `scale` is empty, the form submits `scale=null` in the query. This PR makes it so that in that case a default value of `medium` is sent instead.
