### PR TITLE
feat: display emojis from tags inline in table view

### DIFF
--- a/src/client/components/card/AutocardListItem.tsx
+++ b/src/client/components/card/AutocardListItem.tsx
@@ -8,6 +8,7 @@ import UserContext from '../../contexts/UserContext';
 import Card from '../../datatypes/Card';
 import { getCardTagColorClass } from 'utils/Util';
 import { ListGroupItem } from '../base/ListGroup';
+import DisplayContext from 'contexts/DisplayContext';
 
 export interface AutocardListItemProps {
   card: Card;
@@ -39,6 +40,7 @@ const AutocardListItem: React.FC<AutocardListItemProps> = ({
 }) => {
   const tagColors = useContext(TagColorContext);
   const user = useContext(UserContext);
+  const {showInlineTagEmojis} = useContext(DisplayContext);
   const [cardName, cardId] = useMemo(
     () =>
       card && card.details ? [card.details.name, card.details.scryfall_id] : [CARD_NAME_FALLBACK, CARD_ID_FALLBACK],
@@ -66,9 +68,29 @@ const AutocardListItem: React.FC<AutocardListItemProps> = ({
     return getCardTagColorClass(tagColors, card);
   }, [card, tagColors, user]);
 
+  const findEmojisInTags = (tags: string[]):string[] => {
+    const emojiRegex = /\p{Emoji}/gu;
+    const emojis: string[] = [];
+
+    for (const tag of tags) {
+      const matches = tag.match(emojiRegex);
+      if (matches) {
+        emojis.push(...matches);
+      }
+    }
+
+    return emojis;
+  };
+
+  const emojiTags = useMemo(
+    () =>
+      card && card.tags ? findEmojisInTags(card.tags) : [],
+    [card]
+  )
+
   return (
     <AutocardDiv
-      className={cx(`bg-card-${colorClassname} ${className}`)}
+      className={cx(`flex justify-between bg-card-${colorClassname} ${className}`)}
       card={card}
       onAuxClick={noCardModal ? noOp : handleAuxClick}
       inModal={inModal}
@@ -78,6 +100,10 @@ const AutocardListItem: React.FC<AutocardListItemProps> = ({
     >
       {children && <span>{children}</span>}
       <span>{cardName}</span>
+      {showInlineTagEmojis ?
+        <span className="text-right">{emojiTags.join('')}</span>
+        : ''
+      }
     </AutocardDiv>
   );
 };

--- a/src/client/components/cube/CubeListNavbar.tsx
+++ b/src/client/components/cube/CubeListNavbar.tsx
@@ -57,6 +57,8 @@ const CubeListNavbar: React.FC<CubeListNavbarProps> = ({ cubeView, setCubeView }
     toggleShowCustomImages,
     showMaybeboard,
     toggleShowMaybeboard,
+    showInlineTagEmojis,
+    toggleShowInlineTagEmojis,
     openCollapse,
     setOpenCollapse,
   } = useContext(DisplayContext);
@@ -91,6 +93,9 @@ const CubeListNavbar: React.FC<CubeListNavbarProps> = ({ cubeView, setCubeView }
           <Link onClick={toggleShowMaybeboard}>{showMaybeboard ? 'Hide Maybeboard' : 'Show Maybeboard'}</Link>
           <Link onClick={() => setShowUnsorted(!cube.showUnsorted)}>
             {cube.showUnsorted ? 'Hide Unsorted cards' : 'Show Unsorted cards'}
+          </Link>
+          <Link onClick={toggleShowInlineTagEmojis}>
+            {showInlineTagEmojis ? 'Hide inline emoji tags' : 'Show inline emoji tags'}
           </Link>
         </Flexbox>
       </NavMenu>

--- a/src/client/contexts/DisplayContext.tsx
+++ b/src/client/contexts/DisplayContext.tsx
@@ -8,7 +8,9 @@ export interface DisplayContextValue {
   showCustomImages: boolean;
   toggleShowCustomImages: () => void;
   showMaybeboard: boolean;
+  showInlineTagEmojis: boolean;
   toggleShowMaybeboard: () => void;
+  toggleShowInlineTagEmojis: () => void;
   openCollapse: string | null;
   setOpenCollapse: React.Dispatch<React.SetStateAction<string | null>>;
   cardsPerRow: NumCols;
@@ -18,8 +20,10 @@ export interface DisplayContextValue {
 const DisplayContext = React.createContext<DisplayContextValue>({
   showCustomImages: true,
   showMaybeboard: false,
+  showInlineTagEmojis: false,
   toggleShowCustomImages: () => {},
   toggleShowMaybeboard: () => {},
+  toggleShowInlineTagEmojis: () => {},
   openCollapse: null,
   setOpenCollapse: () => {},
   cardsPerRow: 8,
@@ -54,11 +58,26 @@ export const DisplayContextProvider: React.FC<DisplayContextProviderProps> = ({ 
     setShowMaybeboard((prev) => !prev);
   }, [cubeID, showMaybeboard]);
 
+  const [showInlineTagEmojis, setShowInlineTagEmojis] = useState<boolean>(() => {
+    return (
+      typeof localStorage !== 'undefined' &&
+      typeof cubeID === 'string' &&
+      localStorage.getItem(`inline-tag-emojis-${cubeID}`) === 'true'
+    );
+  });
+
+  const toggleShowInlineTagEmojis = useCallback(() => {
+    if (cubeID) localStorage.setItem(`inline-tag-emojis-${cubeID}`, (!showInlineTagEmojis).toString());
+    setShowInlineTagEmojis((prev) => !prev);
+  }, [cubeID, showInlineTagEmojis])
+
   const value: DisplayContextValue = {
     showCustomImages,
     toggleShowCustomImages,
     showMaybeboard,
     toggleShowMaybeboard,
+    showInlineTagEmojis,
+    toggleShowInlineTagEmojis,
     openCollapse,
     setOpenCollapse,
     cardsPerRow,


### PR DESCRIPTION
Implementing an idea from #2370 that displays emojis from tags in-line if present. This is disabled by default but can be toggled in the Display menu.


https://github.com/user-attachments/assets/1c0cc993-41c0-4c15-867e-25646c61cfb1

