### PR TITLE
Release 5.7 Hotfix

### DIFF
--- a/serverjs/blogpostFeed.js
+++ b/serverjs/blogpostFeed.js
@@ -1,6 +1,30 @@
 const Blog = require('../models/blog.js');
 
-function getBlogFeedItems(user, skip, limit) {
+const getBlogFeedItems = (user, skip, limit) =>
+  Blog.find({
+    $or: [
+      {
+        cube: {
+          $in: user.followed_cubes,
+        },
+      },
+      {
+        owner: {
+          $in: user.followed_users,
+        },
+      },
+      {
+        dev: 'true',
+      },
+    ],
+  })
+    .sort({
+      date: -1,
+    })
+    .skip(skip)
+    .limit(limit);
+
+/* {
   // aggregation returns POJO results, so no .lean() needed
   return Blog.aggregate([
     {
@@ -37,7 +61,7 @@ function getBlogFeedItems(user, skip, limit) {
       $project: { cubes: 0 },
     },
   ]).allowDiskUse(true);
-}
+} */
 
 module.exports = {
   getBlogFeedItems,


### PR DESCRIPTION
This disables private cube ownership for blogpost feeds, as the query was not performant (took 10+ seconds)