### PR TITLE
Tag Input keyboard handling improvements when pressing Enter/Tab

### DIFF
--- a/src/components/TagInput.tsx
+++ b/src/components/TagInput.tsx
@@ -34,7 +34,11 @@ const TagInput: React.FC<TagInputProps> = ({
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setInputValue(value);
-    setFilteredSuggestions(suggestions.filter((suggestion) => suggestion.toLowerCase().includes(value.toLowerCase())));
+    /*
+    * If value is empty then no suggestions should match. String includes("") is true, so if you typed and saw suggestsions, then removed
+    * what you typed, those suggestions would still show.
+    */
+    setFilteredSuggestions(suggestions.filter((suggestion) => value.trim() != "" && suggestion.toLowerCase().includes(value.toLowerCase())));
   };
 
   const handleAddTag = (tagText: string) => {
@@ -42,6 +46,8 @@ const TagInput: React.FC<TagInputProps> = ({
       addTag({ text: tagText, id: tagText });
       setInputValue('');
       setFilteredSuggestions([]);
+      //Reset position to before suggestions
+      setPosition(-1);
     }
   };
 
@@ -60,7 +66,19 @@ const TagInput: React.FC<TagInputProps> = ({
       setPosition((p) => (p > -1 ? p - 1 : p));
     } else if (e.key === 'Enter' || e.key === 'Tab') {
       e.preventDefault();
-      handleAddTag(inputValue);
+      const showingSuggestions = filteredSuggestions.length > 0 && !(filteredSuggestions.length === 1 && filteredSuggestions[0] === inputValue);
+
+      /*
+      * In comparison to AutocompleteInput, which will auto-select the first suggestion showing on a TAB or Enter, or if the input text
+      * matches the single hidden suggestion, we don't do that for tags. Only if there is a suggestion actively highlighted (via keyboard focus)
+      * will TAB/Enter use it, otherwise whatever has been typed will be used given that tags can be anything.
+      */
+      if (showingSuggestions && position >= 0 && position < filteredSuggestions.length) {
+        handleAddTag(filteredSuggestions[position]);
+
+      } else {
+        handleAddTag(inputValue);
+      }
     }
   };
 

--- a/src/components/card/CardModal.tsx
+++ b/src/components/card/CardModal.tsx
@@ -340,7 +340,11 @@ const CardModal: React.FC<CardModalProps> = ({
                     tags={cardTags(card).map((tag): TagData => ({ text: tag, id: tag }))}
                     readOnly={!canEdit}
                     addTag={(tag: TagData) => {
-                      updateField('tags', [...cardTags(card), tag.text]);
+                      //Prevent duplicate tags from being added
+                      let existingTags = cardTags(card);
+                      if (!existingTags.includes(tag.text)) {
+                        updateField('tags', [...cardTags(card), tag.text]);
+                      }
                     }}
                     deleteTag={(index: number) => {
                       const newTags = [...cardTags(card)];

--- a/src/components/cube/ListView.tsx
+++ b/src/components/cube/ListView.tsx
@@ -206,7 +206,10 @@ const ListView: React.FC<ListViewProps> = ({ cards }) => {
       <TagInput
         tags={cardTags(card).map((tag) => ({ text: tag, id: tag }))}
         addTag={(tag: TagData) => {
-          updateField(card, 'tags', [...cardTags(card), tag.text]);
+          let existingTags = cardTags(card);
+          if (!existingTags.includes(tag.text)) {
+            updateField(card, 'tags', [...cardTags(card), tag.text]);
+          }
         }}
         deleteTag={(index: number) => {
           const newTags = [...cardTags(card)];

--- a/src/components/modals/CubeOverviewModal.tsx
+++ b/src/components/modals/CubeOverviewModal.tsx
@@ -166,7 +166,11 @@ const CubeOverviewModal: React.FC<CubeOverviewModalProps> = ({ isOpen, setOpen, 
             <TagInput
               label="Tags"
               tags={state.tags.map((tag) => ({ text: tag, id: tag }))}
-              addTag={(tag) => setState({ ...state, tags: [...state.tags, tag.text] })}
+              addTag={(tag) => {
+                if (!state.tags.includes(tag.text)) {
+                  setState({ ...state, tags: [...state.tags, tag.text] })
+                }
+              }}
               deleteTag={(index) => {
                 const newTags = [...state.tags];
                 newTags.splice(index, 1);


### PR DESCRIPTION
# Problem as reported in discord:
1) Enter text
2) See suggestions
3) Using keyboard up/down navigate to one of the suggestions so it is "active"
4) Press Enter or Tab
5) Instead of the suggestion text being added as a tag, whatever was typed into the input was used

The TagInput code used the input text value when Enter/Tab was pressed even if suggestions were showing and the active position in those was within the possible range of suggestions

# Solution
Use logic from the AutocompleteInput such that if suggestions are showing and there is a valid active position, that suggestions text is used instead of the input.

I also added logic to prevent the same tag from being added multiple times. I noticed when editing cards that adding the same tag would trigger the "Pending changes" changelist which was unneccesary.

# Testing

![tag-autocomplete-v2](https://github.com/user-attachments/assets/e50c585f-d3c2-4d2f-adb3-50b1674a991d)

Cases showed by the gif (in order):
1. Suggestions appear (for Tags, the suggestions are the set of all existing tags in the cards of the cube)
2. Entering new tag (tv)
3. Can navigate up and down the suggestions with keyboard up/down. Then entered tag "Test" which was a suggestion
4. When suggestions are showing but the active position isn't valid, creates a new tag (te)
5. Trying to add the same tag again doesn't do anything (tv again)
6. Pressing enter when on active suggestion adds the suggestion text (reanimate) - This is the specific bug fix
7. Clicking on a suggestion adds it (tutor)
8. Removing tag by clicking on its X (test)
(The rest of the gif is extra)

Performed the same testing in the single card edit Modal and on the Cube Overview tags. The Bulk card update modal's Tags input also is working the same, though there is an separate existing issue that prevented the changes from triggering the pending changelist; however from the code in GroupModal it uses Sets for the bulk tag changes and thus it should already ignore duplicate tags.
