### PR TITLE
Fix .eslintrc configuration

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -4,7 +4,7 @@ env:
 extends:
   - airbnb
   - prettier
-parser: 'babel-eslint'
+parser: '@babel/eslint-parser'
 plugins:
   - prettier
   - react-hooks


### PR DESCRIPTION
When `babel-eslint` was replaced with `@babel/eslint-parser`, the parser setting in `.eslintrc.yml` was not replaced, causing any `eslint` commands to fail (including the CI format checker pipeline). Now, the pipeline can fail for traditional reasons, such as the four hundred linter errors :slightly_smiling_face: 