### PR TITLE
bug(csv) always convert header names from csv to camelCase

### DIFF
--- a/serverjs/cubefn.js
+++ b/serverjs/cubefn.js
@@ -3,6 +3,7 @@ const Papa = require('papaparse');
 const sanitizeHtml = require('sanitize-html');
 
 const fetch = require('node-fetch');
+const _ = require('lodash')
 const sharp = require('sharp');
 const Cube = require('../dynamo/models/cube');
 
@@ -198,9 +199,13 @@ function maybeCards(cube, carddb) {
   return maybe.map((card) => ({ ...card, details: carddb.cardFromId(card.cardID) }));
 }
 
+function camelizeDataRows(data) {
+  return data.map((row) => Object.fromEntries(Object.entries(row).map(([key, value]) => [_.camelCase(key), value])));
+}
+
 function CSVtoCards(csvString, carddb) {
-  let { data } = Papa.parse(csvString.trim(), { header: true });
-  data = data.map((row) => Object.fromEntries(Object.entries(row).map(([key, value]) => [key.toLowerCase(), value])));
+  const { data } = Papa.parse(csvString.trim(), { header: true });
+  const camelizedRows = camelizeDataRows(data)
   const missing = [];
   const newCards = [];
   const newMaybe = [];
@@ -210,17 +215,17 @@ function CSVtoCards(csvString, carddb) {
     type,
     color,
     set,
-    'collector number': collectorNumber,
+    collectorNumber,
     status,
     finish,
     maybeboard,
-    'image url': imageUrl,
-    'image back url': imageBackUrl,
+    imageUrl,
+    imageBackUrl,
     tags,
     notes,
-    'Color Category': colorCategory,
+    colorCategory,
     rarity,
-  } of data) {
+  } of camelizedRows) {
     if (name) {
       const upperSet = (set || '').toUpperCase();
       const card = {


### PR DESCRIPTION
fixes #2458

There was a bug that prevented loading 'Color Category' column from properly loading from a CSV import. There was a hard-to-grok one liner that transformed parsed CSV headers from matching the header values exactly to lower cased values that still contained spaces. ex. 'Set' becomes 'set', 'Collector Number' becomes 'collector number', etc.

Then an object unpacking renamed the keys with spaces to camelCase. This rename is case sensitve still, so the line trying to rename the key 'Color Category' to 'colorCategory' would fail silently (the value would be undefined).

To fix the bug and make the transformation more clear, we now transform the header keys from 'Words With Spaces' to 'camelCaseWords' in one step. This is extracted into a named helper method for further clarity.