### PR TITLE
fix(cube) Refresh Invalid Card Images

### DIFF
--- a/models/comment.js
+++ b/models/comment.js
@@ -13,7 +13,8 @@ const commentSchema = mongoose.Schema({
   updated: Boolean,
   image: {
     type: String,
-    default: 'https://img.scryfall.com/cards/art_crop/front/0/c/0c082aa8-bf7f-47f2-baf8-43ad253fd7d7.jpg?1562826021',
+    default:
+      'https://c1.scryfall.com/file/scryfall-cards/art_crop/front/0/c/0c082aa8-bf7f-47f2-baf8-43ad253fd7d7.jpg?1562826021',
   },
   artist: {
     type: String,

--- a/models/user.js
+++ b/models/user.js
@@ -71,7 +71,8 @@ const UserSchema = mongoose.Schema({
   },
   image: {
     type: String,
-    default: 'https://img.scryfall.com/cards/art_crop/front/0/c/0c082aa8-bf7f-47f2-baf8-43ad253fd7d7.jpg?1562826021',
+    default:
+      'https://c1.scryfall.com/file/scryfall-cards/art_crop/front/0/c/0c082aa8-bf7f-47f2-baf8-43ad253fd7d7.jpg?1562826021',
   },
   artist: {
     type: String,

--- a/one_shot_scripts/refresh_images.js
+++ b/one_shot_scripts/refresh_images.js
@@ -1,0 +1,49 @@
+// Load Environment Variables
+require('dotenv').config();
+
+const mongoose = require('mongoose');
+const Cube = require('../models/cube');
+const carddb = require('../serverjs/cards');
+
+const batchSize = 100;
+
+async function fixImage(cube) {
+  // only urls from the img.* subdomain are invalid
+  if (!cube.image_uri.startsWith('https://img.scryfall.com')) return;
+
+  const image = carddb.imagedict[cube.image_name.toLowerCase().trim()];
+  if (!image) return;
+
+  cube.image_uri = image.uri;
+  await cube.save();
+}
+
+(async () => {
+  await carddb.initializeCardDb();
+  mongoose.connect(process.env.MONGODB_URL).then(async () => {
+    const count = await Cube.countDocuments();
+    const cursor = Cube.find().cursor();
+
+    // batch them by batchSize
+    for (let i = 0; i < count; i += batchSize) {
+      const cubes = [];
+      for (let j = 0; j < batchSize; j++) {
+        try {
+          if (i + j < count) {
+            const cube = await cursor.next();
+            if (cube) {
+              cubes.push(cube);
+            }
+          }
+        } catch (err) {
+          console.debug(err);
+        }
+      }
+      await Promise.all(cubes.map((cube) => fixImage(cube)));
+      console.log(`Finished: ${i} of ${count} cubes`);
+    }
+    await mongoose.disconnect();
+    console.log('done');
+    process.exit();
+  });
+})();

--- a/one_shot_scripts/refresh_images.js
+++ b/one_shot_scripts/refresh_images.js
@@ -3,44 +3,54 @@ require('dotenv').config();
 
 const mongoose = require('mongoose');
 const Cube = require('../models/cube');
-const carddb = require('../serverjs/cards');
+const Article = require('../models/article');
+const Comment = require('../models/comment');
+const User = require('../models/user');
 
 const batchSize = 100;
 
-async function fixImage(cube) {
+async function fixImage(doc, prop) {
   // only urls from the img.* subdomain are invalid
-  if (!cube.image_uri.startsWith('https://img.scryfall.com')) return;
+  if (!doc[prop].startsWith('https://img.scryfall.com')) return;
 
-  const image = carddb.imagedict[cube.image_name.toLowerCase().trim()];
-  if (!image) return;
-
-  cube.image_uri = image.uri;
-  await cube.save();
+  doc[prop] = doc[prop].replace('https://img.scryfall.com/cards', 'https://c1.scryfall.com/file/scryfall-cards');
+  await doc.save();
 }
 
-(async () => {
-  await carddb.initializeCardDb();
-  mongoose.connect(process.env.MONGODB_URL).then(async () => {
-    const count = await Cube.countDocuments();
-    const cursor = Cube.find().cursor();
+const documents = {
+  Article: [Article, 'image'],
+  Comment: [Comment, 'image'],
+  Cube: [Cube, 'image_uri'],
+  User: [User, 'image'],
+};
 
-    // batch them by batchSize
-    for (let i = 0; i < count; i += batchSize) {
-      const cubes = [];
-      for (let j = 0; j < batchSize; j++) {
-        try {
-          if (i + j < count) {
-            const cube = await cursor.next();
-            if (cube) {
-              cubes.push(cube);
+(async () => {
+  mongoose.connect(process.env.MONGODB_URL).then(async () => {
+    for (const [name, value] of Object.entries(documents)) {
+      console.log(`Processing ${name}s...`);
+      const [Collection, prop] = value;
+      const count = await Collection.countDocuments();
+      const cursor = Collection.find().cursor();
+
+      // batch them by batchSize
+      for (let i = 0; i < count; i += batchSize) {
+        const docs = [];
+        for (let j = 0; j < batchSize; j++) {
+          try {
+            if (i + j < count) {
+              const doc = await cursor.next();
+              if (doc) {
+                docs.push(doc);
+              }
             }
+          } catch (err) {
+            console.debug(err);
           }
-        } catch (err) {
-          console.debug(err);
         }
+        await Promise.all(docs.map((doc) => fixImage(doc, prop)));
+        console.log(`Finished: ${i} of ${count} ${name}s`);
       }
-      await Promise.all(cubes.map((cube) => fixImage(cube)));
-      console.log(`Finished: ${i} of ${count} cubes`);
+      console.log(`Done with ${name}s`);
     }
     await mongoose.disconnect();
     console.log('done');

--- a/routes/admin_routes.js
+++ b/routes/admin_routes.js
@@ -535,7 +535,7 @@ router.get('/removecomment/:id', ensureAdmin, async (req, res) => {
   comment.owner = null;
   comment.ownerName = null;
   comment.image =
-    'https://img.scryfall.com/cards/art_crop/front/0/c/0c082aa8-bf7f-47f2-baf8-43ad253fd7d7.jpg?1562826021';
+    'https://c1.scryfall.com/file/scryfall-cards/art_crop/front/0/c/0c082aa8-bf7f-47f2-baf8-43ad253fd7d7.jpg?1562826021';
   comment.artist = 'Allan Pollack';
   comment.updated = true;
   comment.content = '[removed by moderator]';

--- a/routes/comment_routes.js
+++ b/routes/comment_routes.js
@@ -164,7 +164,7 @@ router.post(
     comment.ownerName = newComment.ownerName;
     comment.image = newComment.owner
       ? req.user.image
-      : 'https://img.scryfall.com/cards/art_crop/front/0/c/0c082aa8-bf7f-47f2-baf8-43ad253fd7d7.jpg?1562826021';
+      : 'https://c1.scryfall.com/file/scryfall-cards/art_crop/front/0/c/0c082aa8-bf7f-47f2-baf8-43ad253fd7d7.jpg?1562826021';
     comment.artist = newComment.owner ? 'Allan Pollack' : req.user.artist;
     comment.updated = true;
     comment.content = newComment.content.substring(0, 5000);

--- a/src/components/Comment.js
+++ b/src/components/Comment.js
@@ -48,7 +48,8 @@ const Comment = ({ comment, index, depth, noReplies, editComment }) => {
       content: '[deleted]',
       timePosted: new Date(),
       updated: true,
-      image: 'https://img.scryfall.com/cards/art_crop/front/0/c/0c082aa8-bf7f-47f2-baf8-43ad253fd7d7.jpg?1562826021',
+      image:
+        'https://c1.scryfall.com/file/scryfall-cards/art_crop/front/0/c/0c082aa8-bf7f-47f2-baf8-43ad253fd7d7.jpg?1562826021',
       artist: 'Allan Pollack',
     });
   };


### PR DESCRIPTION
Scryfall deprecated the `img.*` subdomain last year, and it looks like they took it offline today. Some old cubes unfortunately still use those links as image URLs. This is a one-shot script that replaces those broken images with their current versions.

In the long run, it might be worth considering whether it's useful to store the actual URL at all or if we should just fetch it on demand (given that the image dict is loaded in memory).