### PR TITLE
Convert to simple browser hidden input, so blog post id is passed to backend.

### DIFF
--- a/src/components/EditBlogModal.tsx
+++ b/src/components/EditBlogModal.tsx
@@ -42,7 +42,7 @@ const EditBlogModal: React.FC<EditBlogModalProps> = ({ isOpen, setOpen, post, cu
               value={title}
               onChange={(e) => setTitle(e.target.value)}
             />
-            {post && <Input type="hidden" name="id" value={post.id} />}
+            {post && <input type="hidden" name="id" value={post.id} />}
             <TextEntry name="markdown" value={markdown} setValue={setMarkdown} maxLength={10000} />
           </Flexbox>
         </ModalBody>

--- a/src/pages/GridDraftPage.tsx
+++ b/src/pages/GridDraftPage.tsx
@@ -1,5 +1,4 @@
 import { Card } from 'components/base/Card';
-import Input from 'components/base/Input';
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 
 import CSRFForm from 'components/CSRFForm';
@@ -136,7 +135,8 @@ const GridDraftPage: React.FC<GridDraftPageProps> = ({ cube, initialDraft, seatN
             action={`/cube/deck/submitdeck/${initialDraft.cube}`}
             formData={{ body: initialDraft.id }}
           >
-            <Input type="hidden" name="body" value={initialDraft.id} />
+            {/* CSRFForm requires children, and null is a valid React node which does nothing */}
+            {null}
           </CSRFForm>
           <ErrorBoundary>
             <GridDraftPack


### PR DESCRIPTION
Fixes #2500
The CubeCobra Input component doesn't support the name attribute, so though the hidden was in the form it's value was unknown to the backend.

When checking for other type="hidden" inputs I found that the GridDraftPage had a redundant hidden input with the draft id value. The CSRFForm's formData created the working hidden input whereas the <Input> removed was missing the name attribute.

In both cases from git history the Input used to come from Reactstrap instead of the components folder.

# Testing

## Blog
1. Create new blog post using the "Create new blog post" button
2. Edit said blog post, see "Blog update successful" alert and that the changes were saved. Validated both title and body can be changed
3. Edit an automatic blog post successfully

## Grid draft
Grid drafts were working successfully before any changes, because the formData had the draft id as described above. I also completed successful drafts after the changes.