### PR TITLE
Set color-scheme to dark in the dark scss, so scrollbars are dark themed by the browser. Fixes #1770

### DIFF
--- a/scss/bs-dark.scss
+++ b/scss/bs-dark.scss
@@ -1,2 +1,12 @@
 @import 'colors/dark';
 @import 'bs-template';
+
+/*
+* Per https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme setting the color scheme
+* affects elements like scrollbars, form inputs, and other browser supported UI elements. As of
+* Bootstrap 5.3 this is automatic (https://getbootstrap.com/docs/5.3/customize/color-modes/#enable-dark-mode)
+* though the suggested method of setting the theme is via data-bs-theme attributes instead of which CSS file to load.
+*/
+body {
+    color-scheme: dark;
+}


### PR DESCRIPTION
Fixes dekkerglen/CubeCobra#1770

Scrollbars will be styled darkly according to the browser behaviour.

All screenshots are in chrome.

Default theme scrollbars are unchanged:
![default-theme-scrollbar](https://github.com/user-attachments/assets/5c140312-03b5-4fa5-b16e-4f29ec3171af)

Current dark theme scrollbar which is the same as default theme:
![dark-theme-current-scrollbar](https://github.com/user-attachments/assets/ca015a96-a034-41cc-9d3e-06ecab44cdaa)

Updated dark theme scrollbar:
![dark-theme-updated-scrollbar](https://github.com/user-attachments/assets/8199590f-6b8e-4cad-af7b-63c3634a6252)

Firefox and Edge dark mode changes:

| Browser | Current dark theme | Updated |
| --- | --- | --- |
Edge | ![dark-theme-current-edge](https://github.com/user-attachments/assets/5740cba3-3e34-4931-872f-acfde5b5c07b) | ![dark-theme-updated-edge](https://github.com/user-attachments/assets/b0ceb434-919c-45f8-9f68-16ecc73b57f1)
Firefox | ![dark-theme-current-firefox](https://github.com/user-attachments/assets/9ff930e4-6f15-431a-a576-cff354b3f486) | ![dark-theme-updated-firefox](https://github.com/user-attachments/assets/f51fcaac-7e19-42f2-a663-07cfd0909010)