### PR TITLE
Update the non-public cube icon's tooltip wording to match private or unlisted cube visibility.

### DIFF
--- a/src/components/cube/CubeOverviewCard.tsx
+++ b/src/components/cube/CubeOverviewCard.tsx
@@ -29,17 +29,23 @@ const FollowersModalLink = withModal(Link, FollowersModal);
 const CubeIdModalLink = withModal(Link, CubeIdModal);
 const QRCodeModalLink = withModal(Link, QRCodeModal);
 const ConfirmActionModalButton = withModal(Button, ConfirmActionModal);
+interface PrivateCubeIconProps {
+  visibility: string;
+}
 
-const PrivateCubeIcon = () => (
-  <Tooltip
-    text="This cube is set as private."
-    wrapperTag="span"
-    className="text-secondary"
-    style={{ position: 'relative', top: '-3px' }}
-  >
-    <EyeClosedIcon size={24} />
-  </Tooltip>
-);
+const PrivateCubeIcon: React.FC<PrivateCubeIconProps> = ({ visibility }) => {
+  const visibilityWord = visibility == 'pr' ? 'private' : 'unlisted';
+  return (
+    <Tooltip
+      text={`This cube is set as ${visibilityWord}.`}
+      wrapperTag="span"
+      className="text-secondary"
+      style={{ position: 'relative', top: '-3px' }}
+    >
+      <EyeClosedIcon size={24} />
+    </Tooltip>
+  );
+};
 
 interface CubeOverviewCardProps {
   priceOwned: number;
@@ -89,7 +95,7 @@ const CubeOverviewCard: React.FC<CubeOverviewCardProps> = ({ followed, priceOwne
             <CardHeader>
               <Flexbox direction="row" justify="between">
                 <Text xl semibold>
-                  {cube.name} {cube.visibility !== 'pu' && <PrivateCubeIcon />}
+                  {cube.name} {cube.visibility !== 'pu' && <PrivateCubeIcon visibility={cube.visibility} />}
                 </Text>
                 <TextBadge name="Cube ID">
                   <CubeIdModalLink


### PR DESCRIPTION
Reported on Discord that when the cube is set to "Unlisted" visibility, the wording of the visibility indicator says it is "private".

# Testing

Public cube (no visibility icon):
![public-cube](https://github.com/user-attachments/assets/90e73167-b86d-4676-bb58-937154e8437f)

Unlisted cube:
![unlisted-cube](https://github.com/user-attachments/assets/9d88ce68-9805-41c4-afa1-150bd2c7bb14)

Private cube:
![private-cube](https://github.com/user-attachments/assets/105f9403-76bb-46e5-8042-12c1f1d9d5ba)
