### PR TITLE
Change Blog post Save button back to submit.

### DIFF
--- a/src/components/EditBlogModal.tsx
+++ b/src/components/EditBlogModal.tsx
@@ -48,7 +48,7 @@ const EditBlogModal: React.FC<EditBlogModalProps> = ({ isOpen, setOpen, post, cu
         </ModalBody>
         <ModalFooter>
           <Flexbox direction="row" gap="2" className="w-full">
-            <Button block color="primary" onClick={() => setOpen(false)}>
+            <Button type="submit" block color="primary">
               Save
             </Button>
             <Button block color="secondary" onClick={() => setOpen(false)}>


### PR DESCRIPTION
Testing:
1) Create blog post
2) Validate issue where clicking Save does nothing (no actions in dev tools network tab for example)
3) Validate after switching back to submit, network tab has a POST to /cube/blog/post/<id>, page reloads with "Blog post successful" success notification, and content of the changed post is saved