### PR TITLE
Reorder CI pipeline

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -16,8 +16,8 @@ jobs:
         node-version: 16
     - name: Setup
       run: npm ci
-    - name: Build
-      run: npm run ci-build
     - name: Check Code Style
       run: npm run lint
+    - name: Build
+      run: npm run ci-build
   


### PR DESCRIPTION
In my experience, by far the most common reason for the CI pipeline to fail is linter errors, and as a developer, it is frustrating to have to wait for over six minutes while the project is building only for the linter check to fail instantly afterward.

This PR reorders the pipeline so that the code style check is run before the build, short-circuiting this waiting period. 

:warning: :warning:  **Note:** It's probably a good idea to merge this only after the style check is passing again so that we can at least verify that the project still builds properly in the meantime. This order kind of relies on us actually keeping the pipeline passing.