### PR TITLE
fix(ads) Fix ad report button rendering

### DIFF
--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -1300,7 +1300,7 @@ thead th.corner[scope=col] {
 	background-color: #FFFFFF !important
 }
 
-div.advertisement-div > div {
+div.advertisement-div > div:not(.report-link) {
 	height: 100% !important
   }
 


### PR DESCRIPTION
Fixes #2192 

This CSS rule, used to ensure correct behavior on sidebar ads when scrolling, also applied to the report button element on the top ad. That element then had its height overridden from its preset of 20px to 100%, which meant it could overlap site content below. This PR restricts the selector so that it doesn't apply to the report button, fixing this issue.