### PR TITLE
Fix error when exporting to MTGO format when the cube contains a maybeboard

### DIFF
--- a/routes/cube/download.js
+++ b/routes/cube/download.js
@@ -30,7 +30,7 @@ const sortCardsByQuery = (req, cards) => {
     req.query.secondary,
     req.query.tertiary,
     req.query.quaternary,
-    req.query.showother,
+    req.query.showother === "true", //Coerce string parameter to boolean
   );
 };
 

--- a/routes/cube/helper.js
+++ b/routes/cube/helper.js
@@ -223,40 +223,29 @@ const exportToMtgo = (res, fileName, mainCards, sideCards, cards) => {
   res.setHeader('Content-disposition', `attachment; filename=${fileName.replace(/\W/g, '')}.txt`);
   res.setHeader('Content-type', 'text/plain');
   res.charset = 'UTF-8';
-  const main = {};
-  for (const cardIndex of mainCards.flat()) {
-    const cardID = cardIndex.cardID || cards[cardIndex].cardID;
-    const { name } = carddb.cardFromId(cardID);
-    if (main[name]) {
-      main[name] += 1;
-    } else {
-      main[name] = 1;
-    }
-  }
-  for (const [key, value] of Object.entries(main)) {
-    const name = key.replace(' // ', '/');
-    res.write(`${value} ${name}\r\n`);
-  }
-  res.write('\r\n\r\n');
 
-  const side = {};
-  for (const cardIndex of sideCards.flat()) {
-    const cardID = cardIndex.cardID || cards[cardIndex].cardID;
-    const card = carddb.cardFromId(cardID);
-    if (card) {
-      if (side[card.name]) {
-        side[card.name] += 1;
-      } else {
-        side[card.name] = 1;
-      }
-    }
-  }
-  for (const [key, value] of Object.entries(side)) {
-    const name = key.replace(' // ', '/');
-    res.write(`${value} ${name}\r\n`);
-  }
+  exportBoardToMtgo(res, mainCards, cards)
+  res.write('\r\n\r\n');
+  exportBoardToMtgo(res, sideCards, cards)
   return res.end();
 };
+
+const exportBoardToMtgo = (res, boardCards, allCards) => {
+  const cardSet = {};
+  for (const cardIndex of boardCards.flat()) {
+    const cardID = cardIndex.cardID || allCards[cardIndex].cardID;
+    const { name } = carddb.cardFromId(cardID);
+    if (cardSet[name]) {
+      cardSet[name] += 1;
+    } else {
+      cardSet[name] = 1;
+    }
+  }
+  for (const [key, value] of Object.entries(cardSet)) {
+    const name = key.replace(' // ', '/');
+    res.write(`${value} ${name}\r\n`);
+  }
+}
 
 const shuffle = (a) => {
   for (let i = a.length - 1; i > 0; i--) {

--- a/routes/cube/helper.js
+++ b/routes/cube/helper.js
@@ -241,7 +241,8 @@ const exportToMtgo = (res, fileName, mainCards, sideCards, cards) => {
 
   const side = {};
   for (const cardIndex of sideCards.flat()) {
-    const card = carddb.cardFromId(cards[cardIndex].cardID);
+    const cardID = cardIndex.cardID || cards[cardIndex].cardID;
+    const card = carddb.cardFromId(cardID);
     if (card) {
       if (side[card.name]) {
         side[card.name] += 1;


### PR DESCRIPTION
Fixes #2446 

Main problem was lack of `cardIndex.cardID || cards[cardIndex].cardID` in the maybeboard export lines, hence the additional consolidation into a helper function.

Edit: Also found that the "Show other" sorting flag was being passed to sortForDownload as a string instead of a boolean (eg "true" or "false"), such that it was always being treated as truthy