### PR TITLE
Use date passed in from FeaturedQueue.put document for updating featured cube object.

### DIFF
--- a/dynamo/models/featuredQueue.js
+++ b/dynamo/models/featuredQueue.js
@@ -36,7 +36,7 @@ module.exports = {
   put: async (document) => {
     await client.put({
       [FIELDS.CUBE]: document[FIELDS.CUBE],
-      [FIELDS.DATE]: new Date().valueOf(),
+      [FIELDS.DATE]: document[FIELDS.DATE],
       [FIELDS.OWNER]: document[FIELDS.OWNER],
       [FIELDS.FEATURED_ON]: document[FIELDS.FEATURED_ON],
       [FIELDS.STATUS]: STATUS.ACTIVE,


### PR DESCRIPTION
Cubes were getting this date reset with every put call, which meant it happened when they were pulled off the featured list (desired) and when they became featured (undesired). Resetting that date meant that they were never going to be old enough to reach featured=false.