### PR TITLE
Convert legacy color categories to new values throughout the code

### DIFF
--- a/jobs/update_cards.js
+++ b/jobs/update_cards.js
@@ -753,13 +753,26 @@ function convertCard(card, metadata, isExtra) {
     newcard.image_flip = card.card_faces[1].image_uris.normal;
   }
   if (newcard.type.toLowerCase().includes('land')) {
-    newcard.colorcategory = 'l';
+    newcard.colorcategory = 'Lands';
   } else if (newcard.color_identity.length === 0) {
-    newcard.colorcategory = 'c';
+    newcard.colorcategory = 'Colorless';
   } else if (newcard.color_identity.length > 1) {
-    newcard.colorcategory = 'm';
+    newcard.colorcategory = 'Multicolored';
   } else if (newcard.color_identity.length === 1) {
-    newcard.colorcategory = newcard.color_identity[0].toLowerCase();
+    const legacyColorCategoryToCurrentMap = new Map([
+      ['w', 'White'],
+      ['u', 'Blue'],
+      ['b', 'Black'],
+      ['r', 'Red'],
+      ['g', 'Green'],
+    ]);
+
+    const colorFromIdentity = newcard.color_identity[0].toLowerCase();
+    if (legacyColorCategoryToCurrentMap.get(colorFromIdentity) !== undefined) {
+      newcard.colorcategory = legacyColorCategoryToCurrentMap.get(colorFromIdentity);
+    } else {
+      newcard.colorcategory = colorFromIdentity;
+    }
   }
 
   const tokens = getTokens(card, newcard);

--- a/routes/cube/helper.js
+++ b/routes/cube/helper.js
@@ -1,6 +1,7 @@
 const carddb = require('../../serverjs/carddb');
 const { render, redirect } = require('../../serverjs/render');
 const util = require('../../serverjs/util');
+const cardutil = require('../../dist/utils/Card');
 const { CSVtoCards } = require('../../serverjs/cubefn');
 
 // Bring in models
@@ -195,6 +196,9 @@ function writeCard(res, card, maybe) {
   } else {
     imgBackUrl = '';
   }
+
+  const colorCategory = cardutil.convertFromLegacyCardColorCategory(card.colorCategory);
+
   res.write(`"${name.replaceAll(/"/g, '""')}",`);
   res.write(`${card.cmc || cmc},`);
   res.write(`"${card.type_line.replace('—', '-')}",`);
