### PR TITLE
fix(docs) Correct typo in filter docs

### DIFF
--- a/src/pages/FiltersPage.js
+++ b/src/pages/FiltersPage.js
@@ -523,7 +523,7 @@ const ContactPage = ({ loginCallback }) => (
             <tbody>
               <tr>
                 <td>
-                  <code>t:Signed</code>
+                  <code>tag:Signed</code>
                 </td>
                 <td>All cards in a cube who have a tag named Signed, case insensitive.</td>
               </tr>


### PR DESCRIPTION
`t:` is for type, not tag.