### PR TITLE
feat(frontend) Confirm Cube Delete by Name

### DIFF
--- a/src/components/DeleteCubeModal.js
+++ b/src/components/DeleteCubeModal.js
@@ -14,12 +14,12 @@ const DeleteCubeModal = ({ isOpen, toggle, cubeId, cubeName }) => {
         <ModalBody>
           <p>Are you sure you wish to delete this cube? This action cannot be undone.</p>
           <p>
-            Please type <code>{cubeName}</code> in order to confirm.
+            Please type <code>{cubeName.trim()}</code> in order to confirm.
           </p>
           <Input value={deleteText} onChange={(e) => setDeleteText(e.target.value)} />
         </ModalBody>
         <ModalFooter>
-          <Button type="submit" color="unsafe" outline disabled={deleteText !== cubeName}>
+          <Button type="submit" color="unsafe" outline disabled={deleteText !== cubeName.trim()}>
             Delete
           </Button>
           <Button onClick={toggle}>Close</Button>

--- a/src/components/DeleteCubeModal.js
+++ b/src/components/DeleteCubeModal.js
@@ -5,19 +5,21 @@ import { Modal, ModalBody, ModalHeader, Input, Button, ModalFooter } from 'react
 
 import CSRFForm from 'components/CSRFForm';
 
-const DeleteCubeModal = ({ isOpen, toggle, cubeid }) => {
+const DeleteCubeModal = ({ isOpen, toggle, cubeId, cubeName }) => {
   const [deleteText, setDeleteText] = useState('');
   return (
     <Modal size="lg" isOpen={isOpen} toggle={toggle}>
       <ModalHeader toggle={toggle}>Confirm Cube Delete</ModalHeader>
-      <CSRFForm method="POST" action={`/cube/remove/${cubeid}`}>
+      <CSRFForm method="POST" action={`/cube/remove/${cubeId}`}>
         <ModalBody>
           <p>Are you sure you wish to delete this cube? This action cannot be undone.</p>
-          <p>Please type 'Delete' in order to confirm</p>
+          <p>
+            Please type <code>{cubeName}</code> in order to confirm.
+          </p>
           <Input value={deleteText} onChange={(e) => setDeleteText(e.target.value)} />
         </ModalBody>
         <ModalFooter>
-          <Button type="submit" color="unsafe" outline disabled={deleteText !== 'Delete'}>
+          <Button type="submit" color="unsafe" outline disabled={deleteText !== cubeName}>
             Delete
           </Button>
           <Button onClick={toggle}>Close</Button>
@@ -30,7 +32,8 @@ const DeleteCubeModal = ({ isOpen, toggle, cubeid }) => {
 DeleteCubeModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   toggle: PropTypes.func.isRequired,
-  cubeid: PropTypes.string.isRequired,
+  cubeId: PropTypes.string.isRequired,
+  cubeName: PropTypes.string.isRequired,
 };
 
 export default DeleteCubeModal;

--- a/src/pages/CubeOverviewPage.js
+++ b/src/pages/CubeOverviewPage.js
@@ -145,7 +145,9 @@ const CubeOverview = ({ post, priceOwned, pricePurchase, cube, followed, followe
                   </CustomizeBasicsModalLink>
                 </NavItem>
                 <NavItem>
-                  <DeleteCubeModalLink modalProps={{ cubeid: cubeState._id }}>Delete Cube</DeleteCubeModalLink>
+                  <DeleteCubeModalLink modalProps={{ cubeId: cubeState._id, cubeName: cube.name }}>
+                    Delete Cube
+                  </DeleteCubeModalLink>
                 </NavItem>
               </Nav>
             </UncontrolledCollapse>


### PR DESCRIPTION
As is, the confirmation modal for deleting a cube just asks you to type the word 'Delete'. This is problematic, as it can lead to people accidentally deleting the wrong cube. This PR addresses that issue by having the user type in the name of the cube they're deleting instead.

### Screenshots
![Screenshot 2022-06-06 at 10-34-23 Cube Cobra Overview test cube](https://user-images.githubusercontent.com/38463785/172145616-2f57ecad-e70a-4b9f-b005-c5f5bb2366fc.png)
![Screenshot 2022-06-06 at 10-34-43 Cube Cobra Overview test cube](https://user-images.githubusercontent.com/38463785/172145622-fd5c225c-ab06-428a-ad64-55cd54b6cf34.png)
