### PR TITLE
Add Ophiomancer as special case card for tokens

### DIFF
--- a/serverjs/updatecards.js
+++ b/serverjs/updatecards.js
@@ -210,7 +210,8 @@ const specialCaseCards = {
 
   // This card didn't have a printed token until Commander Collection: Black, and the printed version is a double-faced
   // token
-  'Ophiomancer': ['13e4832d-8530-4b85-b738-51d0c18f28ec'],
+  // TODO(#2196): When the card parser can handle DFC tokens, we can remove this special case
+  Ophiomancer: ['13e4832d-8530-4b85-b738-51d0c18f28ec'],
 
   // These two are a bit of a problem. Normaly when an ability creates copies the scryfall tokens associated with it are fetched.
   // This works great in most cases, but these two already have a token in scryfall only it's the wrong token. It's a token refering to


### PR DESCRIPTION
Today, the site doesn't list Ophiomancer's Snake token under the Token page for a cube.

Ophiomancer did not have a printed token until Commander Collection: Black, and the printed token is a double-faced token. I think because of this, the card data doesn't seem to pick up the token for the card, so I've added to special case cards here.

[Here's the image of the Scryfall token ID that was added](https://c1.scryfall.com/file/scryfall-cards/large/front/1/3/13e4832d-8530-4b85-b738-51d0c18f28ec.jpg?1630007268)

Also, if this is accepted, could one of the maintainers please add the `hacktoberfest-accepted` label to this PR? I'm participating in [Hacktoberfest](https://hacktoberfest.digitalocean.com/) this year.