### PR TITLE
fix(carddb) Fix parsing of reversible cards

### DIFF
--- a/__tests__/serverjs/updatecards.test.js
+++ b/__tests__/serverjs/updatecards.test.js
@@ -5,6 +5,7 @@ const updatecards = require('../../serverjs/updatecards');
 const carddb = require('../../serverjs/cards');
 const examplecards = require('../../fixtures/examplecards');
 const cardutil = require('../../dist/utils/Card.js');
+const { getFaceAttributeSource } = require('../../serverjs/updatecards');
 
 const emptyFixturePath = 'fixtures/empty.json';
 const cardsFixturePath = 'fixtures/cards_small.json';
@@ -456,6 +457,66 @@ const convertedExampleNonFoilCard = {
   cubeCount: 0,
 };
 
+const convertedExampleReversibleCard = {
+  color_identity: ['U'],
+  set: 'sld',
+  set_name: 'Secret Lair Drop',
+  foil: true,
+  nonfoil: true,
+  collector_number: '381',
+  released_at: '2022-04-22',
+  reprint: true,
+  promo: false,
+  prices: { usd: null, usd_foil: null, eur: null, tix: null },
+  elo: 1200,
+  popularity: 0,
+  cubeCount: 0,
+  pickCount: 0,
+  embedding: [],
+  digital: false,
+  isToken: false,
+  border_color: 'black',
+  name: 'Propaganda',
+  name_lower: 'propaganda',
+  full_name: 'Propaganda [sld-381]',
+  artist: 'Scott Balmer',
+  scryfall_uri: 'https://scryfall.com/card/sld/381/propaganda-propaganda?utm_source=api',
+  rarity: 'rare',
+  oracle_text:
+    "Creatures can't attack you unless their controller pays {2} for each creature they control that's attacking you.\n" +
+    "Creatures can't attack you unless their controller pays {2} for each creature they control that's attacking you.",
+  _id: '3e3f0bcd-0796-494d-bf51-94b33c1671e9',
+  oracle_id: 'ea9709b6-4c37-4d5a-b04d-cd4c42e4f9dd',
+  cmc: 3.0,
+  legalities: {
+    Legacy: 'legal',
+    Modern: 'not_legal',
+    Standard: 'not_legal',
+    Pioneer: 'not_legal',
+    Pauper: 'not_legal',
+    Brawl: 'not_legal',
+    Historic: 'not_legal',
+    Commander: 'legal',
+    Penny: 'not_legal',
+    Vintage: 'legal',
+  },
+  parsed_cost: ['u', '2'],
+  colors: ['U'],
+  type: 'Enchantment',
+  full_art: false,
+  language: 'en',
+  layout: 'reversible_card',
+  image_small:
+    'https://c1.scryfall.com/file/scryfall-cards/small/front/3/e/3e3f0bcd-0796-494d-bf51-94b33c1671e9.jpg?1637270794',
+  image_normal:
+    'https://c1.scryfall.com/file/scryfall-cards/normal/front/3/e/3e3f0bcd-0796-494d-bf51-94b33c1671e9.jpg?1637270794',
+  art_crop:
+    'https://c1.scryfall.com/file/scryfall-cards/art_crop/front/3/e/3e3f0bcd-0796-494d-bf51-94b33c1671e9.jpg?1637270794',
+  image_flip:
+    'https://c1.scryfall.com/file/scryfall-cards/normal/back/3/e/3e3f0bcd-0796-494d-bf51-94b33c1671e9.jpg?1637270794',
+  colorcategory: 'u',
+};
+
 const mockRatings = [
   {
     name: 'Inspiring Veteran',
@@ -657,25 +718,40 @@ test('convertCard returns a correctly converted Adventure card object', () => {
   expect(result).toEqual(convertedExampleAdventureCard);
 });
 
+test('convertCard returns a correctly converted reversible card', () => {
+  const result = updatecards.convertCard(examplecards.exampleReversibleCard, false);
+  expect(result).toEqual(convertedExampleReversibleCard);
+});
+
 describe.each(fnToAttributeTable)('%s properly converts %s', (convertFn, attribute) => {
   test('for standard card', () => {
-    const result = updatecards[convertFn](examplecards.exampleCard);
+    const card = examplecards.exampleCard;
+    const result = updatecards[convertFn](card, false, getFaceAttributeSource(card, false));
     expect(result).toEqual(convertedExampleCard[attribute]);
   });
 
   test('for a double-faced card', () => {
-    const result = updatecards[convertFn](examplecards.exampleDoubleFacedCard, false);
+    const card = examplecards.exampleDoubleFacedCard;
+    const result = updatecards[convertFn](card, false, getFaceAttributeSource(card, false));
     expect(result).toEqual(convertedExampleDoubleFacedCard[attribute]);
   });
 
   test("for Adventure card's creature", () => {
-    const result = updatecards[convertFn](examplecards.exampleAdventureCard, false);
+    const card = examplecards.exampleAdventureCard;
+    const result = updatecards[convertFn](card, false, getFaceAttributeSource(card, false));
     expect(result).toEqual(convertedExampleAdventureCard[attribute]);
   });
 
   test("for Adventure card's Adventure", () => {
-    const result = updatecards[convertFn](examplecards.exampleAdventureCard, true);
+    const card = examplecards.exampleAdventureCard;
+    const result = updatecards[convertFn](card, true, getFaceAttributeSource(card, true));
     expect(result).toEqual(convertedExampleAdventureCardAdventure[attribute]);
+  });
+
+  test('for a reversible card', () => {
+    const card = examplecards.exampleReversibleCard;
+    const result = updatecards[convertFn](card, false, getFaceAttributeSource(card, false));
+    expect(result).toEqual(convertedExampleReversibleCard[attribute]);
   });
 });
 

--- a/fixtures/examplecards.js
+++ b/fixtures/examplecards.js
@@ -758,6 +758,153 @@ const exampleNonFoilCard = {
   },
 };
 
+const exampleReversibleCard = {
+  object: 'card',
+  id: '3e3f0bcd-0796-494d-bf51-94b33c1671e9',
+  multiverse_ids: [],
+  name: 'Propaganda // Propaganda',
+  lang: 'en',
+  released_at: '2022-04-22',
+  uri: 'https://api.scryfall.com/cards/3e3f0bcd-0796-494d-bf51-94b33c1671e9',
+  scryfall_uri: 'https://scryfall.com/card/sld/381/propaganda-propaganda?utm_source=api',
+  layout: 'reversible_card',
+  highres_image: false,
+  image_status: 'lowres',
+  color_identity: ['U'],
+  keywords: [],
+  card_faces: [
+    {
+      object: 'card_face',
+      oracle_id: 'ea9709b6-4c37-4d5a-b04d-cd4c42e4f9dd',
+      layout: 'normal',
+      name: 'Propaganda',
+      flavor_name: '',
+      mana_cost: '{2}{U}',
+      cmc: 3,
+      type_line: 'Enchantment',
+      oracle_text:
+        "Creatures can't attack you unless their controller pays {2} for each creature they control that's attacking you.",
+      colors: ['U'],
+      flavor_text: '"Obedience is the true path to happiness."\n—Dolorus, magister equitum',
+      artist: 'Scott Balmer',
+      artist_id: 'c26dd9c9-54f9-4a8c-9d54-caac6be0161d',
+      illustration_id: '7af368fa-6036-462a-a480-02ccc589bea5',
+      image_uris: {
+        small:
+          'https://c1.scryfall.com/file/scryfall-cards/small/front/3/e/3e3f0bcd-0796-494d-bf51-94b33c1671e9.jpg?1637270794',
+        normal:
+          'https://c1.scryfall.com/file/scryfall-cards/normal/front/3/e/3e3f0bcd-0796-494d-bf51-94b33c1671e9.jpg?1637270794',
+        large:
+          'https://c1.scryfall.com/file/scryfall-cards/large/front/3/e/3e3f0bcd-0796-494d-bf51-94b33c1671e9.jpg?1637270794',
+        png: 'https://c1.scryfall.com/file/scryfall-cards/png/front/3/e/3e3f0bcd-0796-494d-bf51-94b33c1671e9.png?1637270794',
+        art_crop:
+          'https://c1.scryfall.com/file/scryfall-cards/art_crop/front/3/e/3e3f0bcd-0796-494d-bf51-94b33c1671e9.jpg?1637270794',
+        border_crop:
+          'https://c1.scryfall.com/file/scryfall-cards/border_crop/front/3/e/3e3f0bcd-0796-494d-bf51-94b33c1671e9.jpg?1637270794',
+      },
+    },
+    {
+      object: 'card_face',
+      oracle_id: 'ea9709b6-4c37-4d5a-b04d-cd4c42e4f9dd',
+      layout: 'normal',
+      name: 'Propaganda',
+      flavor_name: '',
+      mana_cost: '{2}{U}',
+      cmc: 3,
+      type_line: 'Enchantment',
+      oracle_text:
+        "Creatures can't attack you unless their controller pays {2} for each creature they control that's attacking you.",
+      colors: ['U'],
+      flavor_text: '"Why rebel? The system can be changed from within."\n—Dolorus, magister equitum',
+      artist: 'Scott Balmer',
+      artist_id: 'c26dd9c9-54f9-4a8c-9d54-caac6be0161d',
+      illustration_id: 'fee742d4-3025-430f-9094-b67f249e54f5',
+      image_uris: {
+        small:
+          'https://c1.scryfall.com/file/scryfall-cards/small/back/3/e/3e3f0bcd-0796-494d-bf51-94b33c1671e9.jpg?1637270794',
+        normal:
+          'https://c1.scryfall.com/file/scryfall-cards/normal/back/3/e/3e3f0bcd-0796-494d-bf51-94b33c1671e9.jpg?1637270794',
+        large:
+          'https://c1.scryfall.com/file/scryfall-cards/large/back/3/e/3e3f0bcd-0796-494d-bf51-94b33c1671e9.jpg?1637270794',
+        png: 'https://c1.scryfall.com/file/scryfall-cards/png/back/3/e/3e3f0bcd-0796-494d-bf51-94b33c1671e9.png?1637270794',
+        art_crop:
+          'https://c1.scryfall.com/file/scryfall-cards/art_crop/back/3/e/3e3f0bcd-0796-494d-bf51-94b33c1671e9.jpg?1637270794',
+        border_crop:
+          'https://c1.scryfall.com/file/scryfall-cards/border_crop/back/3/e/3e3f0bcd-0796-494d-bf51-94b33c1671e9.jpg?1637270794',
+      },
+    },
+  ],
+  legalities: {
+    standard: 'not_legal',
+    future: 'not_legal',
+    historic: 'not_legal',
+    gladiator: 'not_legal',
+    pioneer: 'not_legal',
+    modern: 'not_legal',
+    legacy: 'legal',
+    pauper: 'not_legal',
+    vintage: 'legal',
+    penny: 'not_legal',
+    commander: 'legal',
+    brawl: 'not_legal',
+    historicbrawl: 'not_legal',
+    alchemy: 'not_legal',
+    paupercommander: 'not_legal',
+    duel: 'legal',
+    oldschool: 'not_legal',
+    premodern: 'legal',
+  },
+  games: ['paper'],
+  reserved: false,
+  foil: true,
+  nonfoil: true,
+  finishes: ['nonfoil', 'foil'],
+  oversized: false,
+  promo: false,
+  reprint: true,
+  variation: false,
+  set_id: '4d92a8a7-ccb0-437d-abdc-9d70fc5ed672',
+  set: 'sld',
+  set_name: 'Secret Lair Drop',
+  set_type: 'box',
+  set_uri: 'https://api.scryfall.com/sets/4d92a8a7-ccb0-437d-abdc-9d70fc5ed672',
+  set_search_uri: 'https://api.scryfall.com/cards/search?order=set&q=e%3Asld&unique=prints',
+  scryfall_set_uri: 'https://scryfall.com/sets/sld?utm_source=api',
+  rulings_uri: 'https://api.scryfall.com/cards/3e3f0bcd-0796-494d-bf51-94b33c1671e9/rulings',
+  prints_search_uri:
+    'https://api.scryfall.com/cards/search?order=released&q=oracleid%3Aea9709b6-4c37-4d5a-b04d-cd4c42e4f9dd&unique=prints',
+  collector_number: '381',
+  digital: false,
+  rarity: 'rare',
+  artist: 'Scott Balmer',
+  artist_ids: ['c26dd9c9-54f9-4a8c-9d54-caac6be0161d'],
+  border_color: 'black',
+  frame: '2015',
+  frame_effects: ['inverted'],
+  security_stamp: 'oval',
+  full_art: false,
+  textless: false,
+  booster: false,
+  story_spotlight: false,
+  edhrec_rank: 194,
+  prices: {
+    usd: null,
+    usd_foil: null,
+    usd_etched: null,
+    eur: null,
+    eur_foil: null,
+    tix: null,
+  },
+  related_uris: {
+    tcgplayer_infinite_articles:
+      'https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Propaganda+%2F%2F+Propaganda&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall',
+    tcgplayer_infinite_decks:
+      'https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Propaganda+%2F%2F+Propaganda&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall',
+    edhrec: 'https://edhrec.com/route/?cc=Propaganda+%2F%2F+Propaganda',
+    mtgtop8: 'https://mtgtop8.com/search?MD_check=1&SB_check=1&cards=Propaganda+%2F%2F+Propaganda',
+  },
+};
+
 module.exports = {
   exampleCard,
   exampleDoubleFacedCard,
@@ -765,4 +912,5 @@ module.exports = {
   exampleAdventureCard,
   exampleForeignCard,
   exampleNonFoilCard,
+  exampleReversibleCard,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2312,6 +2312,135 @@
         }
       }
     },
