### PR TITLE
Update playtest draft dropdown options and defaults to match old values

### DIFF
--- a/src/components/GridDraftCard.tsx
+++ b/src/components/GridDraftCard.tsx
@@ -10,7 +10,7 @@ import { Flexbox } from 'components/base/Layout';
 
 const GridDraftCard: React.FC = () => {
   const { cube } = useContext(CubeContext);
-  const [packs, setPacks] = useState('3');
+  const [packs, setPacks] = useState('18');
   const [type, setType] = useState('bot');
   const formRef = React.createRef<HTMLFormElement>();
 
@@ -37,8 +37,7 @@ const GridDraftCard: React.FC = () => {
             <Select
               label="Number of packs"
               id="packs"
-              defaultValue="18"
-              options={rangeOptions(1, 16)}
+              options={rangeOptions(1, 30)}
               value={packs}
               setValue={setPacks}
             />

--- a/src/components/SealedCard.tsx
+++ b/src/components/SealedCard.tsx
@@ -10,7 +10,7 @@ import { Flexbox } from 'components/base/Layout';
 
 const SealedCard: React.FC = () => {
   const { cube } = useContext(CubeContext);
-  const [packs, setPacks] = useState('3');
+  const [packs, setPacks] = useState('6');
   const [cards, setCards] = useState('15');
   const formRef = React.createRef<HTMLFormElement>();
 
@@ -35,7 +35,6 @@ const SealedCard: React.FC = () => {
             <Select
               label="Number of packs"
               id="packs"
-              defaultValue="3"
               options={rangeOptions(1, 16)}
               value={packs}
               setValue={setPacks}
@@ -43,7 +42,6 @@ const SealedCard: React.FC = () => {
             <Select
               label="Cards per pack"
               id="cards"
-              defaultValue="15"
               options={rangeOptions(1, 25)}
               value={cards}
               setValue={setCards}

--- a/src/components/StandardDraftCard.tsx
+++ b/src/components/StandardDraftCard.tsx
@@ -42,7 +42,6 @@ const StandardDraftCard: React.FC<StandardDraftCardProps> = ({ defaultDraftForma
             <Select
               label="Number of packs"
               id="packs"
-              defaultValue="3"
               options={rangeOptions(1, 16)}
               value={packs}
               setValue={setPacks}
@@ -50,7 +49,6 @@ const StandardDraftCard: React.FC<StandardDraftCardProps> = ({ defaultDraftForma
             <Select
               label="Cards per pack"
               id="cards"
-              defaultValue="15"
               options={rangeOptions(1, 25)}
               value={cards}
               setValue={setCards}
@@ -58,7 +56,6 @@ const StandardDraftCard: React.FC<StandardDraftCardProps> = ({ defaultDraftForma
             <Select
               label="Total seats"
               id="seats"
-              defaultValue="8"
               options={rangeOptions(2, 17)}
               value={seats}
               setValue={setSeats}


### PR DESCRIPTION
Updating the playtest dropdown options to match the old values, with the exception of leaving sealed cards per pack at 1-15 rather than the original 5-15.  Also removed defaultValue inputs since they're not being used.