### PR TITLE
Add Arena export (via copy to clipboard)

### DIFF
--- a/src/components/cube/CubeListNavbar.tsx
+++ b/src/components/cube/CubeListNavbar.tsx
@@ -4,6 +4,7 @@ import { Flexbox, NumCols } from 'components/base/Layout';
 import CompareCollapse from 'components/cube/CompareCollapse';
 import EditCollapse from 'components/EditCollapse';
 import FilterCollapse from 'components/FilterCollapse';
+import ArenaExportModal from 'components/modals/ArenaExportModal';
 import PasteBulkModal from 'components/modals/PasteBulkModal';
 import UploadBulkModal from 'components/modals/UploadBulkModal';
 import UploadBulkReplaceModal from 'components/modals/UploadBulkReplaceModal';
@@ -12,19 +13,21 @@ import withModal from 'components/WithModal';
 import CubeContext from 'contexts/CubeContext';
 import DisplayContext from 'contexts/DisplayContext';
 import FilterContext from 'contexts/FilterContext';
+import useAlerts, { Alerts } from 'hooks/UseAlerts';
 import useToggle from 'hooks/UseToggle';
 import React, { useCallback, useContext, useState } from 'react';
+import Checkbox from '../base/Checkbox';
 import Collapse from '../base/Collapse';
 import Controls from '../base/Controls';
 import Link from '../base/Link';
-import ResponsiveDiv from '../base/ResponsiveDiv';
-import Text from '../base/Text';
-import Select from '../base/Select';
 import NavMenu from '../base/NavMenu';
-import Checkbox from '../base/Checkbox';
+import ResponsiveDiv from '../base/ResponsiveDiv';
+import Select from '../base/Select';
+import Text from '../base/Text';
 import Tooltip from '../base/Tooltip';
 import TagColorsModal from '../modals/TagColorsModal';
 
+const ArenaExportModalItem = withModal(Link, ArenaExportModal);
 const PasteBulkModalItem = withModal(Link, PasteBulkModal);
 const UploadBulkModalItem = withModal(Link, UploadBulkModal);
 const UploadBulkReplaceModalItem = withModal(Link, UploadBulkReplaceModal);
