### PR TITLE
fix(frontend) Hotfixes for Bootstrap/Reactstrap Migration

### DIFF
--- a/public/css/default.css
+++ b/public/css/default.css
@@ -47,3 +47,8 @@
   --code-bg: rgb(245, 245, 245);
   --read-only-disabled: #e9ecef;
 }
+
+/* override bootstrap's contrast mechanism for button text */
+.btn-accent, .btn-outline-accent:hover {
+  color: #fff !important;
+}

--- a/routes/users_routes.js
+++ b/routes/users_routes.js
@@ -451,8 +451,8 @@ router.post('/login', (req, res, next) => {
       }
       passport.authenticate('local', {
         successRedirect: redirect,
-        failureRedirect: '/user/Login',
-        failureFlash: true,
+        failureRedirect: '/user/login',
+        failureFlash: { type: 'danger' },
       })(req, res, next);
     }
   });

--- a/src/components/ArticlePreview.js
+++ b/src/components/ArticlePreview.js
@@ -33,7 +33,7 @@ const ArticlePreview = ({ article }) => {
         </small>
       </div>
       <div className={`w-100 pb-1 pt-0 px-2 m-0 ${hover ? 'preview-footer-bg-hover' : 'preview-footer-bg'}`}>
-        <small className="float-left">
+        <small className="float-start">
           Written by <Username userId={article.owner} defaultName={article.username} />
         </small>
         <small className="float-end">

--- a/src/components/BlogPost.js
+++ b/src/components/BlogPost.js
@@ -28,10 +28,10 @@ const BlogPost = ({ post, noScroll }) => {
       <CardHeader className="ps-4 pe-0 pt-2 pb-0">
         <h5 className="card-title">
           <a href={`/cube/blog/blogpost/${post._id}`}>{post.title}</a>
-          <div className="float-sm-right">
+          <div className="float-sm-end">
             {canEdit && (
               <>
-                <BlogContextMenu className="float-sm-right" post={post} value="..." onEdit={() => setEditOpen(true)} />
+                <BlogContextMenu className="float-sm-end" post={post} value="..." onEdit={() => setEditOpen(true)} />
                 <EditBlogModal
                   isOpen={editOpen}
                   toggle={() => setEditOpen((open) => !open)}

--- a/src/components/CreateCubeModal.js
+++ b/src/components/CreateCubeModal.js
@@ -38,14 +38,15 @@ const CreateCubeModal = ({ isOpen, toggle }) => {
           </FormGroup>
         </ModalBody>
         <ModalFooter>
-          {loading && (
-            <div className="centered w-50">
+          {loading ? (
+            <div className="text-center w-100">
               <Spinner />
             </div>
+          ) : (
+            <Button type="submit" color="accent" block outline disabled={loading}>
+              Create
+            </Button>
           )}
-          <Button type="submit" color="accent" block outline disabled={loading}>
-            Create
-          </Button>
         </ModalFooter>
       </CSRFForm>
     </Modal>

--- a/src/components/DeckPreview.js
+++ b/src/components/DeckPreview.js
@@ -9,6 +9,7 @@ import UserContext from 'contexts/UserContext';
 import useKeyHandlers from 'hooks/UseKeyHandlers';
 import DeckDeleteModal from 'components/DeckDeleteModal';
 import Username from 'components/Username';
+import { Col, Row } from 'reactstrap';
 
 /** 2020-11-17 struesdell:
  *  Pulled constants out of component render so that they are defined only once
@@ -61,47 +62,49 @@ const DeckPreview = ({ deck, nextURL }) => {
   };
 
   return (
-    <div className="deck-preview" {...handleClick}>
-      <h6 className="mb-0 text-muted">
-        <a href={`/cube/deck/${deck._id}`} title={fullName}>
-          {name}
-        </a>{' '}
-        by{' '}
-        {deck.seats[0].userid ? (
-          <Username userId={deck.seats[0].userid} defaultName={deck.seats[0].username} />
-        ) : (
-          'Anonymous'
-        )}{' '}
-        - <TimeAgo date={date} />
-        {canEdit && (
-          <>
-            <button
-              type="button"
-              className="btn-close"
-              style={{
-                fontSize: '.8rem',
-                textAlign: 'center',
-                width: '19px',
-                height: '19px',
-                paddingBottom: '2px',
-                lineHeight: '17px',
-                border: '1px solid rgba(0,0,0,.5)',
-                float: 'right',
-              }}
-              onClick={openDeleteModal}
-            >
-              <DeckDeleteModal
-                toggle={closeDeleteModal}
-                isOpen={deleteModalOpen}
-                deckID={deck._id}
-                cubeID={deck.cube}
-                nextURL={nextURL}
-              />
-            </button>
-          </>
-        )}
-      </h6>
-    </div>
+    <Row className="deck-preview" {...handleClick}>
+      <Col xs={canEdit ? 11 : 12}>
+        <h6 className="mb-0 text-muted">
+          <a href={`/cube/deck/${deck._id}`} title={fullName}>
+            {name}
+          </a>{' '}
+          by{' '}
+          {deck.seats[0].userid ? (
+            <Username userId={deck.seats[0].userid} defaultName={deck.seats[0].username} />
+          ) : (
+            'Anonymous'
+          )}{' '}
+          - <TimeAgo date={date} />
+        </h6>
+      </Col>
+      {canEdit && (
+        <Col xs={1}>
+          <button
+            type="button"
+            className="btn-close"
+            style={{
+              fontSize: '.8rem',
+              textAlign: 'center',
+              width: '19px',
+              height: '19px',
+              paddingBottom: '2px',
+              lineHeight: '17px',
+              border: '1px solid rgba(0,0,0,.5)',
+              float: 'right',
+            }}
+            onClick={openDeleteModal}
+          >
+            <DeckDeleteModal
+              toggle={closeDeleteModal}
+              isOpen={deleteModalOpen}
+              deckID={deck._id}
+              cubeID={deck.cube}
+              nextURL={nextURL}
+            />
+          </button>
+        </Col>
+      )}
+    </Row>
   );
 };
 

--- a/src/components/DeckPreview.js
+++ b/src/components/DeckPreview.js
@@ -62,8 +62,8 @@ const DeckPreview = ({ deck, nextURL }) => {
   };
 
   return (
-    <Row className="deck-preview" {...handleClick}>
-      <Col xs={canEdit ? 11 : 12}>
+    <Row className="deck-preview mx-0" {...handleClick}>
+      <Col xs={canEdit ? 11 : 12} className="ps-0">
         <h6 className="mb-0 text-muted">
           <a href={`/cube/deck/${deck._id}`} title={fullName}>
             {name}
@@ -78,7 +78,7 @@ const DeckPreview = ({ deck, nextURL }) => {
         </h6>
       </Col>
       {canEdit && (
-        <Col xs={1}>
+        <Col xs={1} className="pe-0">
           <button
             type="button"
             className="btn-close"

--- a/src/components/PodcastEpisodePreview.js
+++ b/src/components/PodcastEpisodePreview.js
@@ -40,7 +40,7 @@ const PodcastEpisodePreview = ({ episode }) => {
         </small>
       </div>
       <div className={`w-100 pb-1 pt-0 px-2 m-0 ${hover ? 'preview-footer-bg-hover' : 'preview-footer-bg'}`}>
-        <small className="float-left">
+        <small className="float-start">
           By <Username userId={episode.owner} defaultName={episode.username} />
         </small>
         <small className="float-end">

--- a/src/components/VideoPreview.js
+++ b/src/components/VideoPreview.js
@@ -33,7 +33,7 @@ const VideoPreview = ({ video }) => {
         </small>
       </div>
       <div className={`w-100 pb-1 pt-0 px-2 m-0 ${hover ? 'preview-footer-bg-hover' : 'preview-footer-bg'}`}>
-        <small className="float-left">
+        <small className="float-start">
           By <Username userId={video.owner} defaultName={video.username} />
         </small>
         <small className="float-end">

--- a/src/pages/UserAccountPage.js
+++ b/src/pages/UserAccountPage.js
@@ -256,22 +256,28 @@ const UserAccountPage = ({ defaultNav, loginCallback, patreonClientId, patreonRe
                 <CardBody>
                   <CSRFForm method="POST" action="/user/resetpassword">
                     <FormGroup row>
-                      <Label for="password" className="col-sm-4 col-form-Label">
+                      <Label for="password" sm={4}>
                         Old password:
                       </Label>
-                      <Input className="col-sm-8" id="currentPassword" name="password" type="password" />
+                      <Col sm={8}>
+                        <Input id="currentPassword" name="password" type="password" />
+                      </Col>
                     </FormGroup>
                     <FormGroup row>
-                      <Label for="newPassword" className="col-sm-4 col-form-Label">
+                      <Label for="newPassword" sm={4}>
                         New Password:
                       </Label>
-                      <Input className="col-sm-8" id="newPassword" name="password2" type="password" />
+                      <Col sm={8}>
+                        <Input id="newPassword" name="password2" type="password" />
+                      </Col>
                     </FormGroup>
                     <FormGroup row>
-                      <Label for="confirmPassword" className="col-sm-4 col-form-Label">
+                      <Label for="confirmPassword" sm={4}>
                         Confirm New Password:
                       </Label>
-                      <Input className="col-sm-8" id="confirmPassword" name="password3" type="password" />
+                      <Col sm={8}>
+                        <Input id="confirmPassword" name="password3" type="password" />
+                      </Col>
                     </FormGroup>
                     <Button outline block color="accent" type="submit">
                       Change Password
@@ -285,16 +291,20 @@ const UserAccountPage = ({ defaultNav, loginCallback, patreonClientId, patreonRe
                 <CardBody>
                   <CSRFForm method="POST" action="/user/updateemail">
                     <FormGroup row>
-                      <Label for="email" className="col-sm-4 col-form-Label">
+                      <Label for="email" sm={4}>
                         New Email:
                       </Label>
-                      <Input className="col-sm-8" id="email" name="email" type="email" defaultValue={user.email} />
+                      <Col sm={8}>
+                        <Input id="email" name="email" type="email" defaultValue={user.email} />
+                      </Col>
                     </FormGroup>
                     <FormGroup row>
-                      <Label for="emailPassword" className="col-sm-4 col-form-Label">
+                      <Label for="emailPassword" sm={4}>
                         Password:
                       </Label>
-                      <Input className="col-sm-8" id="emailPassword" name="password" type="password" />
+                      <Col sm={8}>
+                        <Input id="emailPassword" name="password" type="password" />
+                      </Col>
                     </FormGroup>
                     <Button block outline color="accent" type="submit">
                       Update


### PR DESCRIPTION
Resolves #2227.

There were several issues introduced in the upgrade to bootstrap 5 which are fixed in this PR:

- Green buttons had black text in default mode. That's because bootstrap calculated it to have higher contrast than white text. However, as it appears a bit out of place, the original white text was restored. Dark mode doesn't have this issue, as it uses a darker shade of green on buttons.
- The "edit" button on blog posts wasn't properly flushed right, due to an error in replacing `float` classes. This has been rectified.
- Some forms on the user account page were misaligned based on a misunderstanding of bootstrap's new layout mechanisms. They were refactored to appear correctly.
- When creating a new cube, the loading spinner appears just above the "Create" button in an awkward position. For aesthetic reasons, this PR updates that modal so that now the spinner simply replaces that button.
- The delete button on deck previews was misaligned when the preview split into multiple lines. This no longer happens.
- The "Invalid Password" prompt used an outdated class (implicitly defined by `passport`) and thus appeared transparent. This PR sets the appropriate class explicitly.

## Screenshots
### Button Text
#### Old
![buttontext_old](https://user-images.githubusercontent.com/38463785/163670300-a6262877-b77c-4796-b971-18ed99fa8118.png)
#### New
![buttontext_new](https://user-images.githubusercontent.com/38463785/163670344-241f1e06-c61b-4084-af5d-76cbc250dc62.png)
### Blogpost Edit
#### Old
![blogpost_old](https://user-images.githubusercontent.com/38463785/163670350-e838f996-2b8e-426b-88a3-41b35fc86698.png)
#### New
![blogpost_new](https://user-images.githubusercontent.com/38463785/163670353-cbd20e2d-6b7a-4470-ac04-6d5f4308fc6c.png)
### Account Forms
#### Old
![form_old](https://user-images.githubusercontent.com/38463785/163670378-5f8959be-39c1-476b-ba9f-7624b1df5cdf.png)
#### New
![form_new](https://user-images.githubusercontent.com/38463785/163670383-d1afb95a-dd66-4be0-ae0d-ab106d352b86.png)
### New Cube Modal
#### Old
![newcube_old](https://user-images.githubusercontent.com/38463785/163670391-4510fed9-a56e-4f0c-a440-bb8dadb51fda.png)
#### New
![newcube_new](https://user-images.githubusercontent.com/38463785/163670395-4916bacf-4f05-4159-84b6-e9bdc3955a2e.png)
### Deck Preview
#### Old
![drafts_old](https://user-images.githubusercontent.com/38463785/163670403-b8b712c4-a19c-44d0-aa57-f05e7ce15f66.png)
#### New
![drafts_new](https://user-images.githubusercontent.com/38463785/163670413-73257621-3c2d-4ccf-835f-6754207a343c.png)
### Password Prompt
#### Old
![password_old](https://user-images.githubusercontent.com/38463785/163670425-7eba87aa-ce16-43bf-9ae5-a8f6446f540c.png)
#### New
![password_new](https://user-images.githubusercontent.com/38463785/163670434-4c98881a-aa5b-4f46-9269-85738bec0d13.png)


