### PR TITLE
fix: use tailwind class for centering markdown

### DIFF
--- a/src/markdown/centering/mdast-centering.js
+++ b/src/markdown/centering/mdast-centering.js
@@ -1,6 +1,6 @@
 function enterCentering(token) {
   this.enter(
-    { type: 'centering', data: { hName: 'div', hProperties: { className: ['centered-markdown'] } }, children: [] },
+    { type: 'centering', data: { hName: 'div', hProperties: { className: ['text-center'] } }, children: [] },
     token,
   );
 }


### PR DESCRIPTION
A basic fix for #2484. There are other markdown issues mentioned in the discord thread that need to be addressed still but this at least uses a tailwind class to center now that the old class is deprecated.