### PR TITLE
Fix secondary sort error in cube comparisons

### DIFF
--- a/src/components/CompareView.js
+++ b/src/components/CompareView.js
@@ -174,7 +174,7 @@ const CompareView = ({ cards, both, onlyA, onlyB }) => {
                     </Col>
                   </Row>
                 </div>
-                {getLabels(column, sortSecondary, cube.showUnsorted)
+                {getLabels(Object.values(column).flat(), sortSecondary, cube.showUnsorted)
                   .filter((label) => column[label])
                   .map((label) => {
                     const group = column[label];


### PR DESCRIPTION
Fixes #2436.

### Issue
The error was caused by the `getLabels` function being incorrectly passed a whole column instead of an array of cards. 

For example, if the primary sort was `Color Category` and the secondary sort was `Guilds`, the `columns` object would end up looking like:
```
{
    "White": { 
        "Azorius": [...],
        "Boros": [...],
        ...
    },
    "Blue": { ...}
    ...
}
```

And then the `column` variable takes on the individual values of that, each of which is an object with guild names as keys (e.g. `{"Azorius": [...], "Boros": [...], ...}`). Because the `getLabels` function expects an array of cards and instead got this object, it caused errors, most notably because objects are not iterable and some sort options require iterating over the passed cards.

This also explains why only some tags were affected. Options such as `Mana Value` only return a predetermined set of labels, so only those options that actually need the list of cards (such as `Tags`) cause a crash.

### Fix
Change the call so that the column is flattened into a simple array of all the cards within it.
