### PR TITLE
migrate history route and removed csrf protection

### DIFF
--- a/app.js
+++ b/app.js
@@ -198,6 +198,7 @@ app.use('/patreon', require('./routes/patreon_routes'));
 app.use('/cache', require('./routes/cache_routes'));
 app.use('/dev', require('./routes/dev_routes'));
 app.use('/cube', require('./routes/cube/index'));
+app.use('/public', require('./routes/cube/api_public'));
 app.use('/user', require('./routes/users_routes'));
 app.use('/tool', require('./routes/tools_routes'));
 app.use('/comment', require('./routes/comment_routes'));

--- a/routes/cube/api.js
+++ b/routes/cube/api.js
@@ -432,24 +432,6 @@ router.get(
 );
 
 router.post(
-  '/history/:id',
-  util.wrapAsyncApi(async (req, res) => {
-    const cube = await Cube.getById(req.params.id);
-
-    if (!isCubeViewable(cube, req.user)) {
-      return res.status(404).send('Cube not found.');
-    }
-
-    const query = await Changelog.getByCube(cube.id, 50, req.body.lastKey);
-    return res.status(200).send({
-      success: 'true',
-      posts: query.items,
-      lastKey: query.lastKey,
-    });
-  }),
-);
-
-router.post(
   '/updatebasics/:id',
   util.wrapAsyncApi(async (req, res) => {
     const cube = await Cube.getById(req.params.id);

--- a/routes/cube/api_public.js
+++ b/routes/cube/api_public.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const util = require('../../serverjs/util');
+const Cube = require('../../dynamo/models/cube');
+const { isCubeViewable } = require('../../serverjs/cubefn');
+const Changelog = require('../../dynamo/models/changelog');
+
+const router = express.Router();
+
+router.post(
+  '/cube/history/:id',
+  util.wrapAsyncApi(async (req, res) => {
+    const cube = await Cube.getById(req.params.id);
+
+    if (!isCubeViewable(cube, req.user)) {
+      return res.status(404).send('Cube not found.');
+    }
+
+    const query = await Changelog.getByCube(cube.id, 50, req.body.lastKey);
+    return res.status(200).send({
+      success: 'true',
+      posts: query.items,
+      lastKey: query.lastKey,
+    });
+  }),
+);
+
+module.exports = router;


### PR DESCRIPTION
/cube/api/history/:id -> /public/cube/history/:id and removed csrf protection from route

## Testing

- manually tested i could access new route while not being able to access `/cube/api/getcardforcube`