### PR TITLE
Fix duplicate labels in Date Added sorting, triggered when cards have string values for added timestamp (addedTmsp)

### DIFF
--- a/src/utils/Card.ts
+++ b/src/utils/Card.ts
@@ -179,7 +179,7 @@ export const cardType = (card: Partial<Card>): string => card.type_line ?? card.
 
 export const cardRarity = (card: Card): string => card.rarity ?? card.details?.rarity ?? '';
 
-export const cardAddedTime = (card: Card): Date | null => (card.addedTmsp ? new Date(card.addedTmsp) : null);
+export const cardAddedTime = (card: Card): Date | null => (card.addedTmsp ? new Date(Number(card.addedTmsp)) : null);
 
 export const cardImageUrl = (card: Card): string =>
   card.imgUrl ?? card.details?.image_normal ?? card.details?.image_small ?? '';

--- a/src/utils/Card.ts
+++ b/src/utils/Card.ts
@@ -189,9 +189,9 @@ export const cardImageBackUrl = (card: Card): string => card.imgBackUrl ?? card.
 export const cardNotes = (card: Card): string | null => card.notes ?? null;
 
 /*
-* Helper to convert the old color category types into current Type. Existing cards may have their colorCategory
-* set to the legacy value and used in places such as CSV export, which then can import instead of the current values.
-*/
+ * Helper to convert the old color category types into current Type. Existing cards may have their colorCategory
+ * set to the legacy value and used in places such as CSV export, which then can import instead of the current values.
+ */
 export const convertFromLegacyCardColorCategory = (colorCategory: string): ColorCategory | null => {
   const legacyColorCategoryToCurrentMap = new Map([
     ['w', 'White'],
@@ -216,12 +216,12 @@ export const convertFromLegacyCardColorCategory = (colorCategory: string): Color
   } else {
     return null;
   }
-}
+};
 
 /*
-* Hybrid color category is explicitly set on cards by cube owners. This function therefore won't
-* return Hybrid as an option, those cards will be funneled into the Multicolored category
-*/
+ * Hybrid color category is explicitly set on cards by cube owners. This function therefore won't
+ * return Hybrid as an option, those cards will be funneled into the Multicolored category
+ */
 export const cardColorCategory = (card: Card): ColorCategory => {
   if (card.colorCategory) {
     const converted = convertFromLegacyCardColorCategory(card.colorCategory);

--- a/src/utils/Sort.ts
+++ b/src/utils/Sort.ts
@@ -339,14 +339,15 @@ function getLabelsRaw(cube: Card[] | null, sort: string, showOther: boolean): st
     ret = tags.sort();
   } else if (sort === 'Date Added') {
     //Convert addedTmsp from a number (or sometimes a string) into Date objects, then to locale string for the labelling and grouping
-    const days = (cube ?? []).map((card) => cardAddedTime(card) ?? new Date(0)).map((date) => date.toLocaleDateString('en-US'));
+    const days = (cube ?? [])
+      .map((card) => cardAddedTime(card) ?? new Date(0))
+      .map((date) => date.toLocaleDateString('en-US'));
     //Remove duplicates from days using Set
     const uniqueDays = [...new Set(days)];
     //Now sort the unique locale strings in order using their date timestamps, as string sorting dates is not well defined
     uniqueDays.sort((a, b) => new Date(a).getTime() - new Date(b).getTime());
 
-    ret = uniqueDays
-
+    ret = uniqueDays;
   } else if (sort === 'Status') {
     ret = ['Not Owned', 'Ordered', 'Owned', 'Premium Owned', 'Proxied'];
   } else if (sort === 'Finish') {
@@ -494,10 +495,10 @@ export function cardGetLabels(card: Card, sort: string, showOther = false): stri
   let ret: string[] = [];
   /* Start of sort options */
   if (sort === 'Color Category') {
-    const convertedColorCategory = convertFromLegacyCardColorCategory(card.colorCategory as string)
+    const convertedColorCategory = convertFromLegacyCardColorCategory(card.colorCategory as string);
     ret = [convertedColorCategory ?? GetColorCategory(cardType(card), cardColorIdentity(card))];
   } else if (sort === 'Color Category Full') {
-    const convertedColorCategory = convertFromLegacyCardColorCategory(card.colorCategory as string)
+    const convertedColorCategory = convertFromLegacyCardColorCategory(card.colorCategory as string);
     const colorCategory = convertedColorCategory ?? GetColorCategory(cardType(card), cardColorIdentity(card));
     if (colorCategory === 'Multicolored') {
       ret = [getColorCombination(cardColorIdentity(card))];

--- a/src/utils/Sort.ts
+++ b/src/utils/Sort.ts
@@ -112,10 +112,6 @@ const SHARDS_AND_WEDGES: string[] = [
 ];
 const FOUR_AND_FIVE_COLOR: string[] = ['Non-White', 'Non-Blue', 'Non-Black', 'Non-Red', 'Non-Green', 'Five Color'];
 
-function removeAdjacentDuplicates<T>(arr: T[]): T[] {
-  return arr.filter((x, i) => i === 0 || x !== arr[i - 1]);
-}
-
 function defaultSort(x: string, y: string): number {
   if (!/^\d+$/.test(x) || !/^\d+$/.test(y)) {
     return x < y ? -1 : 1;
@@ -342,10 +338,15 @@ function getLabelsRaw(cube: Card[] | null, sort: string, showOther: boolean): st
     }
     ret = tags.sort();
   } else if (sort === 'Date Added') {
-    const dates = (cube ?? []).map((card) => cardAddedTime(card) ?? new Date(0));
-    const sortedDates = dates.sort((a, b) => a.getTime() - b.getTime());
-    const days = sortedDates.map((date) => date.toLocaleDateString('en-US'));
-    ret = removeAdjacentDuplicates(days);
+    //Convert addedTmsp from a number (or sometimes a string) into Date objects, then to locale string for the labelling and grouping
+    const days = (cube ?? []).map((card) => cardAddedTime(card) ?? new Date(0)).map((date) => date.toLocaleDateString('en-US'));
+    //Remove duplicates from days using Set
+    const uniqueDays = [...new Set(days)];
+    //Now sort the unique locale strings in order using their date timestamps, as string sorting dates is not well defined
+    uniqueDays.sort((a, b) => new Date(a).getTime() - new Date(b).getTime());
+
+    ret = uniqueDays
+
   } else if (sort === 'Status') {
     ret = ['Not Owned', 'Ordered', 'Owned', 'Premium Owned', 'Proxied'];
   } else if (sort === 'Finish') {


### PR DESCRIPTION
# Problem
Reported in Discord at https://discord.com/channels/592787488523943937/1323699953813684274

Sorting primarily by Date Added could result in the same Dates appearing multiple times and thus cards appearing multiple times in the view. Though sorting can possibly categorise a card multiple times, that logically cannot occur for Date Added.

# Concern
The Cube Table view page does not sort with the Tertiary sort option https://github.com/dekkerglen/CubeCobra/blob/master/src/components/cube/TableView.tsx#L18 for some reason. The Curve view only uses the primary sort https://github.com/dekkerglen/CubeCobra/blob/master/src/components/cube/CurveView.tsx#L72. The list and visual spoiler use all 4 sort options.

Is it intended for some views to use less than all sorts, and if so why (so can document)?

# Solution
When diving into the reported cube's JSON the first thing I noticed was that some cards had addedTmsp as a number and others as a string. Within the code I can see addedTmsp set as both `new Date().valueOf().toString()` and `new Date().valueOf()`, though the Card type defines addedTmsp as a string. And it turns out that `new Date(string timestamp)` and `new Date(number timestamp)` are NOT equivalent; as describe in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date#parameters a string value is parsed equivalent to Date.parse per format https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#date_time_string_format.

Within the Sort.getLabelsRaw for the "Date Added" sort, the cards with string addedTmsp would return a "Invalid Date" Date object whose's time is a `NaN`. The existing code gets all the card dates, sorts them, converts to locale strings, and then removes duplicates. But when the "Invalid Dates" slipped in, the combination of the sorting and removal of duplicates was not able to do its job successfully; from testing it seems that of of a or b in `dates.sort((a, b) => a.getTime() - b.getTime())` is an invalid date the return is `undefined` which per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#parameters implies equivalent, which resulted in the sorted array having "Invalid Date" in various places and NOT grouped together. Thus `removeAdjacentDuplicates` could not remove all duplicates because the incoming array was not truly sorted.

In my testing fixing the cardAddedTime so that string and numbers are handled into valid Dates resulted in the "Date Added" sorting working. However I converted the logic such that it uses Set for uniqueness of the locale date strings, and then sorted those afterwards (as timestamps). Logically this is a more robust way of ensuring a unique set of sorted date labels.

# Testing

## Setup
1. Downloaded the cards from the cube in the reported issue using chrome dev tools and window.reactProps. I could not export and import the cube locally because that would change the added timestamps
2. I created a simple test script seen below in order to quickly test the sorting logic
```
const cards = require('../trash4.json'); //the downloaded cards from step 1
const sortutil = require('../dist/utils/Sort');

const mainboard = cards.mainboard;

const sorted = sortutil.sortDeep(mainboard, true, 'Alphabetical', 'Date Added', 'Types-Multicolored') //the sorts used in the table view from the reported screenshots
console.log("###############")

console.log("Primary groups using the Date Added sort")
for (let c of sorted) {
    let label = c[0];
    console.log(label)
}
```
3. 4. Create an empty cube in my local CubeCobra
5. Using jq I extracted the mainboard from the downloaded cube and massaged it into a mainboard of cards containing cardID, addedTmsp, and status. eg
```
{
  "id": "....",
  "mainboard": [
    {
      "cardID": "3ff91245-57d8-4020-b260-495c938a515b",
      "addedTmsp": 1699410883825,
      "status": "Owned"
    },
    ...
  ]
}
```

6. Using awslocal I uploaded that into the empty cube I created so that I could see it in the UI

## Sort "unit" testing 

Before:
Script output
```
###############
Primary groups using the Date Added sort
11/7/2023
11/11/2023
11/12/2023
11/13/2023
11/25/2023
12/2/2023
12/3/2023
1/7/2024
1/8/2024
2/1/2024
3/7/2024
5/1/2024
5/13/2024
10/5/2024
10/11/2024
10/12/2024
11/25/2024
Invalid Date
11/25/2024
Invalid Date
8/1/2023
1/8/2024
1/15/2024
1/31/2024
2/1/2024
3/7/2024
3/11/2024
3/14/2024
3/27/2024
5/1/2024
10/5/2024
10/11/2024
10/12/2024
Invalid Date
3/7/2024
10/5/2024
10/11/2024
10/12/2024
11/25/2024
```
Can see the "Invalid Date" labels and duplicates of actual date labels such as `1/8/2024`

After:
```
###############
Primary groups using the Date Added sort
8/1/2023
11/7/2023
11/11/2023
11/12/2023
11/13/2023
11/25/2023
12/2/2023
12/3/2023
1/7/2024
1/8/2024
1/15/2024
1/31/2024
2/1/2024
3/7/2024
3/11/2024
3/14/2024
3/27/2024
5/1/2024
5/13/2024
10/5/2024
10/11/2024
10/12/2024
11/25/2024
12/22/2024
```
No "Invalid Date" and no duplicate labels

## UI testing

Before:
![date-added-sort-duplicate-days-local-reproduction](https://github.com/user-attachments/assets/6422295f-481a-49f5-b18d-53e87ebced62)
Can see from the text search (top right) that "1/8/2024" appears twice.

After:
![fixed-date-added-sort-local-reproduction](https://github.com/user-attachments/assets/1c7b8af6-3f74-46b1-943a-628b0dab80b8)
Can see from the text search (top right) that "1/8/2024" appears once.
