### PR TITLE
fix(cards) Regex type hotfix

### DIFF
--- a/serverjs/updatecards.js
+++ b/serverjs/updatecards.js
@@ -298,7 +298,7 @@ function getTokens(card, catalogCard) {
           const re = new RegExp(reString);
           const result = re.exec(ability);
           // eslint-disable-next-line no-continue
-          if (typeof result === 'undefined') continue;
+          if (!result) continue;
 
           let tokenPowerAndToughness = result[4];
           const tokenColorString = result[5] ? result[5] : result[1];
@@ -859,7 +859,7 @@ const downloadFromScryfall = async (
   winston.info('Downloading files from scryfall...');
   try {
     // the module.exports line is necessary to correctly mock this function in unit tests
-    await module.exports.downloadDefaultCards(basePath, defaultPath, allPath);
+    // await module.exports.downloadDefaultCards(basePath, defaultPath, allPath);
   } catch (error) {
     winston.error('Downloading card data failed:');
     winston.error(error.message, error);

--- a/serverjs/updatecards.js
+++ b/serverjs/updatecards.js
@@ -859,7 +859,7 @@ const downloadFromScryfall = async (
   winston.info('Downloading files from scryfall...');
   try {
     // the module.exports line is necessary to correctly mock this function in unit tests
-    // await module.exports.downloadDefaultCards(basePath, defaultPath, allPath);
+    await module.exports.downloadDefaultCards(basePath, defaultPath, allPath);
   } catch (error) {
     winston.error('Downloading card data failed:');
     winston.error(error.message, error);


### PR DESCRIPTION
`RegExp.exec` returns `null` when a match isn't made, not `undefined`. Some recent card actually got to the point of failing the regex, which caused the import to crash on `result[4]` (since `result` is null).