### PR TITLE
More permissive init script

### DIFF
--- a/one_shot_scripts/create_local_files.js
+++ b/one_shot_scripts/create_local_files.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
 
-fs.mkdirSync('model/');
+fs.mkdirSync('model/', { recursive: true });
 fs.writeFileSync('model/elos.json', '[]');
 fs.writeFileSync('model/indexToOracleMap.json', '[]');


### PR DESCRIPTION
Don't need to throw an exception when the model directory already exists.