### PR TITLE
Fix searching cubes by card names with special characters

### DIFF
--- a/routes/root.js
+++ b/routes/root.js
@@ -121,28 +121,28 @@ router.get('/search', async (req, res) => {
 });
 
 const searchCubes = async (query, order, lastKey, ascending, user) => {
-  let updatedQuery = query.toLowerCase().replace(/[^a-z0-9: ]/g, '');
-  const split = updatedQuery.split(':');
+  let sanitizedQuery = query.toLowerCase().replace(/[^a-z0-9: ]/g, '');
+  const split = sanitizedQuery.split(':');
 
   if (split.length === 1 && split[0].length > 0) {
-    updatedQuery = `keywords:${updatedQuery}`;
+    sanitizedQuery = `keywords:${sanitizedQuery}`;
   } else if (split.length === 2 && split[0].length > 0 && split[1].length > 0) {
     // removed surrounding quotes from split[1]
     if (split[1].startsWith('"') && split[1].endsWith('"')) {
       split[1] = split[1].substring(1, split[1].length - 1);
     }
-    updatedQuery = `${split[0].trim()}:${split[1].trim()}`;
+    sanitizedQuery = `${split[0].trim()}:${split[1].trim()}`;
   }
 
-  const [key, value] = updatedQuery.split(':');
-  if (key === 'card') {
+  const [unsafeKey, unsafeValue] = query.split(':');
+  if (unsafeKey === 'card') {
     // get oracle id from card name
-    const card = carddb.getMostReasonable(value);
+    const card = carddb.getMostReasonable(unsafeValue);
 
-    updatedQuery = `oracle:${card ? card.oracle_id : ''}`;
+    sanitizedQuery = `oracle:${card ? card.oracle_id : ''}`;
   }
 
-  const result = await CubeHash.query(updatedQuery, ascending, lastKey, order);
+  const result = await CubeHash.query(sanitizedQuery, ascending, lastKey, order);
 
   const items = (result.items.length > 0 ? await Cube.batchGet(result.items.map((hash) => hash.cube)) : []).filter(
     (cube) => isCubeListed(cube, user),


### PR DESCRIPTION
Searching cubes containing cards with names such as [Oona's Prowler](https://cubecobra.com/search/card%3AOona's%20Prowler) or [Siege-Gang Commander](https://cubecobra.com/search/card%3ASiege-Gang%20Commander) would fail to find anything because of query sanitization logic added a year ago. User might land on this search from [card page](https://cubecobra.com/tool/card/cd79780e-ddad-4ef4-a94d-ab191d118882?tab=4) following the `Cubes with CARDNAME` links.

This PR fixes the search by finding the card oracle ID using the original unsanitized query from the end user on the card filter. `carddb.getMostReasonable` appears to be safe to call with any user input.

I also did minor refactoring, making it more clear which variables hold the sanitized input.

I didn't have a fully working devenv to test this fully, but this _should_ work.