### PR TITLE
Fix server error on individual blog post when the changelist is > 10,000 cards

### DIFF
--- a/dynamo/models/changelog.js
+++ b/dynamo/models/changelog.js
@@ -120,7 +120,11 @@ const hydrateChangelog = (changelog) => {
 const getChangelog = async (cubeId, id) => {
   const changelog = await getObject(process.env.DATA_BUCKET, `changelog/${cubeId}/${id}.json`);
 
-  return hydrateChangelog(changelog);
+  try {
+    return hydrateChangelog(changelog);
+  } catch {
+    return changelog;
+  }
 };
 
 const parseHtml = (html) => {

--- a/dynamo/models/comment.js
+++ b/dynamo/models/comment.js
@@ -4,7 +4,7 @@ require('dotenv').config();
 const uuid = require('uuid');
 
 const createClient = require('../util');
-const util = require('../../serverjs/util');
+const imageutil = require('../../serverjs/imageutil');
 const User = require('./user');
 
 const FIELDS = {
@@ -29,7 +29,7 @@ const client = createClient({
       name: 'ByOwner',
       partitionKey: FIELDS.OWNER,
       sortKey: FIELDS.DATE,
-    }
+    },
   ],
   attributes: {
     [FIELDS.ID]: 'S',
@@ -60,7 +60,7 @@ const hydrate = async (item) => {
   }
 
   item.owner = await User.getById(item.owner);
-  item.image = util.getImageData(item.owner.imageName);
+  item.image = imageutil.getImageData(item.owner.imageName);
 
   return item;
 };
@@ -85,7 +85,7 @@ const batchHydrate = async (items) => {
     }
 
     item.owner = owners.find((owner) => owner.id === item.owner);
-    item.image = util.getImageData(item.owner ? item.owner.imageName : 'Ambush Viper');
+    item.image = imageutil.getImageData(item.owner ? item.owner.imageName : 'Ambush Viper');
 
     return item;
   });

--- a/dynamo/models/content.js
+++ b/dynamo/models/content.js
@@ -1,6 +1,6 @@
 const sanitizeHtml = require('sanitize-html');
 const htmlToText = require('html-to-text');
-const { getImageData } = require('../../serverjs/util');
+const { getImageData } = require('../../serverjs/imageutil');
 const createClient = require('../util');
 const { getObject, putObject } = require('../s3client');
 const uuid = require('uuid');

--- a/dynamo/models/cube.js
+++ b/dynamo/models/cube.js
@@ -2,7 +2,7 @@
 require('dotenv').config();
 
 const _ = require('lodash');
-const { getImageData } = require('../../serverjs/util');
+const { getImageData } = require('../../serverjs/imageutil');
 const createClient = require('../util');
 const { getObject, putObject, deleteObject } = require('../s3client');
 const { getHashRowsForMetadata } = require('./cubeHash');

--- a/dynamo/models/user.js
+++ b/dynamo/models/user.js
@@ -1,6 +1,5 @@
-const { getImageData } = require('../../serverjs/util');
+const { getImageData } = require('../../serverjs/imageutil');
 const createClient = require('../util');
