### PR TITLE
Remove absolute and y offset for the tag suggestions.

### DIFF
--- a/src/components/TagInput.tsx
+++ b/src/components/TagInput.tsx
@@ -97,7 +97,7 @@ const TagInput: React.FC<TagInputProps> = ({
             {filteredSuggestions.length > 0 && (
               <div
                 className={classNames(
-                  'absolute border border-border rounded-md top-0 left-0 translate-y-9 w-full flex flex-col overflow-y-visible z-[1050]',
+                  'border border-border rounded-md top-0 left-0 w-full flex flex-col overflow-y-visible z-[1050]',
                 )}
               >
                 {filteredSuggestions.map((suggestion, index) => (


### PR DESCRIPTION
Absolute caused the suggestions to appear at top of screen instead of after the text input.

The Tag list is also on the Cube overview edit modal, but I could not get any suggestions occurring there so couldn't valid before/after behaviour. I also tried to compare against behaviour pre 1.0.0 but for some reason the CSS/SASS was acting oddly and not styled, so couldn't compare correctly.

Also not sure if the placement of the suggestions in the List view is optimal (beside vs below the input), happy to take another crack at it if a different placement is desired.

# Testing 

## Before fix screenshots

List view:
![tags-list-current](https://github.com/user-attachments/assets/b1872e1d-c7f7-47d5-b6af-fa9725fc39bd)
Edit single card modal:
![edit-card-current](https://github.com/user-attachments/assets/c3e16cc1-7ef3-4184-8c6d-af97b9b0d625)
Edit multiple cards modal:
![edit-multiple-current](https://github.com/user-attachments/assets/758dc718-f2d7-46e4-8e07-32c8bc7e3e2a)
List view (mobile):
![tags-list-mobile-current](https://github.com/user-attachments/assets/2b75b913-9516-4b13-bf04-7618a8f18841)
Edit single card modal (mobile):
![edit-card-mobile-current](https://github.com/user-attachments/assets/39e375a8-73da-4493-a52e-204b785de7e6)
Edit multiple cards modal (mobile):
![edit-multiple-mobile-current](https://github.com/user-attachments/assets/be20bfb4-ee08-4391-8c86-5c6b668a442a)

## After fix screenshots

List view:
![tags-list-fixed](https://github.com/user-attachments/assets/6a224f92-5e6c-45b3-9ee9-eedcc074c4d9)
Edit single card modal:
![edit-card-fixed](https://github.com/user-attachments/assets/33c25142-c182-4b83-b94b-50aff08b3853)
Edit multiple cards modal:
![edit-multiple-fixed](https://github.com/user-attachments/assets/ca6912ed-3dff-43c0-a165-bcae2f18114c)
List view (mobile):
![tags-list-mobile-fixed](https://github.com/user-attachments/assets/8b16f320-2153-4d11-916a-87256589bbc8)
Edit single card modal (mobile):
![edit-card-mobile fixed](https://github.com/user-attachments/assets/a86d6616-53dc-4bcd-a158-562cfecbfe9b)
Edit multiple cards modal (mobile):
![edit-multiple-mobile-fixed](https://github.com/user-attachments/assets/823329a3-54a6-4174-a809-64b432453960)

