### PR TITLE
fix "drafts end early" bug caused by concurrent trybotpicks calls

### DIFF
--- a/serverjs/multiplayerDrafting.js
+++ b/serverjs/multiplayerDrafting.js
@@ -549,7 +549,6 @@ const getDraftPick = async (draftId, seat) => {
 const tryBotPicks = async (draftId) => {
   const { currentPack, seats, totalPacks } = await getDraftMetaData(draftId);
   const finished = await hget(draftRef(draftId), 'finished');
-
   if (finished === 'true') {
     return 'done';
   }
@@ -578,13 +577,13 @@ const tryBotPicks = async (draftId) => {
     if (await isPackDone(draftId)) {
       if (currentPack < totalPacks) {
         await openPack(draftId);
-        return 'in_progress';
+        return 'inProgress';
       }
       // draft is done
       await finishDraft(draftId);
       return 'done';
     }
-    return 'in_progress';
+    return 'inProgress';
   });
 
   return res || 'done'; // could be null if we fail to obtain a lock


### PR DESCRIPTION
Concurrent calls to trybotpicks were updating the pack number twice at once. This replaces the setInterval call with a while loop that has a setTimeout in it.