### PR TITLE
Don't clear changelist on error response - fixes #2452

### DIFF
--- a/src/contexts/CubeContext.js
+++ b/src/contexts/CubeContext.js
@@ -618,7 +618,7 @@ export function CubeContextProvider({ initialCube, cards, children, loadVersionD
         const json = await result.json();
 
         if (json.success !== 'true') {
-          setAlerts([{ color: 'danger', message: json.message }]);
+          setAlerts([...alerts, { color: 'danger', message: json.message }]);
         } else {
           const newCards = JSON.parse(JSON.stringify(unfilteredChangedCards));
 
@@ -672,9 +672,6 @@ export function CubeContextProvider({ initialCube, cards, children, loadVersionD
       } catch (e) {
         setAlerts([{ type: 'error', message: 'Operation timed out' }]);
       }
-
-      setModalSelection([]);
-      setChanges({});
       setLoading(false);
     },
     [cube, changedCards, setCube, setChanges],


### PR DESCRIPTION
Firstly, thankyou dekkerglen and other maintainers, CubeCobra is a really great resource.

Ran into some recent frustration when I my changelist was wiped after an error response. This PR changes the error behaviour when submission fails, so that it does not wipe pending data. This allows user to copy any pending changes and submit again at a later date.

This should be safe to remove lines 675, 676 as they were duplicated inside the try/if scope on lines 665, 666.

Fixes #2452