### PR TITLE
Replace all double-quotes in card names, not just the first

### DIFF
--- a/routes/cube/helper.js
+++ b/routes/cube/helper.js
@@ -195,7 +195,7 @@ function writeCard(res, card, maybe) {
   } else {
     imgBackUrl = '';
   }
-  res.write(`"${name.replace(/"/, '""')}",`);
+  res.write(`"${name.replaceAll(/"/g, '""')}",`);
   res.write(`${card.cmc || cmc},`);
   res.write(`"${card.type_line.replace('—', '-')}",`);
   res.write(`${(card.colors || colorIdentity).join('')},`);


### PR DESCRIPTION
Fixes #2393

Testing: 
1. Add Henzie "Toolbox" Torre to the cube.
2. Export a CSV of the cube
3. Open the CSV in a text editor

**Before:**
`"Henzie ""Toolbox" Torre",3,"Legendary Creature - Devil Rogue"`
Second double quote around Toolbox is not escaped for CSV per [RFC-4180](https://www.ietf.org/rfc/rfc4180.txt)

**After:**
`"Henzie ""Toolbox"" Torre",3,"Legendary Creature - Devil Rogue"`