### PR TITLE
Minor fixes for multiplayer draft to support debugging

### DIFF
--- a/serverjs/ml.js
+++ b/serverjs/ml.js
@@ -119,10 +119,7 @@ const recommend = (oracles) => {
 
 const build = (oracles) => {
   if (!encoder || !deckbuilderDecoder) {
-    return {
-      mainboard: [],
-      sideboard: [],
-    };
+    return [];
   }
 
   const array = tf.tidy(() => {

--- a/serverjs/multiplayerDrafting.js
+++ b/serverjs/multiplayerDrafting.js
@@ -611,8 +611,8 @@ const dumpDraft = async (draftId) => {
   }
 
   const packs = {};
-  for (let i = 0; i < metadata.totalPacks; i++) {
-    for (let j = 0; j < metadata.seats; j++) {
+  for (let i = 0; i < metadata.seats; i++) {
+    for (let j = 0; j < metadata.totalPacks; j++) {
       const ref = packRef(draftId, i, j);
 
       packs[ref] = {


### PR DESCRIPTION
The change in `serverjs/ml.js` should only occur with local development when you don't have any of the actual models in the models directory. It would result in an error below when the draft with bots is finished.
```
cube        |   TypeError: result.filter is not a function
cube        |       at deckbuild (/home/node/app/serverjs/draftbots.js:147:27)
```

While debugging draft errors using dumps user's provided such as https://discord.com/channels/592787488523943937/1319000014931886090/1320505581261426698, I noticed that the packs had missing data. When testing drafting locally, dumping step by step, and comparing directly against redis I noticed that the pack key names were not consistent.
In Redis would see one like `draft:18cc58b5-fb7b-4749-8a60-fc0f8c37ee3d:pack:7-2` but in the dump it would be `draft:18cc58b5-fb7b-4749-8a60-fc0f8c37ee3d:pack:2-7` and have nothing in picks/pack. Thus found in the dump code that the packRef had transposed seat and pack number compared to other usages such as https://github.com/dekkerglen/CubeCobra/blob/master/serverjs/multiplayerDrafting.js#L145