### PR TITLE
Add sorting cards back to list view.

### DIFF
--- a/src/components/cube/ListView.tsx
+++ b/src/components/cube/ListView.tsx
@@ -14,7 +14,7 @@ import withAutocard from 'components/WithAutocard';
 import CubeContext from 'contexts/CubeContext';
 import CardType from 'datatypes/Card';
 import TagData from 'datatypes/TagData';
-import React, { useCallback, useContext, useState } from 'react';
+import React, { useCallback, useContext, useMemo, useState } from 'react';
 import {
   cardCmc,
   cardColorIdentity,
@@ -25,7 +25,7 @@ import {
   cardType,
   normalizeName,
 } from 'utils/Card';
-import { getLabels } from 'utils/Sort';
+import { getLabels, sortForDownload } from 'utils/Sort';
 
 const GroupModalButton = withGroupModal(Button);
 
@@ -86,6 +86,22 @@ const ListView: React.FC<ListViewProps> = ({ cards }) => {
   const [checked, setChecked] = useState<{ [key: string]: boolean }>({});
   const [pageSize, setPageSize] = useState(50);
 
+  const { sortPrimary, sortSecondary, sortTertiary, sortQuaternary, cube } =
+    useContext(CubeContext);
+
+  const sorted = useMemo(
+    () =>
+      sortForDownload(
+        cards,
+        sortPrimary || 'Color Category',
+        sortSecondary || 'Types-Multicolor',
+        sortTertiary || 'CMC',
+        sortQuaternary || 'Alphabetical',
+        cube.showUnsorted || false,
+      ),
+    [cards, cube.showUnsorted, sortQuaternary, sortPrimary, sortSecondary],
+  );
+
   const handleCheck = useCallback(
     (card: CardType) => {
       setChecked((prevChecked) => ({
@@ -116,7 +132,7 @@ const ListView: React.FC<ListViewProps> = ({ cards }) => {
   );
 
   const headers = ['Name', 'Version', 'Type', 'Status', 'Finish', 'CMC', 'Color Identity', 'Tags'];
-  const rows = cards.map((card) => ({
+  const rows = sorted.map((card) => ({
     Name: (
       <Flexbox direction="row" gap="2">
         <Checkbox label="" checked={checked[cardIndex(card)]} setChecked={() => handleCheck(card)} />

--- a/src/components/cube/VisualSpoiler.tsx
+++ b/src/components/cube/VisualSpoiler.tsx
@@ -2,10 +2,10 @@ import { NumCols } from 'components/base/Layout';
 import CardGrid from 'components/card/CardGrid';
 import CubeContext from 'contexts/CubeContext';
 import DisplayContext from 'contexts/DisplayContext';
-import { BoardType, default as Card, default as CardType } from 'datatypes/Card';
+import { BoardType, default as CardType } from 'datatypes/Card';
 import React, { useContext, useMemo } from 'react';
 import { cardIndex } from 'utils/Card';
-import { sortDeep } from 'utils/Sort';
+import { sortForDownload } from 'utils/Sort';
 
 interface VisualSpoilerProps {
   cards: CardType[];
@@ -19,24 +19,21 @@ const VisualSpoiler: React.FC<VisualSpoilerProps> = ({ cards }) => {
 
   const sorted = useMemo(
     () =>
-      sortDeep(
+      sortForDownload(
         cards,
-        cube.showUnsorted || false,
-        sortQuaternary || 'Alphabetical',
         sortPrimary || 'Color Category',
         sortSecondary || 'Types-Multicolor',
         sortTertiary || 'CMC',
-      ) as unknown as [string, [string, [string, Card[]][]][]][],
+        sortQuaternary || 'Alphabetical',
+        cube.showUnsorted || false,
+      ),
     [cards, cube.showUnsorted, sortQuaternary, sortPrimary, sortSecondary],
   );
-  const cardList: Card[] = sorted
-    .map((tuple1) => tuple1[1].map((tuple2) => tuple2[1].map((tuple3) => tuple3[1].map((card) => card))))
-    .flat(4);
 
   return (
     <div className="my-2">
       <CardGrid
-        cards={cardList}
+        cards={sorted}
         onClick={(card) => {
           setModalSelection({ board: card.board as BoardType, index: cardIndex(card) });
           setModalOpen(true);


### PR DESCRIPTION
Switched to sortForDownload for simplicity, as it already accumulates the sorted groups into a flat array of Cards.

The equivalent mapping code in VisualSpoiler was not obvious at first. If there is any functional difference I am not seeing, I can switch back.

# Testing

## Sorting works
1) Switch between each view of a cube
2) While in a view, change the sort
3) Switch to other views and validate sorted the same
4) Cards added or removed are reflected on the list

## Checking cards in list view
1) Validated check all/uncheck all works
2) Checked some cards and switch page of list, editing selected shows the selected cards
3) Change the sort while cards are checked, editing selected still shows the selected cards
4) Validate the checked cards show when switching between sorts