+    "@mapbox/node-pre-gyp": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.7.tgz",
+      "integrity": "sha512-PplSvl4pJ5N3BkVjAdDzpPhVUPdC73JgttkR+LnBx2OORC1GCQsBjUeEuipf9uOaAM1SbxcdZFfR3KDTKm2S0A==",
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.5",
+        "nopt": "^5.0.0",
+        "npmlog": "^6.0.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "dependencies": {
+        "chownr": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+        },
+        "fs-minipass": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+          "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+          "requires": {
+            "minipass": "^3.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "make-dir": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+          "requires": {
+            "semver": "^6.0.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            }
+          }
+        },
+        "minipass": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
+          "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+          "requires": {
+            "minipass": "^3.0.0",
+            "yallist": "^4.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+        },
+        "node-fetch": {
+          "version": "2.6.6",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+          "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "tar": {
+          "version": "6.1.11",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+          "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+          "requires": {
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
+            "minipass": "^3.0.0",
+            "minizlib": "^2.1.1",
+            "mkdirp": "^1.0.3",
+            "yallist": "^4.0.0"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
     "@primer/octicons-react": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-11.0.0.tgz",
@@ -3346,12 +3475,24 @@
       }
     },
     "are-we-there-yet": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
       "requires": {
         "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "argparse": {
@@ -4813,12 +4954,12 @@
       "integrity": "sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo="
     },
     "canvas": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.6.1.tgz",
