### PR TITLE
Add multicolored and colorless symbols to Markdown docs

### DIFF
--- a/src/pages/MarkdownPage.js
+++ b/src/pages/MarkdownPage.js
@@ -334,7 +334,7 @@ const MarkdownPage = ({ loginCallback }) => (
             <Card>
               <CardHeader>Result</CardHeader>
               <CardBody>
-                <Markdown markdown={'{e}{T}{q}{s}{X}{Y}{15}'} />
+                <Markdown markdown={'{e}{T}{q}{s}{m}{c}{X}{Y}{15}'} />
               </CardBody>
             </Card>
           </Col>

--- a/src/pages/MarkdownPage.js
+++ b/src/pages/MarkdownPage.js
@@ -325,7 +325,7 @@ const MarkdownPage = ({ loginCallback }) => (
               <CardHeader>Source</CardHeader>
               <CardBody>
                 <p>
-                  <code>{'{e}{T}{q}{s}{X}{Y}{15}'}</code>
+                  <code>{'{e}{T}{q}{s}{m}{c}{X}{Y}{15}'}</code>
                 </p>
               </CardBody>
             </Card>


### PR DESCRIPTION
Just a teeny PR, the multicolored and colorless symbols are supported by Cubecobra, so this might save someone a few seconds

![Screenshot from 2023-01-21 09-03-09](https://user-images.githubusercontent.com/23239955/213830977-fb66ae7a-d7a4-4d79-abf7-9e3891cf1410.png)
