### PR TITLE
Unify AWS Key ID Variable Name

### DIFF
--- a/dynamo/cache.js
+++ b/dynamo/cache.js
@@ -54,7 +54,7 @@ const AWS = require('aws-sdk');
 
 // Set the region
 AWS.config.update({
-  accessKeyId: process.env.AWS_ACCESS_KEY,
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
   secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
   region: 'us-east-2',
 });

--- a/dynamo/client.js
+++ b/dynamo/client.js
@@ -6,7 +6,7 @@ const AWS = require('aws-sdk');
 
 // Set the region
 AWS.config.update({
-  accessKeyId: process.env.AWS_ACCESS_KEY,
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
   secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
   region: 'us-east-2',
 });

--- a/dynamo/documentClient.js
+++ b/dynamo/documentClient.js
@@ -6,7 +6,7 @@ const AWS = require('aws-sdk');
 
 // Set the region
 AWS.config.update({
-  accessKeyId: process.env.AWS_ACCESS_KEY,
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
   secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
   region: 'us-east-2',
 });

--- a/dynamo/s3client.js
+++ b/dynamo/s3client.js
@@ -8,7 +8,7 @@ const { get, put, invalidate } = require('./cache');
 
 // Set the region
 AWS.config.update({
-  accessKeyId: process.env.AWS_ACCESS_KEY,
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
   secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
   region: 'us-east-2',
 });

--- a/jobs/download_model.js
+++ b/jobs/download_model.js
@@ -5,7 +5,7 @@ const AWS = require('aws-sdk');
 
 const downloadFromS3 = async () => {
   const s3 = new AWS.S3({
-    accessKeyId: process.env.AWS_ACCESS_KEY,
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
   });
 

--- a/jobs/update_cards.js
+++ b/jobs/update_cards.js
@@ -873,7 +873,7 @@ const downloadFromScryfall = async (metadatadict, indexToOracle) => {
 };
 
 const s3 = new AWS.S3({
-  accessKeyId: process.env.AWS_ACCESS_KEY,
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
   secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
 });
 

--- a/serverjs/updatecards.js
+++ b/serverjs/updatecards.js
@@ -4,7 +4,7 @@ const carddb = require('./carddb');
 
 const downloadFromS3 = async (basePath = 'private') => {
   const s3 = new AWS.S3({
-    accessKeyId: process.env.AWS_ACCESS_KEY,
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
   });
 


### PR DESCRIPTION
Some parts of code were using the `AWS_ACCESS_KEY` env variable instead of the documented `AWS_ACCESS_KEY_ID` for AWS credentials. This unexpectedly broke AWS requests on local deployments unless both variables were defined. 

The offending usages have been changed to the correct name to rectify this.