### PR TITLE
Fix modals opened from the NavMenu being closed when they are clicked on

### DIFF
--- a/src/components/base/NavMenu.tsx
+++ b/src/components/base/NavMenu.tsx
@@ -57,13 +57,18 @@ const NavMenu: React.FC<NavMenuProps> = ({ label, children, wide, navBar }) => {
         >
           {label}
         </a>
-        {isOpen && (
-          <div className="w-full bg-bg shadow-lg rounded-md border border-border">
-            <Flexbox direction="col" gap="1" className="p-2">
-              {children}
-            </Flexbox>
-          </div>
-        )}
+        <div
+          className={classNames('w-full bg-bg shadow-lg rounded-md border border-border', {
+            'opacity-100 max-h-screen': isOpen,
+            'opacity-0 pointer-events-none max-h-0': !isOpen,
+            'w-64': !wide,
+            'w-96': wide,
+          })}
+        >
+          <Flexbox direction="col" gap="1" className="p-2">
+            {children}
+          </Flexbox>
+        </div>
       </ResponsiveDiv>
 
       {/* Desktop */}

--- a/src/components/base/NavMenu.tsx
+++ b/src/components/base/NavMenu.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useRef, useEffect } from 'react';
-import ResponsiveDiv from './ResponsiveDiv';
-import { Flexbox } from './Layout';
+import React, { useEffect, useRef, useState } from 'react';
+
 import classNames from 'classnames';
-// import Collapse from './Collapse';
+
+import { Flexbox } from 'components/base/Layout';
+import ResponsiveDiv from 'components/base/ResponsiveDiv';
 
 interface NavMenuProps {
   label: React.ReactNode;
@@ -15,18 +16,31 @@ const NavMenu: React.FC<NavMenuProps> = ({ label, children, wide, navBar }) => {
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
-  const handleClickOutside = (event: MouseEvent) => {
-    if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-      setIsOpen(false);
-    }
-  };
-
   useEffect(() => {
+    /*
+     * Per https://stackoverflow.com/a/55360806 don't register the event listener unless the NavMenu is open.
+     * Without this every NavMenu registers the same handler so clicks on the page trigger 10+ events; though since
+     * only one NavMenu is open at a time, most of the handlers do nothing when they call setIsOpen(false)
+     */
+    if (!isOpen) {
+      return;
+    }
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
     document.addEventListener('mousedown', handleClickOutside);
+    /*
+     * A function returned from useEffect is a cleanup function (https://react.dev/reference/react/useEffect#parameters) which
+     * React calls before the next re-render (when the dependencies change)
+     */
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
     };
-  }, []);
+  }, [isOpen]);
 
   return (
     <div ref={menuRef} className="relative">


### PR DESCRIPTION
# Problem
Bug reported in Discord. When in mobile you opened a modal, such as "Create a new cube", and then clicked into it then the modal disappeared.

The root cause is in the NavMenu component, which powers sub-menus such as About or Your Cubes. It has a handler that checks for document mousedown events and if the event's target doesn't belong to the NavMenu, then it closes the NavMenu. However the NavMenu checked isOpen to decide whether to render the child menu items in the mobile half of the component. The modals such as "Create a new cube" belong to those menu items, so when they aren't rendered the modal itself no longer exists.

# Solution
The desktop half of the NavMenu always renders the child menu items but when it isn't open it adds additional classes most importantly `max-h-0` which hides the child menu items by giving them no height. In that case the modal which is a descendant of the NavMenu always exists even if the NavMenu is not open. Thus the fix is doing the hiding for the mobile half rather than not including the child menu items in rendering.

In addition I made a change to the mousedown handler. From testing every click on the page triggered the handler multiple times, once for each NavMenu in the desktop and mobile halves. In most cases that resulted in no changes because calling `setIsOpen(false)` for NavMenu's where isOpen is already false does nothing as React sees no actual state change. But rather than having so many handlers called all the time, we only need to register the event handler if the NavMenu is opened. And then per existing code the returned cleanup function will deregister the event handler when the component re-renders.

# Testing

## Before

On desktop you can see the modals are still open even when the sub-menu is closed in the background.
![current-desktop-modal-stays-open-when-menu-closes-3](https://github.com/user-attachments/assets/182422ed-e180-4faf-ae02-ed21074b2df4)
![current-desktop-modal-stays-open-when-menu-closes-2](https://github.com/user-attachments/assets/6e16d17a-7ca3-4546-b393-aac485db6f5b)
![current-desktop-modal-stays-open-when-menu-closes](https://github.com/user-attachments/assets/dea7fca3-1814-4281-9ca7-17c103712406)

But on mobile the modals close when the sub-menu closes.
![current-mobile-modal-closes-when-menu-closes-3](https://github.com/user-attachments/assets/b565fa72-8b63-409e-9907-11104dd50b5a)
![current-mobile-modal-closes-when-menu-closes-2](https://github.com/user-attachments/assets/2721c4e0-8a91-4715-9908-aebbef54cb46)
![current-mobile-modal-closes-when-menu-closes](https://github.com/user-attachments/assets/4aed1db7-63ae-4441-bfe0-82c2b4b9589c)

That only applies to modals opened from NavMenu children. For example the Login modal on mobile didn't exhibit the problem because it does not belong to a NavMenu, but to the top-level NavBar.
![new-mobile-login-mobile-not-affected-because-not-in-sub-menu](https://github.com/user-attachments/assets/08438ca0-edcc-4510-8657-3a44aad6b643)


## After

On desktop the behaviour is the same:
![new-desktop-modal-stays-open-when-menu-closes-3](https://github.com/user-attachments/assets/3fccca69-5bc3-4840-b2e8-e61ff841c416)
![new-desktop-modal-stays-open-when-menu-closes-2](https://github.com/user-attachments/assets/4e746ebe-aab4-4ed5-a060-4ad7fc5e584b)
![new-desktop-modal-stays-open-when-menu-closes](https://github.com/user-attachments/assets/7cda7b41-984c-486e-994b-33128aa48fc1)

On mobile now the modal stays open even when the sub-menu closes:
![new-mobile-modal-stays-open-when-menu-closes-3](https://github.com/user-attachments/assets/d0d0b4f8-16cb-4eb9-bce7-2da46247f3c0)
![new-mobile-modal-stays-open-when-menu-closes-2](https://github.com/user-attachments/assets/7d2f96b2-b26a-4414-b442-778c753ac047)
![new-mobile-modal-stays-open-when-menu-closes](https://github.com/user-attachments/assets/e010d023-b436-4aac-96c1-4fb9c79d6660)

And the changes to the mousedown handler have not caused any regression on how the sub-menu closes when its parent is clicked or if you click elsewhere on the page.
![new-mobile-menu-closes-when-clicking-on-it-or-away](https://github.com/user-attachments/assets/9943e09f-645d-43c4-b722-eac4cbd72107)


