### PR TITLE
feat(jobs) Create blogpost when removing invalid cards

### DIFF
--- a/jobs/clean_cubes.js
+++ b/jobs/clean_cubes.js
@@ -32,7 +32,7 @@ const needsCleaning = (cube) =>
 
 const missingCardMarkdown = (card) => {
   const values = {
-    'Date added': card.addedTmsp.toISOString(),
+    'Date Added': card.addedTmsp.toISOString(),
     'Mana Value': card.cmc,
     'Type Line': card.type_line,
     Rarity: card.rarity,
@@ -46,7 +46,7 @@ const missingCardMarkdown = (card) => {
   };
   let md = '';
   for (const [name, val] of Object.entries(values)) {
-    if (val) md += `**${name}:** ${val}\n`;
+    if (val != null) md += `**${name}:** ${val}\n`;
   }
   md += `*ID: ${card.cardID}*\n`;
   return md;

--- a/jobs/clean_cubes.js
+++ b/jobs/clean_cubes.js
@@ -48,6 +48,7 @@ const missingCardMarkdown = (card) => {
   for (const [name, val] of Object.entries(values)) {
     if (val) md += `**${name}:** ${val}\n`;
   }
+  md += `*ID: ${card.cardID}*\n`;
   return md;
 };
 

--- a/jobs/clean_cubes.js
+++ b/jobs/clean_cubes.js
@@ -82,16 +82,17 @@ const processCube = async (leanCube, admin) => {
     const owner = await User.findById(cube.owner);
     let blogText = '';
     if (removedCards.length > 0) {
-      blogText += '## Removed from cube\n';
+      blogText += '>>>### Removed from cube<<<\n';
       blogText += removedCards.map(missingCardMarkdown).join('\n----\n');
+      blogText += '\n';
     }
     if (removedMaybe.length > 0) {
-      blogText += '## Removed from maybeboard\n';
+      blogText += '>>>### Removed from maybeboard<<<\n';
       blogText += removedMaybe.map(missingCardMarkdown).join('\n----\n');
     }
     const blogpost = new Blog();
     blogpost.markdown = blogText;
-    blogpost.title = 'Invalid Cards Automatically Removed';
+    blogpost.title = 'Removed Invalid Cards - Automatic Post';
     blogpost.owner = owner._id;
     blogpost.date = Date.now();
     blogpost.cube = cube._id;

--- a/jobs/clean_cubes.js
+++ b/jobs/clean_cubes.js
@@ -8,6 +8,7 @@ require('dotenv').config();
 const mongoose = require('mongoose');
 const Cube = require('../models/cube');
 const User = require('../models/user');
+const Blog = require('../models/blog');
 const { cardsNeedsCleaning, cleanCards } = require('../models/migrations/cleanCards');
 const carddb = require('../serverjs/cards');
 const util = require('../serverjs/util');
@@ -29,6 +30,27 @@ const needsCleaning = (cube) =>
   cardsNeedsCleaning(cube.maybe) ||
   cube.tags.some((tag) => !tag || tag.toLowerCase() !== tag);
 
+const missingCardMarkdown = (card) => {
+  const values = {
+    'Date added': card.addedTmsp.toISOString(),
+    'Mana Value': card.cmc,
+    'Type Line': card.type_line,
+    Rarity: card.rarity,
+    Status: card.status,
+    Finish: card.finish,
+    'Image URL': card.imgUrl,
+    Colors: card.colors.join(''),
+    'Color Category': card.colorCategory,
+    Tags: card.tags.join(),
+    Notes: card.notes,
+  };
+  let md = '';
+  for (const [name, val] of Object.entries(values)) {
+    if (val) md += `**${name}:** ${val}\n`;
+  }
+  return md;
+};
+
 const processCube = async (leanCube, admin) => {
   if (needsCleaning(leanCube)) {
     const cube = await Cube.findById(leanCube._id);
@@ -40,45 +62,62 @@ const processCube = async (leanCube, admin) => {
     if (!cube.maybe) {
       cube.maybe = [];
     }
-    const oldCardCount = cube.cards.length;
-    const oldMaybeCount = cube.cards.length;
     if (!Array.isArray(cube.basics)) {
       cube.basics = DEFAULT_BASICS;
     }
+    let removedCards = [];
     if (cardsNeedsCleaning(cube.cards)) {
-      cube.cards = cleanCards(cube.cards);
+      [cube.cards, removedCards] = cleanCards(cube.cards);
     }
+    let removedMaybe = [];
     if (cardsNeedsCleaning(cube.maybe)) {
-      cube.maybe = cleanCards(cube.maybe);
+      [cube.maybe, removedMaybe] = cleanCards(cube.maybe);
     }
     if (cube.tags.some((tag) => !tag || tag.toLowerCase() !== tag)) {
       cube.tags = cube.tags.filter((tag) => tag && tag.length > 0).map((tag) => tag.toLowerCase());
     }
     await cube.save();
-
-    const cardDiff = cube.cards.length - oldCardCount;
-    const maybeDiff = cube.maybe.length - oldMaybeCount;
-    if (!cardDiff && !maybeDiff) return;
+    if (removedMaybe.length === 0 && removedCards.length === 0) return;
 
     const owner = await User.findById(cube.owner);
-    if (cardDiff)
-      await util.addNotification(
-        owner,
-        admin,
-        `/cube/list/${cube.id}`,
-        `${cardDiff} invalid card${cardDiff === 1 ? ' was' : 's were'} automatically removed from your cube ${
-          cube.name
-        }`,
-      );
+    let blogText = '';
+    if (removedCards.length > 0) {
+      blogText += '## Removed from cube\n';
+      blogText += removedCards.map(missingCardMarkdown).join('\n----\n');
+    }
+    if (removedMaybe.length > 0) {
+      blogText += '## Removed from maybeboard\n';
+      blogText += removedMaybe.map(missingCardMarkdown).join('\n----\n');
+    }
+    const blogpost = new Blog();
+    blogpost.markdown = blogText;
+    blogpost.title = 'Invalid Cards Automatically Removed';
+    blogpost.owner = owner._id;
+    blogpost.date = Date.now();
+    blogpost.cube = cube._id;
+    blogpost.dev = 'false';
+    blogpost.date_formatted = blogpost.date.toLocaleString('en-US');
+    blogpost.username = owner.username;
+    blogpost.cubename = cube.name;
+    await blogpost.save();
 
-    if (maybeDiff)
+    if (removedCards.length > 0)
       await util.addNotification(
         owner,
         admin,
-        `/cube/list/${cube.id}`,
-        `${maybeDiff} invalid card${maybeDiff === 1 ? ' was' : 's were'} automatically removed from your cube ${
-          cube.name
-        }`,
+        `/cube/blog/blogpost/${blogpost._id}`,
+        `${removedCards.length} invalid card${
+          removedCards.length === 1 ? ' was' : 's were'
+        } automatically removed from your cube ${cube.name}`,
+      );
+    if (removedMaybe.length > 0)
+      await util.addNotification(
+        owner,
+        admin,
+        `/cube/blog/blogpost/${blogpost._id}`,
+        `${removedMaybe.length} invalid card${
+          removedMaybe.length === 1 ? ' was' : 's were'
+        } automatically removed from your cube ${cube.name}`,
       );
   }
 };

--- a/models/migrations/cubeMigrations.js
+++ b/models/migrations/cubeMigrations.js
@@ -17,10 +17,10 @@ const updateCubeDraftFormats = (cube) => {
     ];
   }
   if (cardsNeedsCleaning(cube.cards)) {
-    cube.cards = cleanCards(cube.cards).map((card, index) => ({ ...card, index }));
+    cube.cards = cleanCards(cube.cards)[0].map((card, index) => ({ ...card, index }));
   }
   if (cardsNeedsCleaning(cube.maybe)) {
-    cube.maybe = cleanCards(cube.maybe).map((card, index) => ({ ...card, index }));
+    cube.maybe = cleanCards(cube.maybe)[0].map((card, index) => ({ ...card, index }));
   }
 
   const newFormats = mapNonNull(cubeObject.draft_formats, (oldDraftFormat) => {

--- a/models/migrations/deckMigrations.js
+++ b/models/migrations/deckMigrations.js
@@ -52,7 +52,7 @@ const dedupeCardObjects = async (deck) => {
     return seat;
   });
   addBasics(cardsArray, cube.basics, deck);
-  deck.cards = cleanCards(cardsArray, false);
+  [deck.cards] = cleanCards(cardsArray, false);
   return deck;
 };
 

--- a/models/migrations/draftMigrations.js
+++ b/models/migrations/draftMigrations.js
@@ -25,7 +25,7 @@ const dedupeCardObjects = async (draft) => {
   if (!Array.isArray(cardsArray) || (cardsArray.length > 0 && (!cardsArray[0] || !cardsArray[0].cardID))) {
     throw new Error(`Could not correctly transform the cardsArray. Got ${JSON.stringify(cardsArray[0], null, 2)}`);
   }
-  cardsArray = cleanCards(cardsArray).map((card, index) => ({ ...card, index }));
+  cardsArray = cleanCards(cardsArray)[0].map((card, index) => ({ ...card, index }));
   const replaceWithIndex = (card) => {
     const idx = cardsArray.findIndex((card2) => card && card2 && cardsAreEquivalent(card, card2));
     if (idx === -1) {

--- a/models/migrations/gridDraftMigrations.js
+++ b/models/migrations/gridDraftMigrations.js
@@ -33,7 +33,7 @@ const dedupeCardObjects = async (gridDraft) => {
     );
   }
   addBasics(cardsArray, cube.basics, gridDraft);
-  cardsArray = cleanCards(cardsArray).map((card, index) => ({ ...card, index }));
+  cardsArray = cleanCards(cardsArray)[0].map((card, index) => ({ ...card, index }));
 
   const replaceWithIndex = (card) => {
     const idx = cardsArray.findIndex((card2) => card && card2 && cardsAreEquivalent(card, card2));


### PR DESCRIPTION
In #2170, we added notifications that are sent whenever we remove invalid cards from a cube. This helps with figuring out why the cube count is wrong, but it can still create some detective work to the user in figuring out which cards were removed.

This PR enhances the notification functionality by also creating a blog post for the cube, which lists all properties that we know about each removed card, hopefully allowing the user to more easily figure out what they were.

### Screenshot
![Screenshot 2021-11-10 at 14-15-38 Cube Cobra Blog testing](https://user-images.githubusercontent.com/38463785/141129219-427b4f59-9716-4196-80e6-6c73fe428128.png)


