### PR TITLE
Enable Enter/Return key to apply current Filter [Issue-2421]

### DIFF
--- a/src/components/FilterCollapse.js
+++ b/src/components/FilterCollapse.js
@@ -122,26 +122,33 @@ const FilterCollapse = ({ isOpen, hideDescription }) => {
     [values],
   );
 
+  const handleOnSubmit = (e) => {
+    e.preventDefault();
+    applySearchFilter();
+  };
+
   return (
     <Collapse className="px-3" isOpen={isOpen}>
       <Row>
         <Col>
-          <InputGroup>
-            <InputGroupText htmlFor="filterInput">Filter</InputGroupText>
-            <Input
-              type="text"
-              id="filterInput"
-              name="filterInput"
-              placeholder={'name:"Ambush Viper"'}
-              valid={filterInput.length > 0 && filterValid}
-              invalid={filterInput.length > 0 && !filterValid}
-              value={searchFilterInput}
-              onChange={(event) => setSearchFilterInput(event.target.value)}
-            />
-            <Button color="success" onClick={applySearchFilter}>
-              Apply
-            </Button>
-          </InputGroup>
+          <Form onSubmit={handleOnSubmit} className="input">
+            <InputGroup>
+              <InputGroupText htmlFor="filterInput">Filter</InputGroupText>
+              <Input
+                type="text"
+                id="filterInput"
+                name="filterInput"
+                placeholder={'name:"Ambush Viper"'}
+                valid={filterInput.length > 0 && filterValid}
+                invalid={filterInput.length > 0 && !filterValid}
+                value={searchFilterInput}
+                onChange={(event) => setSearchFilterInput(event.target.value)}
+              />
+              <Button color="success" onSubmit={applySearchFilter}>
+                Apply
+              </Button>
+            </InputGroup>
+          </Form>
           <small>
             Having trouble using filter syntax? Check out our <a href="/filters">syntax guide</a>.
           </small>

--- a/src/components/FilterCollapse.js
+++ b/src/components/FilterCollapse.js
@@ -144,7 +144,7 @@ const FilterCollapse = ({ isOpen, hideDescription }) => {
                 value={searchFilterInput}
                 onChange={(event) => setSearchFilterInput(event.target.value)}
               />
-              <Button color="success" onSubmit={applySearchFilter}>
+              <Button color="success" type="submit">
                 Apply
               </Button>
             </InputGroup>


### PR DESCRIPTION
### Description
This PR wraps the button in a form to handle `Enter` / 'Return' keypress events within the .component instead of requiring users specifically click the '_Apply_' Button discussed in #2421 

### Background
Currently users need to explicitly press the '_Apply_' button to submit filtered searches. This is an attempt to handle `Enter`/`Return` Key presses within the `Filtercollapse.js` component instead of requiring users specifically click the '_Apply_' Button. I've wrapped the `InputGroup` in a `Form`, removed the '_Apply_' button's `onClick` event, added the `"submit" type` to the '_Apply_' button, and added a function to handle when the `onSubmit` event is fired.

This should allow the 'Apply' button to maintain it's ability to be clicked as well as fire when the `Enter`/`Return` Key is pressed.

### How to test
- Check out this branch locally & start app
- Open a Cube list
- Click the 'Filter' option
- Type desired search criteria into the Filter input
- Click the `Enter` / `Return` key on your keyboard
- The Cube list should be filtered accordingly

### Additional Notes:
My first PR here (of hopefully many more) please be gentle! 😂