-      "integrity": "sha512-S98rKsPcuhfTcYbtF53UIJhcbgIAK533d1kJKMwsMwAIFgfd58MOyxRud3kktlzWiEkFliaJtvyZCBtud/XVEA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.8.0.tgz",
+      "integrity": "sha512-gLTi17X8WY9Cf5GZ2Yns8T5lfBOcGgFehDFb+JQwDqdOoBOcECS9ZWMEAqMSVcMYwXD659J8NyzjRY/2aE+C2Q==",
       "requires": {
+        "@mapbox/node-pre-gyp": "^1.0.0",
         "nan": "^2.14.0",
-        "node-pre-gyp": "^0.11.0",
         "simple-get": "^3.0.3"
       }
     },
@@ -5185,11 +5326,6 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-    },
     "collect-v8-coverage": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
@@ -5235,6 +5371,11 @@
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
     },
     "colorette": {
       "version": "1.2.2",
@@ -5899,7 +6040,8 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -6427,8 +6569,7 @@
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "emojis-list": {
       "version": "3.0.0",
@@ -7879,6 +8020,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
       "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "optional": true,
       "requires": {
         "minipass": "^2.6.0"
       }
@@ -8472,18 +8614,34 @@
       "dev": true
     },
     "gauge": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.0.tgz",
+      "integrity": "sha512-F8sU45yQpjQjxKkm1UOAhf0U/O0aFt//Fl7hsrNVto+patMHjs7dPI9mFOGUKbhrgKm0S3EjW3scMFuQmWSROw==",
       "requires": {
-        "aproba": "^1.0.3",
+        "ansi-regex": "^5.0.1",
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
         "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
+        "has-unicode": "^2.0.1",
         "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
       }
     },
     "gensync": {
@@ -9219,14 +9377,6 @@
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
       "dev": true
     },
