### PR TITLE
fix: local setup to run project properly

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         node-version: 16
     - name: Setup
-      run: npm install
+      run: npm ci
     - name: Build
       run: npm run ci-build
     - name: Check Code Style

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -39,7 +39,7 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: Installing NPM
-        run: npm install
+        run: npm ci
 
       - name: Building application
         run: npm run ci-build

--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -39,7 +39,7 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: Installing NPM
-        run: npm install
+        run: npm ci
 
       - name: Building application
         run: npm run ci-build

--- a/.platform/confighooks/prebuild/00_npm_install.sh
+++ b/.platform/confighooks/prebuild/00_npm_install.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 cd /var/app/staging
-sudo -u webapp npm install sharp
+sudo -u webapp npm ci sharp

--- a/.platform/confighooks/prebuild/00_npm_install.sh
+++ b/.platform/confighooks/prebuild/00_npm_install.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 cd /var/app/staging
-sudo -u webapp npm ci sharp
+sudo -u webapp npm install sharp

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ For the first setup, you will need to run:
 
 ```sh
 npm install
+node one_shot_scripts/create_local_files.js
 node --max-old-space-size=4096 one_shot_scripts/createTables.js
 node --max-old-space-size=4096 jobs/update_cards.js
 ```

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Here is a table on how to fill out the env vars:
 For the first setup, you will need to run:
 
 ```sh
-npm install
+npm ci
 node one_shot_scripts/create_local_files.js
 node --max-old-space-size=4096 one_shot_scripts/createTables.js
 node --max-old-space-size=4096 jobs/update_cards.js

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Here is a table on how to fill out the env vars:
 For the first setup, you will need to run:
 
 ```sh
-npm ci
+npm ci && npm run webpack
 node one_shot_scripts/create_local_files.js
 node --max-old-space-size=4096 one_shot_scripts/createTables.js
 node --max-old-space-size=4096 jobs/update_cards.js

--- a/jobs/update_cards.js
+++ b/jobs/update_cards.js
@@ -99,6 +99,9 @@ function initializeCatalog() {
 initializeCatalog();
 
 function downloadFile(url, filePath) {
+  const folder = filePath.substring(0, filePath.lastIndexOf('/'));
+  const folderExists = fs.existsSync(folder);
+  if (!folderExists) fs.mkdirSync(path.join(__dirname, `../${folder}`));
   const file = fs.createWriteStream(filePath);
   return new Promise((resolve, reject) => {
     https

--- a/one_shot_scripts/create_local_files.js
+++ b/one_shot_scripts/create_local_files.js
@@ -1,0 +1,5 @@
+const fs = require('fs');
+
+fs.mkdirSync('model/');
+fs.writeFileSync('model/elos.json', '[]');
+fs.writeFileSync('model/indexToOracleMap.json', '[]');

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "devstart": "npm run nearley && npm run sass -- --watch & npm run nodemon & npm run webpack-dev-server & npm run webpack -- --watch",
     "setup": "npm run nearley && npm run webpack -- --progress && node --max-old-space-size=8000 force_update.js",
     "cards": "node --max-old-space-size=6000 force_update.js",
-    "start": "npm install && npm run cards && node server.js",
+    "start": "npm ci && npm run cards && node server.js",
     "sass": "sass scss:public/css/bootstrap --no-source-map",
     "run-daily-jobs": "sh jobs/definition/daily.sh",
     "run-weekly-jobs": "sh jobs/definition/weekly.sh",


### PR DESCRIPTION
This PR changes some runs of npm i for npm ci.
Running ci is a more secure way to install dependencies without accidentally update some breaking-change lib upgrades. [More about that npm ci x npm i](https://betterprogramming.pub/npm-ci-vs-npm-install-which-should-you-use-in-your-node-js-projects-51e07cb71e26)

I'm also fixing or adding some code to properly run initial scripts. It can save some time for new contributors.
Also these adds encloses an [issue](https://github.com/dekkerglen/CubeCobra/issues/2390) I opened