### PR TITLE
Fixes to Localstack setup, and additional installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Node 20
 
 NodeJS: https://nodejs.org/en/download/
 
+After installing node, ensure you are running Yarn version 4.4.0 to match the project's package.json. With a terminal do:
+- Install yarn via npm to start: `npm install -g yarn`
+- Upgrade to newest yarn (also known as Berry): `yarn set version 4.4.0`
+- Validate correct version is installed: `yarn --version`
+
 ### Redis
 
 Redis Server:
@@ -42,6 +47,22 @@ You may follow the installation guidelines from the localstack site. The recomme
 [docker]: https://docs.docker.com/desktop/install/mac-install/
 
 Once localstack is installed, you can start the server in the background with the CLI: `localstack start --detached`. You can see the status with `localstack status`.
+
+*Note*: Localstack community edition (eg. without a pro account) does not persist anything to disk once the container is stopped.
+
+#### AWSLocal CLI (for Localstack)
+
+The awslocal CLI used by this project (https://github.com/localstack/awscli-local) is required for initial setup of the localstack resources used by Cube Cobra.
+
+First install Python (suggest Python 3) and pip for your operating system. Sample instructions for a linux environment are:
+- Ensure Virtual environment package is installed: `sudo apt-get install python3-venv`
+- Create a virtual environment in your home directory: `python3 -m venv ~/venv`
+- Add the virtual environment to your path: `export PATH=~/venv/bin:$PATH`
+- Also add to your startup profile script (eg. bash profile) the activation of the virtual environment: `source ~/venv/bin/activate`
+- Install awslocal: `pip3 install "awscli-local[ver1]"`
+- Validate install: `awslocal --version`
+  - Will pass and print some "aws-cli" version (likely 1.X) for the system
+
 
 ### Code Editor (IDE)
 

--- a/one_shot_scripts/create_local_files.js
+++ b/one_shot_scripts/create_local_files.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+const fs = require('fs');
 
 fs.mkdirSync('model/', { recursive: true });
 fs.writeFileSync('model/elos.json', '[]');

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "sync-podcasts": "node --max-old-space-size=4096 jobs/update_podcasts.js",
     "start:localstack": "./scripts/local/start_localstack.sh",
     "setup:local": "yarn start:localstack && yarn setup:local:env && yarn setup:local:localstack && yarn setup:local:files && yarn setup:local:db && yarn update-cards",
-    "setup:local:localstack": "./scripts/init_localstack.sh",
+    "setup:local:localstack": "./scripts/local/init_localstack.sh",
     "setup:local:env": "cp .env_EXAMPLE .env",
     "setup:local:files": "node one_shot_scripts/create_local_files.js",
     "setup:local:db": "node --max-old-space-size=4096 one_shot_scripts/createTables.js",


### PR DESCRIPTION
While setting up Cube Cobra locally (using Windows Subsystem for Linux, but that should have no effect in comparison to a regular Linux system) I ran into a few complications which this PR resolves.

Manual testing:
1. Used an Ubuntu 22.04 virtual machine to complete setup with fixes along the way, until I was able to successfully run Cube Cobra locally including the cards from Scryfall
2. Started a fresh Ubuntu 24.04 virtual machine and ran through the install steps one by one from scratch, to ensure all dependencies were installed and in correct versions

Concerns:
1. The yarn lock appears to have been reverted to the yarn 1.X format within [this commit](https://github.com/dekkerglen/CubeCobra/commit/ac1bd7a97d1b146164f6828438827b12bfb4993d#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de) a month ago. While this is easily correctable with a yarn install back to the Yarn 4.X format (to match the package.json requirements), and I plan to open another PR to fix that, in my testing I found that Yarn 1 and 4 will complain about each other.
   - For example with Yarn 1.X it will complain about the package.json requiring yarn 4.4.0 when you install, thus unsure how the lock file format got reverted
   - I have not been able to find a lint or yarn command to ensure the yarn.lock file is the correct 4.X format in order to add to the CI validation (or git commit hook ideally)
3. I'm not a python expert and with recent Linux distributions disallowing system wide package installs in favour of virtual environments, I'm not confident on the awslocal install instructions are best practice nor conflicting with people's existing python setups. So I am also working on a full docker compose setup to help isolate all the dependencies for the build and setup processes, if that is a desirable outcome (I'll ask in the Discord).