### PR TITLE
fix(frontend) Remove Row Gutters in Card Grid

### DIFF
--- a/src/components/CardGrid.js
+++ b/src/components/CardGrid.js
@@ -12,7 +12,7 @@ function cardImage(Tag, card, cardProps, linkDetails) {
 
 const CardGrid = ({ cardList, Tag, colProps, cardProps, linkDetails, ...props }) => {
   return (
-    <Row className="justify-content-center" {...props}>
+    <Row className="justify-content-center g-0" {...props}>
       {cardList.map((card, cardIndex) => (
         <Col key={/* eslint-disable-line react/no-array-index-key */ cardIndex} {...colProps}>
           {cardImage(Tag, card, cardProps, linkDetails)}

--- a/src/components/CardModal.js
+++ b/src/components/CardModal.js
@@ -53,7 +53,7 @@ const CardModal = ({
         <Row>
           <Col xs="12" sm="4">
             <FoilCardImage card={card} finish={values.finish} />
-            <Row className="mb-2 ">
+            <Row className="mb-2 g-0">
               {card.details.prices && Number.isFinite(cardPrice(card)) && (
                 <TextBadge name="Price" className="mt-2 me-2">
                   <Tooltip text="TCGPlayer Market Price">${cardPrice(card).toFixed(2)}</Tooltip>


### PR DESCRIPTION
### Issue
Whenever any `CardGrid` component is rendered (Visual Spoiler, Sample Hand, Card Search, ...), unwanted horizontal margins are displayed between each card in the grid.

### Cause
When creating the Bootstrap 5 migration, I apparently overlooked that the `noGutters` property on `Row` reactstrap components was deprecated in favor of Bootstrap's new gutter utilities. In commit 3e72abda, @dekkerglen seems to have noticed this and replaced these props with the appropriate classname, however the `CardGrid` component wasn't replaced properly - the old prop was removed, but no equivalent CSS classes were added. This also happened in the `CardModal` component.

### Fix
Add the `g-0` CSS class to the components that were missed in the update.