-const { deleteById } = require('./cube');
 
 const FIELDS = {
   ID: 'id',
@@ -171,10 +170,9 @@ module.exports = {
   batchAdd: async (documents) => {
     return client.batchPut(documents);
   },
-  deleteById: async (id) => client.delete({id}),
+  deleteById: async (id) => client.delete({ id }),
   batchGet: async (ids) => batchHydrate(batchStripSensitiveData(await client.batchGet(ids.map((id) => `${id}`)))),
   createTable: async () => client.createTable(),
-  deleteById: async (id) => client.delete({id}),
   convertUser: (user) => ({
     [FIELDS.ID]: `${user._id}`,
     [FIELDS.USERNAME]: user.username,
@@ -189,7 +187,7 @@ module.exports = {
     [FIELDS.IMAGE_NAME]: user.image_name,
     [FIELDS.ROLES]: user.roles,
     [FIELDS.THEME]: user.theme,
-    [FIELDS.HIDE_FEATURED]: user.hide_featured
+    [FIELDS.HIDE_FEATURED]: user.hide_featured,
   }),
   ROLES,
   FIELDS,

--- a/routes/comment_routes.js
+++ b/routes/comment_routes.js
@@ -5,6 +5,7 @@ const express = require('express');
 const { ensureAuth, csrfProtection } = require('./middleware');
 
 const util = require('../serverjs/util');
+const imageutil = require('../serverjs/imageutil');
 const Comment = require('../dynamo/models/comment');
 const User = require('../dynamo/models/user');
 const Content = require('../dynamo/models/content');
@@ -121,7 +122,7 @@ router.post(
         ...comment,
         owner: req.user,
         id,
-        image: util.getImageData(req.user.imageName),
+        image: imageutil.getImageData(req.user.imageName),
       },
     });
   }),

