### PR TITLE
Apply foiling to the Card Grid views

### DIFF
--- a/src/components/card/CardGrid.tsx
+++ b/src/components/card/CardGrid.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
-import CardImage, { CardImageProps } from './CardImage';
+import { Col, NumCols, Row } from 'components/base/Layout';
+import FoilCardImage from 'components/FoilCardImage';
 import Card from 'datatypes/Card';
-import { Col, Row, NumCols } from 'components/base/Layout';
+import { CardImageProps } from './CardImage';
 
 export interface CardGridProps {
   cards: Card[];
@@ -24,7 +25,7 @@ function CardGrid({ cards, cardProps, xs, sm, md, lg, xl, xxl, hrefFn, onClick }
         {cards.map((card, cardIndex) => (
           <Col key={cardIndex} xs={1}>
             <a href={hrefFn(card)} className="hover:cursor-pointer">
-              <CardImage card={card} autocard {...cardProps} />
+              <FoilCardImage card={card} autocard {...cardProps} />
             </a>
           </Col>
         ))}
@@ -36,7 +37,7 @@ function CardGrid({ cards, cardProps, xs, sm, md, lg, xl, xxl, hrefFn, onClick }
     <Row xs={xs} sm={sm} md={md} lg={lg} xl={xl} xxl={xxl}>
       {cards.map((card, cardIndex) => (
         <Col key={cardIndex} xs={1}>
-          <CardImage
+          <FoilCardImage
             card={card}
             autocard
             onClick={() => onClick && onClick(card)}


### PR DESCRIPTION
# Testing

1. Cube visual spoiler
Before (can see the autocard popup is foiling correctly already):
![foil-in-autocard-but-not-in-visual](https://github.com/user-attachments/assets/af6f8db1-9b81-4c29-ad2f-9f5562b65ad1)

After:
![fixed-foiling-in-deck-visual](https://github.com/user-attachments/assets/8d16f619-1ffa-449b-8ccf-083f3319e2c8)

2. Deck view
Before (can see the autocard popup is foiling correctly already):
![non-foil-in-deck-visual](https://github.com/user-attachments/assets/8a92475d-3311-49ce-a9ec-a392e130cab6)

After:
![fixed-foiling-in-deck-visual](https://github.com/user-attachments/assets/0af5dc35-d672-4462-b644-6f1586de8300)

3. Draft picks breakdown
Before:
![not-foiling-in-pick-order-view](https://github.com/user-attachments/assets/604c9a99-d2bb-487a-82b3-1e2bbd12300e)
After:
![fixed-foiling-in-pick-order-view](https://github.com/user-attachments/assets/6fa27eb3-daf2-42d6-a430-5360fbc1731b)

4. Cube sample hand modal
Before:
![not-foil-in-sample-hand](https://github.com/user-attachments/assets/b79eb72d-1ae4-47b1-9291-00e5446d459f)
After:
![fixed-foiling-in-sample-hand](https://github.com/user-attachments/assets/1dea95c6-1a71-4dbe-b3db-d258ae746f64)
