### PR TITLE
fix(filtering) Add overrides for category filters

### DIFF
--- a/src/res/CategoryOverrides.json
+++ b/src/res/CategoryOverrides.json
@@ -1,0 +1,3 @@
+{
+	"commander": ["Grist, the Hunger Tide"]
+}

--- a/src/utils/Card.js
+++ b/src/utils/Card.js
@@ -1,5 +1,6 @@
 import { arraysEqual, fromEntries, arrayIsSubset } from 'utils/Util';
 import LandCategories from 'res/LandCategories.json';
+import CategoryOverrides from 'res/CategoryOverrides.json';
 
 export const COLOR_COMBINATIONS = [
   [],
@@ -248,7 +249,8 @@ export const CARD_CATEGORY_DETECTORS = {
   commander: (details) =>
     details.legalities.Commander === 'legal' &&
     ((details.type.includes('Legendary') && details.type.includes('Creature')) ||
-      details.oracle_text.includes('can be your commander')),
+      details.oracle_text.includes('can be your commander') ||
+      CategoryOverrides.commander.includes(details.name)),
   spell: (details) => !details.type.includes('Land') && !cardIsSpecialZoneType({ details }),
   permanent: (details) =>
     !details.type.includes('Instant') && !details.type.includes('Sorcery') && !cardIsSpecialZoneType({ details }),


### PR DESCRIPTION
Fixes #2185.

Sometimes, cards fall into categories in a way that isn't easily represented by generic test conditions. An example of this is Grist, the Hunger Tide, whose first ability allows it to be your commander even though it doesn't match any of the usual commander templates.

This PR adds a generic way to include specific cards as exceptions to the general filtering rules using a simple JSON file, and adds Grist in particular as one such exception.