### PR TITLE
Support special characters in autocomplete

### DIFF
--- a/serverjs/carddb.js
+++ b/serverjs/carddb.js
@@ -145,7 +145,7 @@ function reasonableId(id) {
   return reasonableCard(cardFromId(id));
 }
 
-function normalizeName(name) {
+function getNameForComparison(name) {
   return name
     .trim()
     .normalize('NFD') // convert to consistent unicode format
@@ -160,11 +160,11 @@ function getIdsFromName(name) {
     const split = name.split('[');
     return getIdsFromName(split[0])
       .map((id) => cardFromId(id))
-      .filter((card) => normalizeName(card.full_name) === name)
+      .filter((card) => getNameForComparison(card.full_name) === getNameForComparison(name))
       .map((card) => card.scryfall_id);
   }
 
-  return data.nameToId[normalizeName(name)];
+  return data.nameToId[getNameForComparison(name)];
 }
 
 // Printing = 'recent' or 'first'

--- a/src/components/AutocompleteInput.js
+++ b/src/components/AutocompleteInput.js
@@ -32,11 +32,11 @@ function cloneIfNecessary(value, optionsArgument) {
 function mergeObject(target, source, optionsArgument) {
   const destination = {};
   if (isMergeableObject(target)) {
-    Object.keys(target).forEach(function (key) {
+    Object.keys(target).forEach((key) => {
       destination[key] = cloneIfNecessary(target[key], optionsArgument);
     });
   }
-  Object.keys(source).forEach(function (key) {
+  Object.keys(source).forEach((key) => {
     if (!isMergeableObject(source[key]) || !target[key]) {
       destination[key] = cloneIfNecessary(source[key], optionsArgument);
     } else {
@@ -63,7 +63,7 @@ function deepmerge(target, source, optionsArgument) {
 
 function defaultArrayMerge(target, source, optionsArgument) {
   const destination = target.slice();
-  source.forEach(function (e, i) {
+  source.forEach((e, i) => {
     if (typeof destination[i] === 'undefined') {
       destination[i] = cloneIfNecessary(e, optionsArgument);
     } else if (isMergeableObject(e)) {
@@ -165,9 +165,7 @@ deepmerge.all = function deepmergeAll(array, optionsArgument) {
   }
 
   // we are sure there are at least 2 values, so it is safe to have no initial value
-  return array.reduce(function (prev, next) {
-    return deepmerge(prev, next, optionsArgument);
-  });
+  return array.reduce((prev, next) => deepmerge(prev, next, optionsArgument));
 };
 
 // Map URL => Promise returning tree
@@ -240,9 +238,13 @@ const AutocompleteInput = forwardRef(
     );
 
     // Replace curly quotes with straight quotes. Needed for iOS.
-    const normalizedValue = (value || '').replace(/[\u2018\u2019\u201C\u201D]/g, (c) =>
-      '\'\'""'.substr('\u2018\u2019\u201C\u201D'.indexOf(c), 1),
-    );
+    const normalizedValue = (value || '')
+      .replace(/[\u2018\u2019\u201C\u201D]/g, (c) => '\'\'""'.substr('\u2018\u2019\u201C\u201D'.indexOf(c), 1))
+      .trim()
+      .normalize('NFD') // convert to consistent unicode format
+      .replace(/[\u0300-\u036f]/g, '') // remove unicode
+      .toLowerCase();
+
     const matches = useMemo(() => getAllMatches(tree, normalizedValue), [tree, normalizedValue]);
     const showMatches = visible && value && matches.length > 0 && !(matches.length === 1 && matches[0] === value);
 


### PR DESCRIPTION
The autocomplete widget won't match a card name like `Lórien Revealed`. This PR fixes that. It also renames the `normalizeName` function in the API route, because I realized it conflicted with an export.

Finally, auto-fix did some stuff in AutocompleteInput.js.

Video:

https://github.com/dekkerglen/CubeCobra/assets/12662580/de624313-8438-40c9-b6da-eb38faf538fe