-    "ignore-walk": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
-      "requires": {
-        "minimatch": "^3.0.4"
-      }
-    },
     "immutability-helper": {
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-2.9.1.tgz",
@@ -9588,12 +9738,9 @@
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-generator-fn": {
       "version": "2.1.0",
@@ -13904,6 +14051,7 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
       "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -13982,6 +14130,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
       "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "optional": true,
       "requires": {
         "minipass": "^2.9.0"
       }
@@ -14496,31 +14645,6 @@
         "semver": "^5.4.1"
       }
     },
-    "needle": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.1.tgz",
-      "integrity": "sha512-x/gi6ijr4B7fwl6WYL9FwlCvRQKGlUNvnceho8wxkwXqN8jvVmmmATTmZPRRG7b/yC1eode26C2HO9jl78Du9g==",
-      "requires": {
-        "debug": "^3.2.6",
-        "iconv-lite": "^0.4.4",
-        "sax": "^1.2.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -14738,33 +14862,6 @@
         }
       }
     },
-    "node-pre-gyp": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz",
-      "integrity": "sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==",
-      "requires": {
-        "detect-libc": "^1.0.2",
-        "mkdirp": "^0.5.1",
-        "needle": "^2.2.1",
-        "nopt": "^4.0.1",
-        "npm-packlist": "^1.1.6",
-        "npmlog": "^4.0.2",
-        "rc": "^1.2.7",
-        "rimraf": "^2.6.1",
-        "semver": "^5.3.0",
-        "tar": "^4"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
-      }
-    },
     "node-schedule": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-1.3.2.tgz",