--- a/serverjs/imageutil.js
+++ b/serverjs/imageutil.js
@@ -7,27 +7,27 @@ const carddb = require('./carddb');
 // artist
 // id
 function getImageData(imagename) {
-    const exact = carddb.imagedict[imagename.toLowerCase()];
+  const exact = carddb.imagedict[imagename.toLowerCase()];
 
-    if (exact) {
-        return exact;
+  if (exact) {
+    return exact;
+  }
+
+  const name = cardutil.normalizeName(imagename);
+  const ids = carddb.nameToId[name];
+  if (ids) {
+    const byName = carddb.cardFromId(ids[0]);
+    if (byName.scryfall_id) {
+      return {
+        uri: byName.art_crop,
+        artist: byName.artist,
+        id: byName.scryfall_id,
+        imageName: imagename,
+      };
     }
+  }
 
-    const name = cardutil.normalizeName(imagename);
-    const ids = carddb.nameToId[name];
-    if (ids) {
-        const byName = carddb.cardFromId(ids[0]);
-        if (byName.scryfall_id) {
-            return {
-                uri: byName.art_crop,
-                artist: byName.artist,
-                id: byName.scryfall_id,
-                imageName: imagename,
-            };
-        }
-    }
-
-    return carddb.imagedict['doubling cube [10e-321]'];
+  return carddb.imagedict['doubling cube [10e-321]'];
 }
 
 module.exports = {

--- a/serverjs/imageutil.js
+++ b/serverjs/imageutil.js
@@ -1,0 +1,35 @@
+//Split this into its own file to prevent cyclic dependencies
+
+const cardutil = require('../dist/utils/Card');
+const carddb = require('./carddb');
+
+// uri
+// artist
+// id
+function getImageData(imagename) {
+    const exact = carddb.imagedict[imagename.toLowerCase()];
+
+    if (exact) {
+        return exact;
+    }
+
+    const name = cardutil.normalizeName(imagename);
+    const ids = carddb.nameToId[name];
+    if (ids) {
+        const byName = carddb.cardFromId(ids[0]);
+        if (byName.scryfall_id) {
+            return {
+                uri: byName.art_crop,
+                artist: byName.artist,
+                id: byName.scryfall_id,
+                imageName: imagename,
+            };
+        }
+    }
+
+    return carddb.imagedict['doubling cube [10e-321]'];
+}
+
+module.exports = {
+  getImageData,
+};

--- a/serverjs/util.js
+++ b/serverjs/util.js
@@ -305,33 +305,6 @@ function flatten(arr, n) {
   return toNonNullArray([].concat(...mapNonNull(arr, (a) => flatten(a, n - 1))));
 }
 
-// uri
-// artist
-// id
-function getImageData(imagename) {
-  const exact = carddb.imagedict[imagename.toLowerCase()];
-
-  if (exact) {
-    return exact;
-  }
-
-  const name = cardutil.normalizeName(imagename);
-  const ids = carddb.nameToId[name];
-  if (ids) {
-    const byName = carddb.cardFromId(ids[0]);
-    if (byName.scryfall_id) {
-      return {
-        uri: byName.art_crop,
-        artist: byName.artist,
-        id: byName.scryfall_id,
-        imageName: imagename,
-      };
-    }
-  }
-
-  return carddb.imagedict['doubling cube [10e-321]'];
-}
-
 module.exports = {
   shuffle(array, seed) {
     if (!seed) {
@@ -373,6 +346,5 @@ module.exports = {
   toNonNullArray,
   flatten,
   mapNonNull,
-  getImageData,
-  validateEmail
+  validateEmail,
 };


### PR DESCRIPTION
# Problem
Bug reported in Discord. Though a blog post with a changelist > 10,000 cards can be seen in the Cube's blog posts list, clicking into the post itself caused a server error.

Based on the code the error should have triggered the route to redirect to the error page with the message "Too many cards to load this changelog". However the `util.handleRouteError` fails to call `redirect` from the render.js file due to circular dependencies, which crazily nodejs handles but just leaving required/imported values undefined! This causes the server error screen rather than at least a nice error message (see testing).

# Solution
When bulk hydrating blog posts, such as done on the Cube's blog posts list, the Error about changelist > 10,000 is caught. In that case the changelist is not hydrated with card details, it remains a list of adds/removes/swaps/edits with each only containing card ids. However when hydrating a single blog post that error was not caught.

Secondly the circular dependency within the serverjs/dynamo files caused the actual server error described above. I used https://github.com/acrazing/dpdm to detect them and determined the simplest change was moving getImageData into its own file. Te output from dpdm for serverjs/utils.js was:
```
• Circular Dependencies
  1) serverjs/util.js -> serverjs/render.js -> dynamo/models/cube.js
  2) serverjs/util.js -> serverjs/render.js -> dynamo/models/cube.js -> dynamo/models/user.js
  3) dynamo/models/cube.js -> dynamo/models/user.js
```
I used the tool to check the other directories containing JS files and it reported no other cycles. It did report some on src with typescript, but I assume that is OK since the build process can detect and handle those.

## Concerns
The UI of a blog post with a huge changelog is verbose and useless imo. Showing each add/remove/etc as an icon with no card details just creates a huge scrollable area that isn't useful. To me I'd think that on such a large changelog either there is no reason to render anything for the individual changes so the +/- summary is the pertinent information, or collapse the add/removes/etc with the icon as a summary like "<+ icon> ###" (eg the same as the +/- text summary but with icons)

# Testing
To set myself up I extracted from the window.reactProps of the [cube blog in the bug report](https://cubecobra.com/cube/blog/457e46ef-bd0b-43bc-a5b2-91bdc8facaa1) the changelist containing >10,000 changes. Then I created a new blog post on my local for a cube, and uploaded to S3 the changelist json.

## Before
When trying to go to the individual blog post the browser eventually just shows a "Service unavailable" message. The server logs show the "Too many cards in changelog" error and then the failure to redirect after.
![old-blog-post-huge-changelist-fails-2](https://github.com/user-attachments/assets/3d9b492a-e53a-441a-b34a-216fdc56f260)
![old-blog-post-huge-changelist-fails](https://github.com/user-attachments/assets/57777979-e1c7-4b88-b242-15a74f3a7aa1)

## After
Can see the blog with the huge changelist is visible in the blog list (works the same beforehand).
![new-blog-list-huge-changelist-empty-of-details](https://github.com/user-attachments/assets/78a73332-3aea-4a71-b0fa-a5d074b383d6)
Now on the individual blog post page it works the same, not failing though showing tons of empty information.
![new-blog-post-huge-changelist-has-details](https://github.com/user-attachments/assets/94cf86a4-cdf6-4235-9604-fa628afd35c8)


