### PR TITLE
Fix pressing enter on card autocomplete goes directly to the add/remove action

### DIFF
--- a/src/components/EditCollapse.tsx
+++ b/src/components/EditCollapse.tsx
@@ -221,7 +221,8 @@ const EditCollapse: React.FC<EditCollapseProps> = ({ isOpen }) => {
                 name="add"
                 value={addValue}
                 setValue={setAddValue}
-                onSubmit={(e) => handleAdd(e, removeValue)}
+                //Can't be addValue or else the selected text from the autocomplete input is ignored
+                onSubmit={(e, addCardValue) => handleAdd(e, addCardValue!)}
                 placeholder="Card to Add"
                 autoComplete="off"
                 data-lpignore
@@ -243,7 +244,7 @@ const EditCollapse: React.FC<EditCollapseProps> = ({ isOpen }) => {
                 name="remove"
                 value={removeValue}
                 setValue={setRemoveValue}
-                onSubmit={(e) => handleRemoveReplace(e, removeValue)}
+                onSubmit={(e, removeCardValue) => handleRemoveReplace(e, removeCardValue!)}
                 placeholder="Card to Remove"
                 autoComplete="off"
                 data-lpignore

--- a/src/components/base/AutocompleteInput.tsx
+++ b/src/components/base/AutocompleteInput.tsx
@@ -270,6 +270,7 @@ const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLInputElement>) => {
+      let enterPressed = event.keyCode === 13;
       if (event.keyCode === 40) {
         // DOWN key
         event.preventDefault();
@@ -278,15 +279,21 @@ const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
         // UP key
         event.preventDefault();
         setPosition((p) => (p > -1 ? p - 1 : p));
-      } else if (event.keyCode === 9 || event.keyCode === 13) {
+      } else if (event.keyCode === 9 || enterPressed) {
         // TAB or ENTER key
         if (showMatches) {
           const goodPosition = position >= 0 && position < matches.length ? position : 0;
           const match = matches[goodPosition];
           acceptSuggestion(match);
-          if (event.keyCode === 13 && onSubmit) {
+          if (enterPressed && onSubmit) {
             // ENTER key
             onSubmit(event, match);
+          }
+          //If not showing matches but there is a single match for the current card name, then hitting enter should trigger the on submit
+        } else if (matches.length === 1 && matches[0] === value) {
+          if (enterPressed && onSubmit) {
+            // ENTER key
+            onSubmit(event, matches[0]);
           }
         }
       }


### PR DESCRIPTION
Compared behaviour against pre 1.0.0 code (commit dd3fde3c if interested), validated the pressing enter behaviour changed.

The two issues identified were:
1) Typo from refactor where the Add card autocomplete referred to the Remove card autocomplete value
2) The typescript change to the onSubmit from a simple function name reference to `(e) => handleAdd(e, addValue)` caused the current addValue state to be passed to handleAdd rather than the matched string that the Autocomplete component passes when it calls onSubmit. Oddly by the time onSubmit is called the Autocomplete has called the setValue of the parent component so the handleAdd should logically have the selected text, but I guess there is some delay caused by React state updates or when the input value actually modifies.

# Testing (behaviour matching pre-1.0.0 code)
1) Use keyboard to navigate to an item in the autocomplete list and then click, the input is filled but Add button not focused
2) Use keyboard to navigate to an item in the autocomplete list and then press Tab, the input is filled and the Add button is focused. Then can press enter to Add
3) **[Fix]** Use keyboard to navigate to an item in the autocomplete list and then press Enter, the input is filled and the Add button is triggered
4) Press enter when autocomplete is showing (without any keyboard navigation) then the first card name is chosen and the Add button is triggered
5) **[New]** When the input is filled and not autocomplete not showing, assuming the input matches a valid card name then pressing enter will trigger the Add button

Also tested the other pages using the Autocomplete component to validate that the new enter behaviour doesn't cause any problems. The cube and user profile image autocompletes worked the same before and after for me.