@@ -14915,12 +15012,11 @@
       }
     },
     "nopt": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-      "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
       "requires": {
-        "abbrev": "1",
-        "osenv": "^0.1.4"
+        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -14940,29 +15036,6 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
-    "npm-bundled": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
-      "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
-      "requires": {
-        "npm-normalize-package-bin": "^1.0.1"
-      }
-    },
-    "npm-normalize-package-bin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
-    },
-    "npm-packlist": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
-      "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
-      "requires": {
-        "ignore-walk": "^3.0.1",
-        "npm-bundled": "^1.0.1",
-        "npm-normalize-package-bin": "^1.0.1"
-      }
-    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -14972,14 +15045,14 @@
       }
     },
     "npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.0.tgz",
+      "integrity": "sha512-03ppFRGlsyUaQFbGC2C8QWJN/C/K7PsfyD9aQdhVKAQIH4sQBc8WASqFBP7O+Ut4d2oo5LoeoboB3cGdBZSp6Q==",
       "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^4.0.0",
+        "set-blocking": "^2.0.0"
       }
     },
     "nth-check": {
@@ -14989,11 +15062,6 @@
       "requires": {
         "boolbase": "^1.0.0"
       }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nwsapi": {
       "version": "2.2.0",
@@ -15206,11 +15274,6 @@
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
     },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-    },
     "os-locale": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
@@ -15224,16 +15287,8 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-    },
-    "osenv": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
-      }
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "p-defer": {
       "version": "1.0.0",
@@ -16286,6 +16341,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -16296,7 +16352,8 @@
         "minimist": {
           "version": "1.2.5",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
         }
       }
     },
