### PR TITLE
Align the old and new card details in the Changelist when there is a swap

### DIFF
--- a/src/components/Changelist.tsx
+++ b/src/components/Changelist.tsx
@@ -99,22 +99,22 @@ const Edit = ({ card, revert }: { card: CardData; revert: () => void }) => (
 
 const Swap = ({ card, oldCard, revert }: { card: CardData; oldCard: CardData; revert: () => void }) => {
   const [loading, setLoading] = useState(true);
-  const [details, setDetails] = useState<CardDetails | null>();
-  const [details2, setDetails2] = useState<CardDetails | null>();
+  const [newCardDetails, setNewCardDetails] = useState<CardDetails | null>();
+  const [oldCardDetails, setOldCardDetails] = useState<CardDetails | null>();
 
   useEffect(() => {
     const getData = async () => {
       const response = await fetch(`/cube/api/getcardfromid/${card.cardID}`);
       if (response.ok) {
         const data = await response.json();
-        setDetails(data.card);
+        setNewCardDetails(data.card);
         setLoading(false);
       }
 
       const response2 = await fetch(`/cube/api/getcardfromid/${oldCard.cardID}`);
       if (response2.ok) {
         const data = await response2.json();
-        setDetails2(data.card);
+        setOldCardDetails(data.card);
         setLoading(false);
       }
 
@@ -129,14 +129,14 @@ const Swap = ({ card, oldCard, revert }: { card: CardData; oldCard: CardData; re
       <span className="mx-1" style={{ color: 'blue' }}>
         <ArrowSwitchIcon />
       </span>
-      {!loading && details ? (
-        <TextAutocard card={{ ...oldCard, details }}>{details.name}</TextAutocard>
+      {!loading && oldCardDetails ? (
+        <TextAutocard card={{ ...oldCard, details: oldCardDetails }}>{oldCardDetails.name}</TextAutocard>
       ) : (
         <Spinner sm />
       )}
       <ArrowRightIcon className="mx-1" />
-      {!loading && details2 ? (
-        <TextAutocard card={{ ...card, details: details2 }}>{details2.name}</TextAutocard>
+      {!loading && newCardDetails ? (
+        <TextAutocard card={{ ...card, details: newCardDetails }}>{newCardDetails.name}</TextAutocard>
       ) : (
         <Spinner sm />
       )}


### PR DESCRIPTION
# Problem
Issue reported on Discord that the visual display of a card swap was reversed, including details such as tags or foiling status. The actual swap occurs as desired and the generated blog post displays the swap correctly.

Tracked the issue to https://github.com/dekkerglen/CubeCobra/commit/d2cc1e9e4a7fc166d11aa60ab08ef87a3236cd20#diff-6fe9681a990180e28b6c330b311870fde35304d9cf1a844208b8527770c5e129 with the new conflict resolution code, in which the new and old card details got swapped as did the order of them between the right arrow.

# Solution
More descriptive useState names makes it clear the alignment of the card/oldCard with their respective details. As well swapping the order so old card -> new card.

# Testing
The Changelist component is also used on the BulkUploadPage, which is shown when there are cards not correctly identified in the upload (eg missing). By context this usage of Changelist only contains adds and missing types, not swaps which this issue is relevant towards.

Before:
The cards are on the wrong sides of the right arrow and the details such as tags and foiling on the current cube card are being displayed on the incoming card.
![reversed-swap-order](https://github.com/user-attachments/assets/76a8820b-8892-4d31-8f0f-d9e4dddb4c00)
The blog post changelog is ordered correctly though:
![old-blog-post-swap-correct](https://github.com/user-attachments/assets/7a1fb99d-2dc0-4440-b153-1c210ee66494)

After:
Outgoing and incoming cards are on the correct sides of the right arrow, and the current card details are on the correct outgoing card.
![fixed-swap-order](https://github.com/user-attachments/assets/4bef0956-bfb0-4aa1-99a5-ba3920e5dfad)
The blog post changelog is the same:
![new-blog-post-swap-correct](https://github.com/user-attachments/assets/d11c02e6-49f1-4fff-8150-a656b6f549c5)