@@ -202,7 +206,7 @@ function writeCard(res, card, maybe) {
   res.write(`"${carddb.cardFromId(card.cardID).set}",`);
   res.write(`"${carddb.cardFromId(card.cardID).collector_number}",`);
   res.write(`${card.rarity && card.rarity !== 'undefined' ? card.rarity : rarity},`);
-  res.write(`${card.colorCategory || colorcategory},`);
+  res.write(`${colorCategory || colorcategory},`);
   res.write(`${card.status || ''},`);
   res.write(`${card.finish || ''},`);
   res.write(`${maybe},`);

--- a/serverjs/cubefn.js
+++ b/serverjs/cubefn.js
@@ -6,6 +6,7 @@ const fetch = require('node-fetch');
 const _ = require('lodash')
 const sharp = require('sharp');
 const Cube = require('../dynamo/models/cube');
+const { convertFromLegacyCardColorCategory } = require('../dist/utils/Card');
 
 const util = require('./util');
 const { getDraftFormat, createDraft } = require('../dist/drafting/createdraft');
@@ -228,6 +229,9 @@ function CSVtoCards(csvString, carddb) {
   } of camelizedRows) {
     if (name) {
       const upperSet = (set || '').toUpperCase();
+
+      const validatedColorCategory = convertFromLegacyCardColorCategory(colorCategory);
+
       const card = {
         name,
         cmc: cmc || null,
@@ -242,7 +246,7 @@ function CSVtoCards(csvString, carddb) {
         tags: tags && tags.length > 0 ? tags.split(';').map((t) => t.trim()) : [],
         notes: notes || '',
         rarity: rarity || null,
-        colorCategory: colorCategory || null,
+        colorCategory: validatedColorCategory || null,
       };
 
       const potentialIds = carddb.allVersions(card);

--- a/src/datatypes/CardDetails.ts
+++ b/src/datatypes/CardDetails.ts
@@ -1,13 +1,7 @@
-export type ColorCategory =
-  | 'White'
-  | 'Blue'
-  | 'Black'
-  | 'Red'
-  | 'Green'
-  | 'Colorless'
-  | 'Multicolor'
-  | 'Hybrid'
-  | 'Lands';
+
+export const COLOR_CATEGORIES = ['White', 'Blue', 'Black', 'Red', 'Green', 'Colorless', 'Multicolored', 'Hybrid', 'Lands'] as const;
+export type ColorCategory = typeof COLOR_CATEGORIES[number];
+
 export default interface CardDetails {
   scryfall_id: string;
   oracle_id: string;

--- a/src/utils/Card.ts
+++ b/src/utils/Card.ts
@@ -236,7 +236,7 @@ export const cardColorCategory = (card: Card): ColorCategory => {
     return 'Colorless';
   }
   if (colors.length > 1) {
-    return 'Multicolor';
+    return 'Multicolored';
   }
 
   if (colors.length === 1) {
@@ -274,7 +274,7 @@ export const cardColorIdentityCategory = (card: Card): ColorCategory => {
     return 'Colorless';
   }
   if (colors.length > 1) {
-    return 'Multicolor';
+    return 'Multicolored';
   }
 
   if (colors.length === 1) {

--- a/src/utils/Sort.ts
+++ b/src/utils/Sort.ts
@@ -23,6 +23,7 @@ import {
   COLOR_COMBINATIONS,
 } from 'utils/Card';
 import { alphaCompare, arrayIsSubset, fromEntries } from 'utils/Util';
+import { COLOR_CATEGORIES } from 'datatypes/CardDetails';
 
 const COLOR_MAP: Record<string, string> = {
   W: 'White',
@@ -297,7 +298,8 @@ function getLabelsRaw(cube: Card[] | null, sort: string, showOther: boolean): st
 
   /* Start of sort Options */
   if (sort === 'Color Category') {
-    ret = ['White', 'Blue', 'Black', 'Red', 'Green', 'Hybrid', 'Multicolored', 'Colorless', 'Lands'];
+    //Slice creates a copy of the readonly COLOR_CATEGORIES array (as it is a const assertion), as a regular array
+    ret = COLOR_CATEGORIES.slice();
   } else if (sort === 'Color Category Full') {
     ret = SINGLE_COLOR.concat(['Colorless'])
       .concat(GUILDS)

--- a/src/utils/Sort.ts
+++ b/src/utils/Sort.ts
@@ -21,6 +21,7 @@ import {
   cardTix,
   cardType,
   COLOR_COMBINATIONS,
+  convertFromLegacyCardColorCategory,
 } from 'utils/Card';
 import { alphaCompare, arrayIsSubset, fromEntries } from 'utils/Util';
 import { COLOR_CATEGORIES } from 'datatypes/CardDetails';
@@ -492,9 +493,11 @@ export function cardGetLabels(card: Card, sort: string, showOther = false): stri
   let ret: string[] = [];
   /* Start of sort options */
   if (sort === 'Color Category') {
-    ret = [card.colorCategory ?? GetColorCategory(cardType(card), cardColorIdentity(card))];
+    const convertedColorCategory = convertFromLegacyCardColorCategory(card.colorCategory as string)
+    ret = [convertedColorCategory ?? GetColorCategory(cardType(card), cardColorIdentity(card))];
   } else if (sort === 'Color Category Full') {
-    const colorCategory = card.colorCategory ?? GetColorCategory(cardType(card), cardColorIdentity(card));
+    const convertedColorCategory = convertFromLegacyCardColorCategory(card.colorCategory as string)
+    const colorCategory = convertedColorCategory ?? GetColorCategory(cardType(card), cardColorIdentity(card));
     if (colorCategory === 'Multicolored') {
       ret = [getColorCombination(cardColorIdentity(card))];
     } else {

--- a/src/utils/Util.ts
+++ b/src/utils/Util.ts
@@ -225,7 +225,7 @@ const colorToColorClass: { [key in ColorCategory]: string } = {
   Red: 'red',
   Green: 'green',
   Colorless: 'colorless',
-  Multicolor: 'multi',
+  Multicolored: 'multi',
   Hybrid: 'multi',
   Lands: 'lands',
 };


### PR DESCRIPTION
# Problem
1. Cards in cubes may still have the legacy color category values such as "l", "w", or "m" rather than the current color category types of "Lands", "White", or "Multicolored" etc
2. These can be both on the card, and in the respective card details
3. Exporting the cube as CSV uses the legacy values if they are on the card
4. Importing did not convert legacy to current
5. The Color Category sort used the new values and so anything with the legacy values got stuck in the "Other" bucket, hence could import and see no cards as they were all unsorted
6. Cards with legacy color category could show in the card edit modal as having blank in the Color category dropdown. I think this occurred when the card details had legacy color category, but unsure. Sometimes the new value was selected, I think because the legacy values match the first letter (case insensitive) of the new values and browsers are flexible in that way
7. In a couple places the word "Multicolor" was used instead of "Multicolored", the latter which is in the color category type (and occurred more often in the codebase)

# Solution
1. Updated the export and import process to explicitly covert from legacy to current color categories (if possible)
2. Updated the Color Category sort to also convert
3. Updated the 

# Concerns
1. I am not sure whether the card dictionary JSONs should be converted to the new values for good
2. Should the placeholder card in carddb.getPlaceholderCard be updated?
3. Unsure why both the Card and Card details can container color category, and why one is colorCategory and the other colorcategory

# Testing

## Existing behaviour
Used Cube's https://cubecobra.com/cube/list/jank and https://cubecobra.com/cube/list/trash-pile-test from the reported issues in Discord.

1. Exported both as CSV, and can see the legacy values of color category in them eg.
```
name,CMC,Type,Color,Set,Collector Number,Rarity,Color Category,status,Finish,maybeboard,image URL,image Back URL,tags,Notes,MTGO ID
"Grim Lavamancer",1,"Creature - Human Wizard",R,"dmr","324",rare,r,Owned,Foil,false,,,"","",107333
"Ignoble Hierarch",1,"Creature - Goblin Shaman",G,"mh2","414",rare,m,Owned,Foil,false,,,"","",91101
```
(r and m respectively)
2. Imported those into my local cube cobra using the current master branch. Many cards were categorized as "Other" using the color category sort (the default) per screenshots. For each first screenshot shows imported, then second shows after Display -> Show unsorted is on

**Cube 1**
![555jank-import-old1](https://github.com/user-attachments/assets/cc852663-1397-4bbf-822b-cb069a9e51df)
![555jank-import-old2-show-unsorted](https://github.com/user-attachments/assets/c4aec155-7706-4529-8f52-b249a5f3d28d)

**Cube 2**
![trashpiletest-old1](https://github.com/user-attachments/assets/b118d4be-66e7-4b82-8862-09c8a56a6671)
![trashpiletest-old2-show-unsorted](https://github.com/user-attachments/assets/a0ef125b-3b45-4943-94a2-537737e7b30a)

4. Validated the legacy color categories in the cube JSON
![555jank-import-old5](https://github.com/user-attachments/assets/3122c25f-e226-4cce-acbc-e30b84e021bc)
![trashpiletest-old5](https://github.com/user-attachments/assets/06746217-9ffb-48c2-9ac4-4de4b41a8066)

5. Sorting by color identity works

![555jank-import-old6-sorted-by-color-identity](https://github.com/user-attachments/assets/b73f7a33-76e8-4720-9fb0-98588336b2ea)
![trashpiletest-old6-sorted-by-color-identity](https://github.com/user-attachments/assets/98f7380a-258d-43a7-8897-6d4d2de79a32)

## New behaviour
1. The color category sorting works for the cubes imported from the previous section (no edits or anything to the cards)
![555jank-import-old6-sorted-by-color-identity](https://github.com/user-attachments/assets/1a1403cb-5fec-4edf-892b-7c903773e1ff)
![trashpiletest-old6-sorted-by-color-identity](https://github.com/user-attachments/assets/0158ccaa-8189-4b81-9bbf-4469105fc9d6)

2. Importing the cubes from CSV correctly has color category set
![555jank-import-new](https://github.com/user-attachments/assets/bca1d799-c216-4de1-be5b-199cd14bb2a6)
![trashpiletest-import-new](https://github.com/user-attachments/assets/8b5c45ba-3185-4a62-b813-634748a32052)

4. New color categories are saved in the cube JSON (on the card itself)
![converted-color-category](https://github.com/user-attachments/assets/64a5a93c-c9ae-4ba2-9f03-276f010cbd3f)

5. CSV export uses the current color categories (r -> Red in comparison)
```
"Grim Lavamancer",1,"Creature - Human Wizard",R,"dmr","324",rare,Red,Owned,Foil,false,,,"","",107333
```