@@ -17552,9 +17609,9 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "simple-concat": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
     },
     "simple-get": {
       "version": "3.1.0",
@@ -18171,13 +18228,28 @@
       }
     },
     "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
       }
     },
     "string.prototype.matchall": {
@@ -18374,7 +18446,8 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
     },
     "style-loader": {
       "version": "1.1.3",
@@ -18616,6 +18689,7 @@
       "version": "4.4.19",
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
       "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
+      "optional": true,
       "requires": {
         "chownr": "^1.1.4",
         "fs-minipass": "^1.2.7",
@@ -18629,7 +18703,8 @@
         "safe-buffer": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "optional": true
         }
       }
     },
@@ -20513,11 +20588,11 @@
       }
     },
     "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
       "requires": {
-        "string-width": "^1.0.2 || 2"
+        "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
     "widest-line": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "bad-words": "^3.0.3",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.19.0",
-    "canvas": "^2.6.1",
+    "canvas": "^2.8.0",
     "chart.js": "^2.9.4",
     "cheerio": "^1.0.0-rc.10",
     "classnames": "^2.2.6",

--- a/serverjs/updatecards.js
+++ b/serverjs/updatecards.js
@@ -78,8 +78,8 @@ const catalog = {};
  *   art_crop: URI?
  *   image_flip: URI?
  *   // Lowercase
- *   color_category: Char
- *   // Card ID's
+ *   colorcategory: Char
+ *   // Card IDs
  *   tokens: [UUID]?
  */
 function initializeCatalog() {
@@ -470,11 +470,11 @@ function getTokens(card, catalogCard) {
   return mentionedTokens;
 }
 
-function convertCmc(card, isExtra) {
+function convertCmc(card, isExtra, faceAttributeSource) {
   if (isExtra) {
     return 0;
   }
-  return card.cmc;
+  return typeof faceAttributeSource.cmc === 'number' ? faceAttributeSource.cmc : card.cmc;
 }
 
 function convertLegalities(card, isExtra) {
@@ -621,17 +621,24 @@ function convertName(card, isExtra) {
   return str.trim();
 }
 
-function convertCard(card, isExtra) {
+function getFaceAttributeSource(card, isExtra) {
   let faceAttributeSource;
-  const newcard = {};
   if (isExtra) {
     [, faceAttributeSource] = card.card_faces;
-    card = { ...card };
-    card.card_faces = [faceAttributeSource];
   } else if (card.card_faces) {
     [faceAttributeSource] = card.card_faces;
   } else {
     faceAttributeSource = card;
+  }
+  return faceAttributeSource;
+}
+
+function convertCard(card, isExtra) {
+  const faceAttributeSource = getFaceAttributeSource(card, isExtra);
+  const newcard = {};
+  if (isExtra) {
+    card = { ...card };
+    card.card_faces = [faceAttributeSource];
   }
   const name = convertName(card, isExtra);
   newcard.color_identity = Array.from(card.color_identity);
@@ -692,7 +699,7 @@ function convertCard(card, isExtra) {
   newcard._id = convertId(card, isExtra);
   // reversible cards have a separate Oracle ID on each face
   newcard.oracle_id = faceAttributeSource.oracle_id || card.oracle_id;
-  newcard.cmc = convertCmc(card, isExtra);
+  newcard.cmc = convertCmc(card, isExtra, faceAttributeSource);
   newcard.legalities = convertLegalities(card, isExtra);
   newcard.parsed_cost = convertParsedCost(card, isExtra);
   newcard.colors = convertColors(card, isExtra);
@@ -926,4 +933,5 @@ module.exports = {
   convertParsedCost,
   convertCmc,
   getTokens,
+  getFaceAttributeSource,
 };


### PR DESCRIPTION
### Issue
The "Heads I Win, Tails You Lose" Secret Lair drop introduced a new type of cards referred to as reversible cards. These cards have a completely separate card on each face. 

Because the faces are separate, they contain some properties that are usually relegated to the root card object. Notably, the root object of such cards doesn't include a `type_line` or an `oracle_id`; instead, each face has its own entry.

The lack of a `type_line` in particular broke down our parsing logic and caused every card update to crash, meaning our card database wasn't getting updated.

### Fix
I adjusted the handling of properties I found moved to correctly parse reversible cards from their face objects.

### Additional Notes
The way we handle cards with multiple faces is really wonky right now, and deserves a complete overhaul at some point. This PR doesn't aim for any big changes and exists purely to restore compatibility as quickly as possible.
