### PR TITLE
Fix amount of cards filtered text so it shows when there is no maybeboard

### DIFF
--- a/src/components/cube/CubeListNavbar.tsx
+++ b/src/components/cube/CubeListNavbar.tsx
@@ -231,9 +231,10 @@ const CubeListNavbar: React.FC<CubeListNavbarProps> = ({ cubeView, setCubeView }
             isOpen={openCollapse === 'filter'}
             showReset
             filterTextFn={({ mainboard, maybeboard }) =>
+              //Undefined what text to show if there is no mainboard
               mainboard && maybeboard
                 ? `Showing ${mainboard[0]} / ${mainboard[1]} cards in Mainboard, ${maybeboard[0]} / ${maybeboard[1]} cards in Maybeboard.`
-                : 'No cards to filter.'
+                : (mainboard ? `Showing ${mainboard[0]} / ${mainboard[1]} cards in Mainboard.` : 'No cards to filter.')
             }
           />
           <CompareCollapse isOpen={openCollapse === 'compare'} />

--- a/src/pages/CubeListPage.tsx
+++ b/src/pages/CubeListPage.tsx
@@ -65,7 +65,7 @@ const CubeListPageRaw: React.FC = () => {
                   {boardcards.length === 0 &&
                     (cardFilter ? (
                       <Text semibold md>
-                        No cards match filter.
+                        No {boardname == 'mainboard' ? 'Mainboard' : 'Maybeboard'} cards match filter.
                       </Text>
                     ) : (
                       <Text semibold md>


### PR DESCRIPTION

# Testing

Filter when empty:
![filtering-when-empty](https://github.com/user-attachments/assets/19ff2cab-d934-4185-80de-63085d4d110a)

Filtering with a mainboard:
![filtering-text-showing-mainboard](https://github.com/user-attachments/assets/f7000292-c65f-446e-9be1-a33bdcc3b67b)

Filtering with maybeboard:
![filter-text-with-maybeboar](https://github.com/user-attachments/assets/e8034849-2b7c-4212-89e3-dfa23288833b)

Filter not showing anything in mainboard (no maybeboard):
![added-mainboard-to-nothing-showing-text](https://github.com/user-attachments/assets/584216f0-d02d-4e53-98b4-26a219506dfc)

Filter that matches both boards:
![filter-matching-both-boards](https://github.com/user-attachments/assets/4e842ea1-be5f-407f-93f2-42ad1a3c4a6b)
