### PR TITLE
Updated CompareView.js to utilize card modals with AutoCardListItems.

### DIFF
--- a/src/components/CompareView.js
+++ b/src/components/CompareView.js
@@ -9,6 +9,9 @@ import { getLabels, sortIntoGroups } from 'utils/Sort';
 import AutocardListItem from 'components/AutocardListItem';
 import CardPropType from 'proptypes/CardPropType';
 import CubeContext from 'contexts/CubeContext';
+import withCardModal from './WithCardModal';
+
+const CardModalLink = withCardModal(AutocardListItem);
 
 const CompareGroup = ({ heading, both, onlyA, onlyB }) => {
   const bothCmc = sortIntoGroups(both, 'Mana Value');
@@ -36,7 +39,17 @@ const CompareGroup = ({ heading, both, onlyA, onlyB }) => {
             ].map(([cards, key]) => (
               <Col xs="4" key={key}>
                 {(cards[cmc] || []).map((card, index) => (
-                  <AutocardListItem key={index} card={card} />
+                  <CardModalLink 
+                  key={card.index}
+                  card={card}
+                  altClick={() => {
+                    window.open(`/tool/card/${card.cardID}`);
+                  }}
+                  className={index === 0 ? 'cmc-group' : undefined}
+                  modalProps={{
+                    card,
+                  }}  
+                />
                 ))}
               </Col>
             ))}


### PR DESCRIPTION
issue #2407

**Context**

When comparing two cubes the listed cards cannot be clicked on to open the relevant Card Modals. This negatively impacts the utility of the compare view for mobile users as there is not way to view card details/oracle text. 

**Changelog**

Updates the CompareView.js component to utilize a CardModalLink similar to a cube list table view.



 On branch add_card_modal_to_compare_view_issue_2407
 Changes to be committed:
	modified:   src/components/CompareView.js