@@ -41,6 +44,7 @@ const CubeListNavbar: React.FC<CubeListNavbarProps> = ({ cubeView, setCubeView }
   const [isSortUsed, setIsSortUsed] = useState(true);
   const [isFilterUsed, setIsFilterUsed] = useState(true);
   const { cardsPerRow, setCardsPerRow } = useContext(DisplayContext);
+  const { alerts } = useAlerts();
 
   const { canEdit, hasCustomImages, cube, sortPrimary, sortSecondary, sortTertiary, sortQuaternary, setShowUnsorted } =
     useContext(CubeContext);
@@ -106,6 +110,9 @@ const CubeListNavbar: React.FC<CubeListNavbarProps> = ({ cubeView, setCubeView }
           <Link href={`/cube/download/forge/${cube.id}?${urlSegment}`}>Forge (.dck)</Link>
           <Link href={`/cube/download/mtgo/${cube.id}?${urlSegment}`}>MTGO (.txt)</Link>
           <Link href={`/cube/download/xmage/${cube.id}?${urlSegment}`}>XMage (.dck)</Link>
+          <ArenaExportModalItem modalprops={{ isFilterUsed: isFilterUsed, isSortUsed: isSortUsed }}>
+            Arena (.txt)
+          </ArenaExportModalItem>
           <Flexbox direction="row" justify="between" onClick={() => setIsSortUsed((is) => !is)}>
             <Checkbox label="Use Sort" checked={isSortUsed} setChecked={setIsSortUsed} />
             <Tooltip text="Order export using current sort options." wrapperTag="span" className="ms-auto me-0">
@@ -226,6 +233,7 @@ const CubeListNavbar: React.FC<CubeListNavbarProps> = ({ cubeView, setCubeView }
             }
           />
           <CompareCollapse isOpen={openCollapse === 'compare'} />
+          <Alerts alerts={alerts} />
         </div>
       </Flexbox>
     </Controls>

--- a/src/components/modals/ArenaExportModal.tsx
+++ b/src/components/modals/ArenaExportModal.tsx
@@ -18,7 +18,7 @@ interface ArenaExportModalProps {
 }
 
 const ArenaExportModal: React.FC<ArenaExportModalProps> = ({ isOpen, setOpen, isSortUsed, isFilterUsed }) => {
-  const { alerts, addAlert } = useAlerts();
+  const { alerts, addAlert, dismissAlerts } = useAlerts();
   const [text, setText] = useState('');
   const { cube, sortPrimary, sortSecondary, sortTertiary, sortQuaternary } = useContext(CubeContext);
   const { cardFilter } = useContext(FilterContext)!;
@@ -89,18 +89,23 @@ const ArenaExportModal: React.FC<ArenaExportModalProps> = ({ isOpen, setOpen, is
   }
 
   async function copyToClipboard() {
+    //Dismiss any remaining alerts before adding the new one, so multiple don't stack up
+    dismissAlerts();
     await navigator.clipboard.writeText(text);
     addAlert('success', 'Copied to clipboard successfully.');
+    //Auto dismiss after a few seconds
+    setTimeout(dismissAlerts, 3000);
   }
 
-  //Modal setOpen is when the background is clicked to close
   function onClose() {
     setOpen(false);
+    //Dismiss when closing the dialog so it opens in a fresh state
+    dismissAlerts();
   }
 
   return (
     <Modal isOpen={isOpen} setOpen={onClose} md>
-      <ModalHeader setOpen={setOpen}>Arena Export</ModalHeader>
+      <ModalHeader setOpen={onClose}>Arena Export</ModalHeader>
       <ModalBody>
         <Text>Copy the textbox or use the Copy to clipboard button.</Text>
         <Text>Note: Arena can only import 250 cards into a deck.</Text>

--- a/src/components/modals/ArenaExportModal.tsx
+++ b/src/components/modals/ArenaExportModal.tsx
@@ -1,0 +1,129 @@
+import Button from 'components/base/Button';
+import { Flexbox } from 'components/base/Layout';
+import { Modal, ModalBody, ModalFooter, ModalHeader } from 'components/base/Modal';
+import Text from 'components/base/Text';
+import TextArea from 'components/base/TextArea';
+import CubeContext from 'contexts/CubeContext';
+import FilterContext from 'contexts/FilterContext';
+import CardDetails from 'datatypes/CardDetails';
+import useAlerts, { Alerts } from 'hooks/UseAlerts';
+import React, { useCallback, useContext, useState } from 'react';
+import { sortForDownload } from 'utils/Sort';
+
+interface ArenaExportModalProps {
+  isOpen: boolean;
+  setOpen: (open: boolean) => void;
+  isSortUsed: boolean;
+  isFilterUsed: boolean;
+}
+
+const ArenaExportModal: React.FC<ArenaExportModalProps> = ({ isOpen, setOpen, isSortUsed, isFilterUsed }) => {
+  const { alerts, addAlert } = useAlerts();
+  const [text, setText] = useState('');
+  const { cube, sortPrimary, sortSecondary, sortTertiary, sortQuaternary } = useContext(CubeContext);
+  const { cardFilter } = useContext(FilterContext)!;
+
+  const AFTERMATH_ORACLE_TEXT = 'Aftermath (Cast this spell only from your graveyard. Then exile it.)'.toLowerCase();
+
+  //Component is being re-rendered a lot so the useCallback isn't doing much, though ideally it would optimize how often the export is generated
+  const generateExport = useCallback(() => {
+    generateArenaExport();
+  }, [
+    cube.cards.mainboard,
+    isFilterUsed,
+    isSortUsed,
+    cardFilter,
+    sortPrimary,
+    sortSecondary,
+    sortTertiary,
+    sortQuaternary,
+  ]);
+
+  // console.log([cube.cards.mainboard,
+  //   isFilterUsed,
+  //   isSortUsed,
+  //   cardFilter,
+  //   sortPrimary,
+  //   sortSecondary,
+  //   sortTertiary,
+  //   sortQuaternary,]);
+
+  async function generateArenaExport() {
+    console.log("Generate export");
+    let cards = cube.cards.mainboard;
+    if (isFilterUsed) {
+      console.log("Filter used");
+      cards = cards.filter(cardFilter.filter);
+    }
+
+    let sortedCards = cards;
+    if (isSortUsed) {
+      console.log("Sort used");
+      //Use ?? in case the sorts are null. Undefined results in the defaults within sortForDownload being used
+      sortedCards = sortForDownload(cards, sortPrimary ?? undefined, sortSecondary ?? undefined, sortTertiary ?? undefined, sortQuaternary ?? undefined, cube.showUnsorted);
+    }
+
+    let exportText = '';
+    for (const card of sortedCards) {
+      if (card.details == undefined) {
+        continue;
+      }
+      /*
+       * While card set and collector number can be imported to Arena, if the set is not available on Arena (or if in a different set code than paper),
+       * it causes a failure to import for the card name. Thus we omit the information.
+       */
+      exportText += `1 ${getCardNameForArena(card.details)}\n`;
+    }
+
+    setText(exportText);
+  }
+
+  function getCardNameForArena(cardDetails: CardDetails) {
+    let name = cardDetails.name;
+    const oracleText = cardDetails.oracle_text;
+
+    /*
+     * Arena import (bug?) requires aftermath cards to be separated by three slashes not two. Normal split cards (and/or rooms) with 2 slashes are fine.
+     * Best logic found so far is to check the oracle text has the full Aftermath keyword/reminder text.
+     */
+    if (oracleText.toLowerCase().includes(AFTERMATH_ORACLE_TEXT)) {
+      name = name.replace(new RegExp("//", 'g'), '///');
+    }
+    return name;
+  }
+
+  async function copyToClipboard() {
+    await navigator.clipboard.writeText(text);
+    addAlert('success', 'Copied to clipboard successfully.');
+  }
+
+  //Modal setOpen is when the background is clicked to close
+  function onClose() {
+    console.log("onClose");
+    setOpen(isOpen);
+    //Dismiss alerts
+  }
+
+  return (
+    <Modal isOpen={isOpen} setOpen={onClose} md>
+      <ModalHeader setOpen={setOpen}>Arena Export</ModalHeader>
+      <ModalBody>
+        <Text>Copy the textbox or use the Copy to clipboard button.</Text>
+        <Alerts alerts={alerts} />
+        <TextArea rows={10} placeholder="Copy Cube" value={text} disabled />
+      </ModalBody>
+      <ModalFooter>
+        <Flexbox direction="row" justify="between" gap="2" className="w-full">
+          <Button color="primary" block onClick={copyToClipboard}>
+            Copy to clipboard
+          </Button>
+          <Button color="danger" onClick={onClose} block>
+            Close
+          </Button>
+        </Flexbox>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export default ArenaExportModal;

--- a/src/hooks/UseAlerts.tsx
+++ b/src/hooks/UseAlerts.tsx
@@ -17,7 +17,11 @@ export const Alerts: React.FC<AlertsProps> = ({ alerts, ...props }) =>
     </Alert>
   ));
 
-const useAlerts = (): { addAlert: (color: string, message: string) => void; alerts: Alert[] } => {
+const useAlerts = (): {
+  addAlert: (color: string, message: string) => void;
+  dismissAlerts: () => void;
+  alerts: Alert[];
+} => {
   const [alerts, setAlerts] = useState<Alert[]>([]);
 
   const addAlert = useCallback(
@@ -25,7 +29,9 @@ const useAlerts = (): { addAlert: (color: string, message: string) => void; aler
     [],
   );
 
-  return { addAlert, alerts };
+  const dismissAlerts = useCallback(() => setAlerts([]), []);
+
+  return { addAlert, dismissAlerts, alerts };
 };
 
 export default useAlerts;


### PR DESCRIPTION
Implements #1181. For the mainboard of the cube it generates the text to copy/paste into Arena, and has a button to copy direct to browser clipboard.

As I would only classify myself as having a working man's knowledge of React/Hooks, happy to adjust in case there are more React-y ways of doing things.

### Testing

#### General

1) Use Sort/filter buttons apply to the Arena export when the modal opens. Tested several sort changes of the primary and secondary sorts, assuming the rest would work the same
2) Add and remove cards from the cube, the Arena export list is updated when modal opens
3) Multiple of the same card are exported and in Arena are counted together

#### Importing to Arena:
1) For each set on Arena (including extras like Jumpstart, Anthologies, and remasters) exported the card names via Scryfall. This got me approximately 170 cards per set. Tested over 40 sets.
2) Imported those names into a Cube
3) Exported to Arena via copy to clipboard
4) Imported to Arena

Issues encountered:
1) The backside of meld cards (ex. Mishra, Lost to Phyrexia) are not found on import to Arena. It does not have the backsides as "cards"
2) Cards ending with exclamation mark (ex. Fear, Fire, Foes!) cannot be imported (even using Arena export/import). Known bug open with Arena

### Screenshots

Export modal
![export](https://github.com/user-attachments/assets/aa94fc1f-6ffa-4d4f-83de-c82776681b18)

Modal after clicking copy to clipboard button
![export-after-copy](https://github.com/user-attachments/assets/47892e2c-678d-46ec-8b06-81cae632cfe9)

Example of filter applying when "Use filter" is enabled
![filter-applying](https://github.com/user-attachments/assets/b59851a9-00c1-45f3-86b8-b1c384864203)

Example of filter ignored when "Use filter" is off
![filter-not-applied](https://github.com/user-attachments/assets/7d6fda4d-0139-44ca-824a-ee50198082dd)

Sorting applied
![sorting](https://github.com/user-attachments/assets/2ac0f09a-3d61-4ede-b72b-5d5371bac279)

