### PR TITLE
Revert back to CSRF Form when deleting a Cube, with correct URL.

### DIFF
--- a/src/components/modals/DeleteCubeModal.tsx
+++ b/src/components/modals/DeleteCubeModal.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import { Modal, ModalBody, ModalFooter, ModalHeader } from 'components/base/Modal';
 import Button from 'components/base/Button';
-import Text from 'components/base/Text';
 import { Flexbox } from 'components/base/Layout';
+import { Modal, ModalBody, ModalFooter, ModalHeader } from 'components/base/Modal';
+import Text from 'components/base/Text';
+import CSRFForm from 'components/CSRFForm';
+import React from 'react';
 
 interface DeleteCubeModalProps {
   isOpen: boolean;
@@ -13,21 +14,23 @@ interface DeleteCubeModalProps {
 const DeleteCubeModal: React.FC<DeleteCubeModalProps> = ({ isOpen, setOpen, cubeID }) => {
   return (
     <Modal isOpen={isOpen} setOpen={setOpen} sm>
-      <ModalHeader setOpen={setOpen}>Delete Cube</ModalHeader>
-      <ModalBody>
-        <Text>Are you sure you want to delete this cube? This action cannot be undone.</Text>
-      </ModalBody>
-      <ModalFooter>
-        <Flexbox direction="row" gap="2" className="w-full">
-          <Button block type="link" color="danger" href={`/cube/delete/${cubeID}`}>
-            Delete
-          </Button>
-          <Button block color="secondary" onClick={() => setOpen(false)}>
-            Cancel
-          </Button>
-        </Flexbox>
-      </ModalFooter>
-    </Modal>
+      <CSRFForm method="POST" action={`/cube/remove/${cubeID}`} formData={{}}>
+        <ModalHeader setOpen={setOpen}>Delete Cube</ModalHeader>
+        <ModalBody>
+          <Text>Are you sure you want to delete this cube? This action cannot be undone.</Text>
+        </ModalBody>
+        <ModalFooter>
+          <Flexbox direction="row" gap="2" className="w-full">
+            <Button block type="submit" color="danger">
+              Delete
+            </Button>
+            <Button block color="secondary" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+          </Flexbox>
+        </ModalFooter>
+      </CSRFForm>
+    </Modal >
   );
 };
 


### PR DESCRIPTION
Tested locally:
1) Create cube (passing Captcha)
2) Delete cube via modal
3) End up on the Dashboard page with "Cube Removed" success alert present

Concern: In comparison I see the blog delete modal uses a GET request, which should be a POST imo. If valid, I can create a ticket and work on it.