### PR TITLE
Use carddb defaults for cmc and colors in csv export

### DIFF
--- a/routes/cube/helper.js
+++ b/routes/cube/helper.js
@@ -186,7 +186,7 @@ function writeCard(res, card, maybe) {
   if (!card.type_line) {
     card.type_line = carddb.cardFromId(card.cardID).type;
   }
-  const { name, rarity, colorcategory } = carddb.cardFromId(card.cardID);
+  const { name, rarity, colorcategory, cmc,  color_identity} = carddb.cardFromId(card.cardID);
   let { imgUrl, imgBackUrl } = card;
   if (imgUrl) {
     imgUrl = `"${imgUrl}"`;
@@ -199,9 +199,9 @@ function writeCard(res, card, maybe) {
     imgBackUrl = '';
   }
   res.write(`"${name.replace(/"/, '""')}",`);
-  res.write(`${card.cmc || ''},`);
+  res.write(`${card.cmc || cmc},`);
   res.write(`"${card.type_line.replace('—', '-')}",`);
-  res.write(`${(card.colors || []).join('')},`);
+  res.write(`${(card.colors || color_identity).join('')},`);
   res.write(`"${carddb.cardFromId(card.cardID).set}",`);
   res.write(`"${carddb.cardFromId(card.cardID).collector_number}",`);
   res.write(`${card.rarity && card.rarity !== 'undefined' ? card.rarity : rarity},`);


### PR DESCRIPTION
Currently, csv export leaves Color and CMC empty unless you manually set them on each card.

This change uses defaults from the carddb instead, since we're already loading from the carddb for other fields anyway.

Tested locally, using both cards that have these fields manually overridden and cards that don't.
