### PR TITLE
fix(featured cubes) Fix adding cubes to featured queue

### DIFF
--- a/routes/users_routes.js
+++ b/routes/users_routes.js
@@ -844,6 +844,10 @@ router.post('/queuefeatured', ensureAuth, async (req, res) => {
   }
 
   const cube = await Cube.findOne(buildIdQuery(req.body.cubeId)).lean();
+  if (!cube) {
+    req.flash('danger', 'Cube not found');
+    return res.redirect(redirect);
+  }
   if (!req.user._id.equals(cube.owner)) {
     req.flash('danger', 'Only an owner of a cube can add it to the queue');
     return res.redirect(redirect);
@@ -878,7 +882,7 @@ router.post('/queuefeatured', ensureAuth, async (req, res) => {
 
   if (!update.ok) req.flash('danger', update.message);
   else req.flash('success', update.return);
-  return res.redirect('/user/account?nav=patreon');
+  return res.redirect(redirect);
 });
 
 router.post('/unqueuefeatured', ensureAuth, async (req, res) => {

--- a/src/pages/UserAccountPage.js
+++ b/src/pages/UserAccountPage.js
@@ -51,7 +51,7 @@ const AddFeaturedModal = ({ isOpen, toggle, cubes }) => {
         <ModalBody>
           <CustomInput type="select" id="featuredCube" name="cubeId">
             {cubes.map((cube) => (
-              <option value={cube.id}>{cube.name}</option>
+              <option value={cube._id}>{cube.name}</option>
             ))}
           </CustomInput>
         </ModalBody>

--- a/src/pages/UserAccountPage.js
+++ b/src/pages/UserAccountPage.js
@@ -73,7 +73,7 @@ AddFeaturedModal.propTypes = {
   toggle: PropTypes.func.isRequired,
   cubes: PropTypes.arrayOf(
     PropTypes.shape({
-      id: PropTypes.string.isRequired,
+      _id: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired,
     }),
   ).isRequired,


### PR DESCRIPTION
Turns out, cubes under the `user` object don't have an `id` property, they have an `_id` property. So, the value of options in the add modal was being set to `undefined`, meaning it wasn't being set, meaning the value defaulted to the option text, meaning the cube names were being sent as cube IDs, the lookup obviously failed, and the route handler crashed, which was uncaught and ultimately resulted in a gateway timeout. 

fml
