### PR TITLE
Markdown style fixes and documentation improvements

### DIFF
--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -2589,6 +2589,12 @@ img.mana-symbol-sm {
   margin-bottom: 1rem;
 }
 
+/* Add margin to images rendered within centered markdown blocks */
+
+.markdown .text-center .markdown-card-image {
+  margin: auto;
+}
+
 @media (min-width: 640px) {
   .sm\:container {
     width: 100%;

--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -2577,6 +2577,18 @@ img.mana-symbol-sm {
   }
 }
 
+/* Loose lists (https: //spec.commonmark.org/0.31.2/#lists) have a <p> within the list items. Using inline-block and bottom margin
+* results in a blank line after the list item, and in conjunction with list-style-position: inside on the list element itself
+* ensures the <p> content starts on the same line as the item marker (eg 1 or *). Without inline-block, the list-style-position would
+* move the item content to the next line.
+*/
+
+.markdown ul p,
+.markdown ol p {
+  display: inline-block;
+  margin-bottom: 1rem;
+}
+
 @media (min-width: 640px) {
   .sm\:container {
     width: 100%;

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -301,7 +301,7 @@ const Markdown: React.FC<MarkdownProps> = ({ markdown, limited = false }) => {
   const markdownStr = markdown?.toString() ?? '';
   return (
     <ReactMarkdown
-      className="flex flex-col gap-2"
+      className="markdown flex flex-col gap-2"
       remarkPlugins={ALL_PLUGINS as any}
       rehypePlugins={limited ? LIMITED_REHYPE_PLUGINS : ALL_REHYPE_PLUGINS}
       components={RENDERERS as any}

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -48,15 +48,15 @@ interface RenderBlockQuoteProps {
   children: ReactNode;
 }
 const renderBlockQuote: React.FC<RenderBlockQuoteProps> = (node) => (
-  <div className="border border-border background-background-secondary mb-4 p-4">{node.children}</div>
+  <div className="border border-border bg-bg-active mb-4 p-4">{node.children}</div>
 );
 
-interface RenderImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {}
+interface RenderImageProps extends React.ImgHTMLAttributes<HTMLImageElement> { }
 const renderImage: React.FC<RenderImageProps> = (node) => (
   <img className="max-w-full" src={node.src} alt={node.alt} title={node.title} />
 );
 
-interface RenderLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {}
+interface RenderLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> { }
 const renderLink: React.FC<RenderLinkProps> = (node) => {
   const ref = node.href ?? '';
 

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -155,7 +155,7 @@ const renderCardImage: React.FC<RenderCardImageProps> = (node) => {
   if (node.dfc) details.image_flip = `/tool/cardimageflip/${idURL}`;
   const tag = node.inParagraph ? 'span' : 'div';
   return (
-    <div className="w-1/2 lg:w-1/4 p-2">
+    <div className="w-1/2 lg:w-1/4 p-2 markdown-card-image">
       <Link href={`/tool/card/${idURL}`} target="_blank" rel="noopener noreferrer">
         <FoilCardImage autocard card={{ details } as any} className="clickable" wrapperTag={tag} />
       </Link>

--- a/src/css/stylesheet.css
+++ b/src/css/stylesheet.css
@@ -278,3 +278,14 @@ img.mana-symbol-sm {
 		max-width: 12.5%;
   }
 }
+
+/* Loose lists (https: //spec.commonmark.org/0.31.2/#lists) have a <p> within the list items. Using inline-block and bottom margin
+* results in a blank line after the list item, and in conjunction with list-style-position: inside on the list element itself
+* ensures the <p> content starts on the same line as the item marker (eg 1 or *). Without inline-block, the list-style-position would
+* move the item content to the next line.
+*/
+.markdown ul p,
+.markdown ol p {
+	display: inline-block;
+	margin-bottom: 1rem;
+}

--- a/src/css/stylesheet.css
+++ b/src/css/stylesheet.css
@@ -289,3 +289,8 @@ img.mana-symbol-sm {
 	display: inline-block;
 	margin-bottom: 1rem;
 }
+
+/* Add margin to images rendered within centered markdown blocks */
+.markdown .text-center .markdown-card-image {
+	margin: auto;
+}

--- a/src/pages/MarkdownPage.tsx
+++ b/src/pages/MarkdownPage.tsx
@@ -704,6 +704,55 @@ const MarkdownPage: React.FC<MarkdownProps> = ({ loginCallback }) => (
             </Col>
           </Row>
         </CardBody>
+        <CardBody className="border-top">
+          <Text semibold md>
+            Header linking
+          </Text>
+          <p>
+            Headers in markdown can be linked to within the page by creating anchors with fragment (#) URLs. The content of the fragment
+            is the text content of the header in lowercase, with whitespace replaced by "-" (dash) and non-letter/numbers characters removed (see examples).
+            Each heading must have unique text (within the page) for the linking to work.
+          </p>
+          <p>Examples:</p>
+          <ul>
+            <li>A header with text "This is my cube" can be linked from fragment "#this-is-my-cube"</li>
+            <li>Non-letters such as emoji's or symbols will be removed: "😄 emoji ♥" can be linked from fragment "#-emoji-"</li>
+            <li>Non-ASCII letters work: "The Héroïne" can be linked from fragment "#the-héroïne"</li>
+          </ul>
+          <br />
+          <Row>
+            <Col xs={12} sm={6}>
+              <Card>
+                <CardHeader>Source</CardHeader>
+                <CardBody>
+                  <p>
+                    <code># My cube is awesome!</code>
+                    <code>[Read the cube themes](#what-are-the-themes-of-the-cube)</code>
+                    <code>[All about the money](#all-cards-must-be-less-than-50-)</code>
+                    <br />
+                    <code>## What are the themes of the cube?</code>
+                    <br />
+                    <code>### All cards must be less than 50 ¢</code>
+                    <br />
+                    <code>[Back to top](#my-cube-is-awesome)</code>
+                  </p>
+                </CardBody>
+              </Card>
+            </Col>
+            <Col xs={12} sm={6}>
+              <Card>
+                <CardHeader>Result</CardHeader>
+                <CardBody>
+                  <Markdown
+                    markdown={
+                      '# My cube is awesome!\n[Read the cube themes](#what-are-the-themes-of-the-cube)\n[All about the money](#all-cards-must-be-less-than-50-)\n## What are the themes of the cube?\n### All cards must be less than 50 ¢\n[Back to top](#my-cube-is-awesome)'
+                    }
+                  />
+                </CardBody>
+              </Card>
+            </Col>
+          </Row>
+        </CardBody>
       </Flexbox>
     </Card>
   </MainLayout>


### PR DESCRIPTION
More fixes coming from the reporting issues in thread https://discord.com/channels/592787488523943937/1318662199333355571/threads/1318687048474951720

# Problems
1. Block quote background is the same as rest
2. Loose lists don't have blank lines separating content
3. Centered images don't center

# Solution and testing
## 1. Block quote background is the same as rest
Solution: Corrected background class name, and choose a different variant so light and dark mode look better

Before:
![markdown-blockquote-before-light](https://github.com/user-attachments/assets/fa00c86a-e7a7-4f2e-b61a-e5e853a8f817)
![markdown-blockquote-before-dark](https://github.com/user-attachments/assets/c58ecbb4-3458-410d-94ac-59b228e32a1d)

After:
![markdown-blockquote-background-light](https://github.com/user-attachments/assets/3d72b041-6afb-4160-8b56-4331b83da298)
![markdown-blockquote-background-dark](https://github.com/user-attachments/assets/7560deb8-0e77-4c4a-91f0-74dc0d6d6788)

**I tried to play around with constrast and color so the Latex components dont' blend in but I reached the limits of my knowledge**

## 2. Loose lists don't have blank lines separating content
Solution: list-style-position: inside pushed the text to the next line because the paragraph had display block. Best solution I found was setting those paragraphs to display inline-block and then adding bottom margin to them to be the blank line.

Before:
![markdown-loose-list-before-blank-lines](https://github.com/user-attachments/assets/c4653774-6f3d-40b4-bfd2-72f193573460)

After:
![markdown-loose-list-blank-lines](https://github.com/user-attachments/assets/7eb9fd59-ce44-42d2-adcf-eef72ed1124c)

## 3. Centered images don't center
Solution: Based on how the previous styling worked, added margin auto to images within centered blocks of markdown rendered content.

Before:
![markdown-centered-image-before](https://github.com/user-attachments/assets/dcf99b92-6d0d-429e-b9a7-e629383990ed)

After:
![markdown-centered-image](https://github.com/user-attachments/assets/b46684ae-d466-485d-bad9-b675331aded3)

## 4. Also added a new markdown documentation section to describe how to use anchor links to headers

![markdown-heading-linking-docs](https://github.com/user-attachments/assets/3da8bb2d-63d5-465a-9862-b2ea3d49ba6b)

