### PR TITLE
fix: use color identity for background color

### DIFF
--- a/src/utils/Card.ts
+++ b/src/utils/Card.ts
@@ -206,6 +206,44 @@ export const cardColorCategory = (card: Card): ColorCategory => {
   return 'Colorless';
 };
 
+/// Get the color category from the color identity instead of what the user has set
+/// for the color category. This is helpful for rendering the color of the card background
+/// regardless of what column the card is in.
+export const cardColorIdentityCategory = (card: Card): ColorCategory => {
+  if (cardType(card).includes('Land')) {
+    return 'Lands';
+  }
+
+  const colors = cardColorIdentity(card);
+
+  if (colors.length === 0) {
+    return 'Colorless';
+  }
+  if (colors.length > 1) {
+    return 'Multicolor';
+  }
+
+  if (colors.length === 1) {
+    if (colors.includes('W')) {
+      return 'White';
+    }
+    if (colors.includes('U')) {
+      return 'Blue';
+    }
+    if (colors.includes('B')) {
+      return 'Black';
+    }
+    if (colors.includes('R')) {
+      return 'Red';
+    }
+    if (colors.includes('G')) {
+      return 'Green';
+    }
+  }
+
+  return 'Colorless';
+};
+
 // prices being null causes unwanted coercing behaviour in price filters,
 // so nullish price values are transformed to undefined instead
 export const cardNormalPrice = (card: Card): number | undefined => card.details?.prices.usd ?? undefined;

--- a/src/utils/Util.ts
+++ b/src/utils/Util.ts
@@ -1,7 +1,7 @@
 import Card from 'datatypes/Card';
 import { ColorCategory } from 'datatypes/CardDetails';
 import { TagColor } from 'datatypes/Cube';
-import { cardCmc, cardColorCategory, cardType } from 'utils/Card';
+import { cardCmc, cardColorIdentityCategory, cardType } from 'utils/Card';
 
 export function arraysEqual(a: any, b: any): boolean {
   if (a === b) return true;
@@ -218,7 +218,7 @@ export function isSamePageURL(to: string): boolean {
   }
 }
 
-const colorCategoryToColorClass: { [key in ColorCategory]: string } = {
+const colorToColorClass: { [key in ColorCategory]: string } = {
   White: 'white',
   Blue: 'blue',
   Black: 'black',
@@ -235,7 +235,7 @@ export function getCardColorClass(card: Card): string {
     return 'colorless';
   }
 
-  return colorCategoryToColorClass[cardColorCategory(card)];
+  return colorToColorClass[cardColorIdentityCategory(card)];
 }
 
 export function getCardTagColorClass(tagColors: TagColor[], card: Card): string {


### PR DESCRIPTION
Use the color identity of the card to determine background color of the card list item instead of the color category. This re-implements the previous status quo.