### PR TITLE
fix(patreon): fix level check on frontend and server

### DIFF
--- a/serverjs/featuredQueue.js
+++ b/serverjs/featuredQueue.js
@@ -4,7 +4,7 @@ const Cube = require('../dynamo/models/cube');
 const Patron = require('../dynamo/models/patron');
 
 function canBeFeatured(patron) {
-  return patron && patron.status === Patron.STATUSES.ACTIVE;
+  return patron && patron.status === Patron.STATUSES.ACTIVE && patron.level > 1;
 }
 
 async function rotateFeatured(queue) {

--- a/src/pages/UserAccountPage.js
+++ b/src/pages/UserAccountPage.js
@@ -41,6 +41,8 @@ import withModal from 'components/WithModal';
 import CubePreview from 'components/CubePreview';
 import CubePropType from 'proptypes/CubePropType';
 
+const LEVELS = ['Patron', 'Cobra Hatchling', 'Coiling Oracle', 'Lotus Cobra'];
+
 const AddFeaturedModal = ({ isOpen, toggle, cubes }) => {
   return (
     <Modal isOpen={isOpen} toggle={toggle}>
@@ -343,7 +345,7 @@ const UserAccountPage = ({ defaultNav, loginCallback, patreonClientId, patreonRe
                   <CardBody>
                     {user.roles.includes('Patron') ? (
                       <p>
-                        Your account is linked at the <b>{patron.level}</b> level.
+                        Your account is linked at the <b>{LEVELS[patron.level]}</b> level.
                       </p>
                     ) : (
                       <p>Your account is linked, but you are not an active patron.</p>
@@ -379,7 +381,7 @@ const UserAccountPage = ({ defaultNav, loginCallback, patreonClientId, patreonRe
                               </RemoveFeaturedButton>
                             </Col>
                           </Row>
-                        ) : [1, 2].includes(patron.level) ? (
+                        ) : [2, 3].includes(patron.level) ? (
                           <>
                             <p>Share your cube with others by adding it to a rotating queue of featured cubes!</p>
                             <AddFeaturedButton block outline color="accent" modalProps={{ cubes: user.cubes }}>

--- a/src/proptypes/PatronPropType.js
+++ b/src/proptypes/PatronPropType.js
@@ -4,7 +4,7 @@ const PatronPropType = PropTypes.shape({
   id: PropTypes.string.isRequired,
   email: PropTypes.string.isRequired,
   user: PropTypes.string.isRequired,
-  level: PropTypes.string.isRequired,
+  level: PropTypes.number.isRequired,
   active: PropTypes.bool.isRequired,
 });
 


### PR DESCRIPTION
Fixes these two issues posted by vaasa on Discord:

> - The front-end checks for levels 1 or 2 to determine if you're able to add to the featured queue, but the actual list of levels is:
const LEVELS = ['Patron', 'Cobra Hatchling', 'Coiling Oracle', 'Lotus Cobra'];
Meaning the check should actually be for levels 2+ and right now Lotus Cobras probably aren't getting the option to feature their cube. 

> - The level check was completely removed from the backend and all active patrons are allowed to feature a cube (see the canFeatureQueue function and how it changed in commit 7254fc9). This is either an undocumented change that didn't make its way to the frontend, or a refactoring mistake ( @DEKKARU  will know which one).