### PR TITLE
Fix cards not being trashed

### DIFF
--- a/src/components/draft/CubeDraft.tsx
+++ b/src/components/draft/CubeDraft.tsx
@@ -7,8 +7,9 @@ import DeckStacks from 'components/DeckStacks';
 import Pack from 'components/Pack';
 import AutocardContext from 'contexts/AutocardContext';
 import { CSRFContext } from 'contexts/CSRFContext';
+import CardInterface from 'datatypes/Card';
 import Draft from 'datatypes/Draft';
-import DraftLocation, { addCard, locations, removeCard } from 'drafting/DraftLocation';
+import DraftLocation, { addCard, location, locations, removeCard } from 'drafting/DraftLocation';
 import { draftStateToTitle, getCardCol, setupPicks } from 'drafting/draftutil';
 import useMount from 'hooks/UseMount';
 import { cardCmc, cardType, makeSubtitle } from 'utils/Card';
@@ -167,25 +168,87 @@ const CubeDraft: React.FC<CubeDraftProps> = ({ draft, socket }) => {
     run();
   });
 
-  const onClickCard = useCallback(
-    (cardIndex: number) => {
-      console.log('click', cardIndex);
-      const card = draft.cards[pack[cardIndex]];
+  const getCardsDeckStackPosition = useCallback((card: CardInterface): { row: number; col: number } => {
+    const isCreature = cardType(card).toLowerCase().includes('creature');
+    const cmc = cardCmc(card);
 
-      const isCreature = cardType(card).toLowerCase().includes('creature');
-      const cmc = cardCmc(card);
+    const row = isCreature ? 0 : 1;
+    const col = Math.max(0, Math.min(7, cmc));
 
-      const row = isCreature ? 0 : 1;
-      const col = Math.max(0, Math.min(7, cmc));
+    return { row, col };
+  }, []);
 
-      setMainboard(
-        addCard(mainboard, new DraftLocation(locations.deck, row, col, mainboard[row][col].length), pack[cardIndex]),
-      );
-      makePick(cardIndex);
+  //When a card is chosen from the pack
+  const applyCardSelectionForStep = useCallback(
+    (packIndex: number, locationType: location, row: number, col: number) => {
+      const cardIndex = pack[packIndex];
+
+      if (stepQueue[0] === 'pick' || stepQueue[0] === 'pickrandom') {
+        if (locationType === locations.deck) {
+          setMainboard(
+            addCard(mainboard, new DraftLocation(locations.deck, row, col, mainboard[row][col].length), cardIndex),
+          );
+        } else if (locationType === locations.sideboard) {
+          setSideboard(
+            addCard(sideboard, new DraftLocation(locations.deck, row, col, sideboard[row][col].length), cardIndex),
+          );
+        }
+      } else if (stepQueue[0] === 'trash' || stepQueue[0] === 'trashrandom') {
+        setTrashed([...trashed, cardIndex]);
+      }
+
+      makePick(packIndex);
     },
-    [pack, mainboard, draft.cards, makePick, setMainboard],
+    [mainboard, makePick, pack, sideboard, stepQueue, trashed],
   );
 
+  const selectCardByIndex = useCallback(
+    (packIndex: number) => {
+      const cardIndex = pack[packIndex];
+      const card = draft.cards[cardIndex];
+
+      const { row, col } = getCardsDeckStackPosition(card);
+      applyCardSelectionForStep(packIndex, locations.deck, row, col);
+    },
+    [pack, draft.cards, getCardsDeckStackPosition, applyCardSelectionForStep],
+  );
+
+  const getLocationReferences = useCallback(
+    (type: location): { board: any[][][]; setter: React.Dispatch<React.SetStateAction<any[][][]>> } => {
+      if (type === locations.deck) {
+        return {
+          board: mainboard,
+          setter: setMainboard,
+        };
+      } else {
+        return {
+          board: sideboard,
+          setter: setSideboard,
+        };
+      }
+    },
+    [mainboard, sideboard],
+  );
+
+  const moveCardBetweenDeckStacks = useCallback(
+    (source: DraftLocation, target: DraftLocation) => {
+      const { board: sourceBoard, setter: sourceSetter } = getLocationReferences(source.type);
+
+      //Moving within the same DeckStack
+      if (source.type === target.type) {
+        const [card, newCards] = removeCard(sourceBoard, source);
+        sourceSetter(addCard(newCards, target, card));
+      } else {
+        const { board: targetBoard, setter: targetSetter } = getLocationReferences(target.type);
+        const [card, newCards] = removeCard(sourceBoard, source);
+        sourceSetter(addCard(targetBoard, target, card));
+        targetSetter(newCards);
+      }
+    },
+    [getLocationReferences],
+  );
+
+  //Move card between Pack and/or DeckStacks
   const onMoveCard = useCallback(
     async (event: any) => {
       const { active, over } = event;
@@ -202,7 +265,7 @@ const CubeDraft: React.FC<CubeDraftProps> = ({ draft, socket }) => {
         const dragTime = Date.now() - (dragStartTime ?? 0);
 
         if (dragTime < 200) {
-          return onClickCard(source.index);
+          return selectCardByIndex(source.index);
         }
       } else if (source.equals(target)) {
         return;
@@ -214,44 +277,16 @@ const CubeDraft: React.FC<CubeDraftProps> = ({ draft, socket }) => {
       }
 
       if (source.type === locations.pack) {
-        if (target.type === locations.deck) {
-          if (stepQueue[0] === 'pick' || stepQueue[0] === 'pickrandom') {
-            setMainboard(addCard(mainboard, target, pack[source.index]));
-          } else if (stepQueue[0] === 'trash' || stepQueue[0] === 'trashrandom') {
-            setTrashed([...trashed, pack[source.index]]);
-          }
+        if (target.type === locations.deck || target.type === locations.sideboard) {
+          applyCardSelectionForStep(source.index, target.type, target.row, target.col);
+        }
 
-          makePick(source.index);
-        } else if (target.type === locations.sideboard) {
-          if (stepQueue[0] === 'pick' || stepQueue[0] === 'pickrandom') {
-            setSideboard(addCard(sideboard, target, pack[source.index]));
-          } else if (stepQueue[0] === 'trash' || stepQueue[0] === 'trashrandom') {
-            setTrashed([...trashed, pack[source.index]]);
-          }
-
-          makePick(source.index);
-        }
-      } else if (source.type === locations.deck) {
-        if (target.type === locations.deck) {
-          const [card, newCards] = removeCard(mainboard, source);
-          setMainboard(addCard(newCards, target, card));
-        } else if (target.type === locations.sideboard) {
-          const [card, newCards] = removeCard(mainboard, source);
-          setSideboard(addCard(sideboard, target, card));
-          setMainboard(newCards);
-        }
-      } else if (source.type === locations.sideboard) {
-        if (target.type === locations.deck) {
-          const [card, newCards] = removeCard(sideboard, source);
-          setMainboard(addCard(mainboard, target, card));
-          setSideboard(newCards);
-        } else if (target.type === locations.sideboard) {
-          const [card, newCards] = removeCard(sideboard, source);
-          setSideboard(addCard(newCards, target, card));
-        }
+        return;
       }
+
+      moveCardBetweenDeckStacks(source, target);
     },
-    [stepQueue, makePick, mainboard, pack, trashed, onClickCard, dragStartTime, sideboard],
+    [moveCardBetweenDeckStacks, dragStartTime, selectCardByIndex, applyCardSelectionForStep],
   );
 
   useEffect(() => {
@@ -263,10 +298,10 @@ const CubeDraft: React.FC<CubeDraftProps> = ({ draft, socket }) => {
     ) {
       setLoading(true);
       setTimeout(() => {
-        onClickCard(Math.floor(Math.random() * pack.length));
+        selectCardByIndex(Math.floor(Math.random() * pack.length));
       }, 1000);
     }
-  }, [stepQueue, onClickCard, pack, loading]);
+  }, [stepQueue, selectCardByIndex, pack, loading]);
 
   return (
     <DndContext onDragEnd={onMoveCard} onDragStart={() => setDragStartTime(Date.now())}>

--- a/src/components/draft/CubeDraft.tsx
+++ b/src/components/draft/CubeDraft.tsx
@@ -252,6 +252,32 @@ const CubeDraft: React.FC<CubeDraftProps> = ({ draft, socket }) => {
     [getLocationReferences],
   );
 
+  /*
+   * Clicking on a card within either deck stack moves it to the other. Unlike a drag where we have different source and targets,
+   * on a click we only have the source. We determine the target location based on the source card's cmc/type (getCardsDeckStackPosition)
+   * though if moving to the sideboard only the CMC matters to determine the column.
+   */
+  /*const applyCardClickOnDeckStack = useCallback(
+    (source: DraftLocation) => {
+      //Determine the card which was clicked in the board, so we can calculate its standard row/col destination
+      const { board: sourceBoard } = getLocationReferences(source.type);
+      const cardIndex = sourceBoard[source.row][source.col][source.index];
+      const card = draft.cards[cardIndex];
+      const { row, col } = getCardsDeckStackPosition(card);
+
+      const targetLocation = source.type === locations.deck ? locations.sideboard : locations.deck;
+      //The sideboard only has one row, unlike the deck with has 1 row for creatures and 1 for non-creatures
+      const targetRow = targetLocation === locations.sideboard ? 0 : row;
+      const { board: targetBoard } = getLocationReferences(targetLocation);
+
+      //The card should be added to the end of the stack of cards at the grid position (row/col). Be extra careful
+      //with the boards (using .? operator) even though they are pre-populated via setupPicks() at the top
+      const targetIndex = targetBoard?.[targetRow]?.[col]?.[source.index] || 0;
+      moveCardBetweenDeckStacks(source, new DraftLocation(targetLocation, targetRow, col, targetIndex));
+    },
+    [draft.cards, getLocationReferences, moveCardBetweenDeckStacks],
+  );*/
+
   //Move card between Pack and/or DeckStacks
   const onMoveCard = useCallback(
     async (event: any) => {
@@ -271,7 +297,12 @@ const CubeDraft: React.FC<CubeDraftProps> = ({ draft, socket }) => {
         if (dragTime < 200) {
           return selectCardByIndex(source.index);
         }
-      } else if (source.equals(target)) {
+        //TODO: Uncomment alongside the sideboard DeckStacks
+      } /*else if (source.equals(target) && (source.type === locations.deck || source.type === locations.sideboard)) {
+        //Clicking a card within the deck or sideboard should move it from one to the other
+        applyCardClickOnDeckStack(source);
+        return;
+      }*/ else if (source.equals(target)) {
         return;
       }
 

--- a/src/components/draft/CubeDraft.tsx
+++ b/src/components/draft/CubeDraft.tsx
@@ -313,6 +313,7 @@ const CubeDraft: React.FC<CubeDraftProps> = ({ draft, socket }) => {
       }
 
       if (source.type === locations.pack) {
+        //Dragged a card from the pack to the deck or sideboard (the latter is off)
         if (target.type === locations.deck || target.type === locations.sideboard) {
           applyCardSelectionForStep(source.index, target.type, target.row, target.col, target.index);
         }
@@ -320,6 +321,7 @@ const CubeDraft: React.FC<CubeDraftProps> = ({ draft, socket }) => {
         return;
       }
 
+      //Otherwise the drag had nothing to do with the pack
       moveCardBetweenDeckStacks(source, target);
     },
     [moveCardBetweenDeckStacks, dragStartTime, selectCardByIndex, applyCardSelectionForStep],
@@ -334,6 +336,7 @@ const CubeDraft: React.FC<CubeDraftProps> = ({ draft, socket }) => {
     ) {
       setLoading(true);
       setTimeout(() => {
+        //Automatically select a card from the pack, by picking a random index position within the available card pack
         selectCardByIndex(Math.floor(Math.random() * pack.length));
       }, 1000);
     }

--- a/src/components/draft/CubeDraft.tsx
+++ b/src/components/draft/CubeDraft.tsx
@@ -178,41 +178,6 @@ const CubeDraft: React.FC<CubeDraftProps> = ({ draft, socket }) => {
     return { row, col };
   }, []);
 
-  //When a card is chosen from the pack
-  const applyCardSelectionForStep = useCallback(
-    (packIndex: number, locationType: location, row: number, col: number) => {
-      const cardIndex = pack[packIndex];
-
-      if (stepQueue[0] === 'pick' || stepQueue[0] === 'pickrandom') {
-        if (locationType === locations.deck) {
-          setMainboard(
-            addCard(mainboard, new DraftLocation(locations.deck, row, col, mainboard[row][col].length), cardIndex),
-          );
-        } else if (locationType === locations.sideboard) {
-          setSideboard(
-            addCard(sideboard, new DraftLocation(locations.deck, row, col, sideboard[row][col].length), cardIndex),
-          );
-        }
-      } else if (stepQueue[0] === 'trash' || stepQueue[0] === 'trashrandom') {
-        setTrashed([...trashed, cardIndex]);
-      }
-
-      makePick(packIndex);
-    },
-    [mainboard, makePick, pack, sideboard, stepQueue, trashed],
-  );
-
-  const selectCardByIndex = useCallback(
-    (packIndex: number) => {
-      const cardIndex = pack[packIndex];
-      const card = draft.cards[cardIndex];
-
-      const { row, col } = getCardsDeckStackPosition(card);
-      applyCardSelectionForStep(packIndex, locations.deck, row, col);
-    },
-    [pack, draft.cards, getCardsDeckStackPosition, applyCardSelectionForStep],
-  );
-
   const getLocationReferences = useCallback(
     (type: location): { board: any[][][]; setter: React.Dispatch<React.SetStateAction<any[][][]>> } => {
       if (type === locations.deck) {
@@ -228,6 +193,34 @@ const CubeDraft: React.FC<CubeDraftProps> = ({ draft, socket }) => {
       }
     },
     [mainboard, sideboard],
+  );
+
+  //When a card is chosen from the pack
+  const applyCardSelectionForStep = useCallback(
+    (packIndex: number, locationType: location, row: number, col: number) => {
+      const cardIndex = pack[packIndex];
+
+      if (stepQueue[0] === 'pick' || stepQueue[0] === 'pickrandom') {
+        const { board, setter } = getLocationReferences(locationType);
+        setter(addCard(board, new DraftLocation(locationType, row, col, board[row][col].length), cardIndex));
+      } else if (stepQueue[0] === 'trash' || stepQueue[0] === 'trashrandom') {
+        setTrashed([...trashed, cardIndex]);
+      }
+
+      makePick(packIndex);
+    },
+    [getLocationReferences, makePick, pack, stepQueue, trashed],
+  );
+
+  const selectCardByIndex = useCallback(
+    (packIndex: number) => {
+      const cardIndex = pack[packIndex];
+      const card = draft.cards[cardIndex];
+
+      const { row, col } = getCardsDeckStackPosition(card);
+      applyCardSelectionForStep(packIndex, locations.deck, row, col);
+    },
+    [pack, draft.cards, getCardsDeckStackPosition, applyCardSelectionForStep],
   );
 
   const moveCardBetweenDeckStacks = useCallback(

--- a/src/components/draft/CubeDraft.tsx
+++ b/src/components/draft/CubeDraft.tsx
@@ -197,12 +197,22 @@ const CubeDraft: React.FC<CubeDraftProps> = ({ draft, socket }) => {
 
   //When a card is chosen from the pack
   const applyCardSelectionForStep = useCallback(
-    (packIndex: number, locationType: location, row: number, col: number) => {
+    (packIndex: number, locationType: location, row: number, col: number, targetIndex: number = -1) => {
       const cardIndex = pack[packIndex];
 
       if (stepQueue[0] === 'pick' || stepQueue[0] === 'pickrandom') {
         const { board, setter } = getLocationReferences(locationType);
-        setter(addCard(board, new DraftLocation(locationType, row, col, board[row][col].length), cardIndex));
+        const gridPositionCardCount = board[row][col].length;
+        /*
+         * Move card into the stack within the target grid position (row/col). If the index isn't known, such as
+         * because we clicked to move, then adds to the end of the stack. Be extra careful that the target index fits within
+         * the array of cards in this grid position
+         */
+        const placementIndex =
+          targetIndex === -1 || targetIndex < 0 || targetIndex > gridPositionCardCount
+            ? gridPositionCardCount
+            : targetIndex;
+        setter(addCard(board, new DraftLocation(locationType, row, col, placementIndex), cardIndex));
       } else if (stepQueue[0] === 'trash' || stepQueue[0] === 'trashrandom') {
         setTrashed([...trashed, cardIndex]);
       }
@@ -271,7 +281,7 @@ const CubeDraft: React.FC<CubeDraftProps> = ({ draft, socket }) => {
 
       if (source.type === locations.pack) {
         if (target.type === locations.deck || target.type === locations.sideboard) {
-          applyCardSelectionForStep(source.index, target.type, target.row, target.col);
+          applyCardSelectionForStep(source.index, target.type, target.row, target.col, target.index);
         }
 
         return;

--- a/src/components/draft/CubeDraft.tsx
+++ b/src/components/draft/CubeDraft.tsx
@@ -244,8 +244,9 @@ const CubeDraft: React.FC<CubeDraftProps> = ({ draft, socket }) => {
       } else {
         const { board: targetBoard, setter: targetSetter } = getLocationReferences(target.type);
         const [card, newCards] = removeCard(sourceBoard, source);
-        sourceSetter(addCard(targetBoard, target, card));
-        targetSetter(newCards);
+        //Add card to the target, then update the source with the cards minus the moved card
+        targetSetter(addCard(targetBoard, target, card));
+        sourceSetter(newCards);
       }
     },
     [getLocationReferences],

--- a/src/components/draft/CubeDraft.tsx
+++ b/src/components/draft/CubeDraft.tsx
@@ -1,16 +1,17 @@
 import React, { useCallback, useContext, useEffect, useState } from 'react';
-import { Card } from 'components/base/Card';
 
+import { DndContext } from '@dnd-kit/core';
+
+import { Card } from 'components/base/Card';
 import DeckStacks from 'components/DeckStacks';
 import Pack from 'components/Pack';
 import AutocardContext from 'contexts/AutocardContext';
-import DraftLocation, { locations, addCard, removeCard } from 'drafting/DraftLocation';
+import { CSRFContext } from 'contexts/CSRFContext';
+import Draft from 'datatypes/Draft';
+import DraftLocation, { addCard, locations, removeCard } from 'drafting/DraftLocation';
 import { draftStateToTitle, getCardCol, setupPicks } from 'drafting/draftutil';
 import useMount from 'hooks/UseMount';
 import { cardCmc, cardType, makeSubtitle } from 'utils/Card';
-import Draft from 'datatypes/Draft';
-import { DndContext } from '@dnd-kit/core';
-import { CSRFContext } from 'contexts/CSRFContext';
 
 interface CubeDraftProps {
   draft: Draft;
@@ -89,7 +90,7 @@ const CubeDraft: React.FC<CubeDraftProps> = ({ draft, socket }) => {
 
       await callApi('/multiplayer/draftpick', { draft: draft.id, seat, pick });
     },
-    [hideCard, stepQueue, pack, draft.id, tryPopPack, seat],
+    [hideCard, stepQueue, pack, callApi, draft.id, tryPopPack],
   );
 
   const updatePack = async (data: any) => {
@@ -113,7 +114,7 @@ const CubeDraft: React.FC<CubeDraftProps> = ({ draft, socket }) => {
           draft: draft.id,
         });
         if (res) {
-          let json = await res.json();
+          const json = await res.json();
           status = json.result;
 
           if (json.picks === 0) {


### PR DESCRIPTION
# Problem
Reported in Discord. Clicking cards when the draft step is "trashing" instead added them to the mainboard. This also occurred if the step was "auto trash".
Dragging the card correctly trashed it.

A corollary to the issue is that the draft step "Pack X Pick Y: <action>" title got out of sync and would be ahead of the current draft position (and sometimes illogical such as the pick being larger than than number of cards per pack).

The source of the problem comes from the 1.0.0 refactor and the conversion to the Drag and Drop Context surrounding the pack and deck stacks (boards). Before then (see https://github.com/dekkerglen/CubeCobra/blob/dd3fde3cbdfff410fe9a85df477091d957f35c4c/src/components/CubeDraft.js#L157) the click and drag (on move) were two different handles, with a click transforming into a move action.

After the refactor there are onDragStart and onDragEnd handlers, with the bulk of the logic in the latter. When the drag is less than 200ms it is considered a click, but the click handler was rebuilt to only put cards into the mainboard. The rest of the onDragEnd handler would consider the step and trash appropriately.

# Solution
Refactored the handler logic to move the business logic of the step action away from the drag or click actions.

During testing I enabled the sideboard DeckStack and validated that cards can be dragged or clicked from the mainboard to the sideboard and vice versa. However left the sideboard disabled as per Discord discussion nothing tracks the state of the sideboard so if the page is reloaded everything would go back to the mainboard.

## Concerns
I haven't been able to reproduce it consistently nor understand why, but I've seen cases where the auto-draft useEffect timeout triggers multiple times for the same draft step. In theory that shouldn't happen because of useEffect and specifically the pack dependency (let along the loading state), as that is an array containing the indices of the cards in the pack (the index being the position in the randomized set of cards). Thus after each active draft step, the pack array would be a unique array because its either a new pack or when the pack wheels, a subset of a previous pack array. **So likely its best to chalk this up to in progress development rather than an actual issue**

The CubeDeckbuilderPage has very similar logic for handling clicks and drag/drops, so we should probably refactor for consistency.

# Testing
For all tests created a custom draft with 3 packs, 5 cards per pack. The first pack is non-standard with trashing and auto-trashing alongside picks, see:
![trashing-draft-setup](https://github.com/user-attachments/assets/91606779-2e88-41a8-a7ff-00d2e012f132)

## Before
Clicking on cards during the trashing steps, and in the auto trash step actually adds the cards to the mainboard. Also note that the pack X, pick Y gets out of sync after the first trash step.
![trashing-clicking-adds-to-board](https://github.com/user-attachments/assets/0deca962-4ece-4287-bd05-d2c6706f9875)

However if cards are dragged from the pack to the mainboard the trashing works. The auto-trash step still fails. The pack X, pick Y gets out of sync after the auto-trash step.
![trashing-dragging-works2](https://github.com/user-attachments/assets/8ff8159e-d617-4f9a-ac16-841c17b4854c)

## After
Clicking on cards during the trashing steps, and in the auto trash step does not change the mainboard. The pack X, pick Y stays accurate.
![trashing-fixed-clicking](https://github.com/user-attachments/assets/a98634bb-cc98-4f29-963c-4afa2b89805b)

Dragging works still, and the auto-trash is working.
![trashing-fixed-dragging](https://github.com/user-attachments/assets/f36f0184-41da-4e98-8c12-641cbd51811d)
