### PR TITLE
Consolidate tokens based on their Oracle Id, not simply card id.

### DIFF
--- a/src/analytics/Tokens.tsx
+++ b/src/analytics/Tokens.tsx
@@ -38,13 +38,20 @@ const Tokens: React.FC<TokensProps> = ({ tokenMap }) => {
     const byOracleId: { [key: string]: { token: CardType; cards: PositionedCard[] } } = {};
     for (const card of positioned) {
       for (const token of card.details?.tokens || []) {
-        if (!byOracleId[token]) {
-          byOracleId[token] = {
+        //Equivalent tokens from different sets have their own unique id, but share an oracle id.
+        //Eg 2 1/1 white bird tokens from different sets have card Ids A and B, but share oracle id C
+        const oracleId = tokenMap[token].details?.oracle_id;
+        if (oracleId == undefined) {
+          continue;
+        }
+
+        if (!byOracleId[oracleId]) {
+          byOracleId[oracleId] = {
             token: tokenMap[token],
             cards: [],
           };
         }
-        byOracleId[token].cards.push({
+        byOracleId[oracleId].cards.push({
           ...card,
           position: card.position,
         });


### PR DESCRIPTION
Reverts to previous behaviour.

The change occurred in https://github.com/dekkerglen/CubeCobra/commit/2f2d6b120201e918824e3e63befcb4ef0790cdb9#diff-a4ee4ad6cca5c6e91aa519b73dcf827ce773f67b60b5e8a4bad072ead490835e when converting from JS to Typescript. I'd guess it was an assumption that the token map used the oracle id of the token as the key, rather than its card id.

# Testing

1) Create a cube locally with lots of cards and token (imported from a pauper cube found on the front page)
2) Validate the ungrouped token behaviour reported
3) Validated the fixed grouping behaviour after using oracle id again

Before fix:
![unconsolidated-tokens1](https://github.com/user-attachments/assets/2f7c5e25-c557-4d53-a292-c70f396b454c)
![unconsolidated-tokens2](https://github.com/user-attachments/assets/fb637bea-c75a-4e33-a11a-a4f237a55b51)

Ex. 1/1 white birds and food tokens split across different sets unintentionally.

After fix:
![consolidated-tokens1](https://github.com/user-attachments/assets/0c04ebff-e9a5-498b-bf73-f5d48c1ae905)
![consolidated-tokens2](https://github.com/user-attachments/assets/b45618e8-b9ae-4000-9f45-491451f31b4f)
![consolidated-tokens3](https://github.com/user-attachments/assets/1fb1b8b7-1ff8-4293-b626-b8cebc5293a3)

Ex. 1/1 white birds, food, and 1/1 red goblins grouped together