### PR TITLE
GitHub actions linting (eslint/prettier) only for changed files

### DIFF
--- a/.github/actions/prettier/LICENSE
+++ b/.github/actions/prettier/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Matteo Agnoletto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.github/actions/prettier/action.yml
+++ b/.github/actions/prettier/action.yml
@@ -1,0 +1,95 @@
+name: 'Run Prettier with reviewdog'
+description: '🐶 Run Prettier with reviewdog to improve code checking, formatting and review experience for your codebase.'
+author: 'EPMatt'
+inputs:
+  github_token:
+    description: 'GITHUB_TOKEN'
+    default: '${{ github.token }}'
+    required: false
+  workdir:
+    description: |
+      Working directory relative to the root directory.
+      This is where the action will look for a
+      package.json which declares Prettier as a dependency.
+      Please note that this is different from the directory
+      Prettier will run on, which is defined in the prettier_flags input.
+      Default is `.`.
+    default: '.'
+    required: false
+  ### Flags for reviewdog ###
+  level:
+    description: |
+      Report level for reviewdog [info,warning,error].
+      Default is `error`.
+    default: 'error'
+    required: false
+  reporter:
+    description: |
+      Reporter of reviewdog command [github-check,github-pr-check,github-pr-review].
+      Default is `github-pr-check`.
+    default: 'github-pr-check'
+    required: false
+  filter_mode:
+    description: |
+      Filtering mode for the reviewdog command [added,diff_context,file,nofilter].
+      Default is `added`.
+    default: 'added'
+    required: false
+  fail_on_error:
+    description: |
+      Exit code for reviewdog when errors are found [true,false].
+      Default is `false`.
+    default: 'false'
+    required: false
+  reviewdog_flags:
+    description: |
+      Additional reviewdog flags.
+      Default is ``.
+    default: ''
+    required: false
+  tool_name:
+    description: 'Tool name to use for reviewdog reporter'
+    default: 'prettier'
+    required: false
+  ### Flags for prettier ###
+  prettier_flags:
+    description: |
+      Flags and args to pass to Prettier.
+      If you override this input, please make sure to append to it the directory
+      which Prettier will run on.
+      The path provided here is relative to the workdir path, provided in the workdir input.
+      Default is `.`, which makes Prettier run on the path provided in the workdir input.
+    default: '.'
+    required: false
+runs:
+  using: 'composite'
+  steps:
+    - uses: reviewdog/action-setup@v1
+      with:
+        reviewdog_version: v0.14.2
+    - run: .github/actions/prettier/script.sh
+      shell: bash
+      env:
+        INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}
+        INPUT_WORKDIR: ${{ inputs.workdir }}
+        INPUT_LEVEL: ${{ inputs.level }}
+        INPUT_REPORTER: ${{ inputs.reporter }}
+        INPUT_FILTER_MODE: ${{ inputs.filter_mode }}
+        INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
+        INPUT_REVIEWDOG_FLAGS: ${{ inputs.reviewdog_flags }}
+        INPUT_TOOL_NAME: ${{ inputs.tool_name }}
+        INPUT_PRETTIER_FLAGS: ${{ inputs.prettier_flags }}
+    - if: ${{ inputs.reporter == 'github-pr-review' && always() }}
+      uses: reviewdog/action-suggester@v1
+      with:
+        github_token: ${{ inputs.github_token }}
+        tool_name: ${{ inputs.tool_name }}
+        level: ${{ inputs.level }}
+        filter_mode: ${{ inputs.filter_mode }}
+        fail_on_error: ${{ inputs.fail_on_error }}
+        reviewdog_flags: ${{ inputs.reviewdog_flags }}
+
+# Ref: https://haya14busa.github.io/github-action-brandings/
+branding:
+  icon: 'align-left'
+  color: 'blue'

--- a/.github/actions/prettier/action.yml
+++ b/.github/actions/prettier/action.yml
@@ -66,7 +66,7 @@ runs:
   steps:
     - uses: reviewdog/action-setup@v1
       with:
-        reviewdog_version: v0.14.2
+        reviewdog_version: v0.20.3
     - run: .github/actions/prettier/script.sh
       shell: bash
       env:

--- a/.github/actions/prettier/readme.md
+++ b/.github/actions/prettier/readme.md
@@ -1,0 +1,1 @@
+A copy of https://github.com/EPMatt/reviewdog-action-prettier but with reviewdog upgraded to latest, as the version used does not correctly check github token permissions in forks.

--- a/.github/actions/prettier/script.sh
+++ b/.github/actions/prettier/script.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -e
+
+# Move to the provided workdir
+cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}" || exit 1
+
+# Install prettier
+if [ ! -f "$(npm root)"/.bin/prettier ]; then
+  echo "::group::🔄 Running npm install to install prettier..."
+  npm install
+  echo "::endgroup::"
+fi
+
+if [ ! -f "$(npm root)"/.bin/prettier ]; then
+  echo "❌ Unable to locate or install prettier. Did you provide a workdir which contains a valid package.json?"
+  exit 1
+else
+  echo ℹ️ prettier version: "$("$(npm root)"/.bin/prettier --version)"
+fi
+
+echo "::group::📝 Running prettier with reviewdog 🐶 ..."
+
+export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
+
+# if reporter is github-pr-review, run prettier in write mode and report code suggestions
+if [ "$INPUT_REPORTER" = "github-pr-review" ]; then
+  "$(npm root)"/.bin/prettier --write "${INPUT_PRETTIER_FLAGS}" 2>&1 \
+  | reviewdog \
+      -efm="%E[%trror] %f: %m (%l:%c)" \
+      -efm="%C[error]%r" \
+      -efm="%Z[error]%r" \
+      -efm="%-G%r" \
+      -name="${INPUT_TOOL_NAME}" \
+      -reporter="${INPUT_REPORTER}" \
+      -filter-mode="${INPUT_FILTER_MODE}" \
+      -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
+      -level="${INPUT_LEVEL}" \
+      "${INPUT_REVIEWDOG_FLAGS}"
+# else run prettier in check mode and report warnings and errors
+else
+  
+  # shellcheck disable=SC2086
+  "$(npm root)"/.bin/prettier --check "${INPUT_PRETTIER_FLAGS}"  2>&1 | sed --regexp-extended 's/(\[warn\].*)$/\1 File is not properly formatted./' \
+  | reviewdog \
+      -efm="%-G[warn] Code style issues found in the above file(s). Forgot to run Prettier%. File is not properly formatted." \
+      -efm="[%tarn] %f %m" \
+      -efm="%E[%trror] %f: %m (%l:%c)" \
+      -efm="%C[error]%r" \
+      -efm="%Z[error]%r" \
+      -efm="%-G%r" \
+      -name="${INPUT_TOOL_NAME}" \
+      -reporter="${INPUT_REPORTER}" \
+      -filter-mode="${INPUT_FILTER_MODE}" \
+      -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
+      -level="${INPUT_LEVEL}" \
+      "${INPUT_REVIEWDOG_FLAGS}"
+fi
+
+exit_code=$?
+echo "::endgroup::"
+exit $exit_code

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Run Prettier on changed files
         # Always run both eslint and prettier
         if: always()
-        uses: EPMatt/reviewdog-action-prettier@v1
+        uses: ./.github/actions/prettier
         with:
           fail_on_error: true
           filter_mode: file

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,6 +1,12 @@
 name: CI Tests
 
-on: [push, pull_request]
+# Pull request will trigger when PR is opened or updated, and more (https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request)
+# Thus limit push checks to master branch so things run after the PR is merged. Without the limit multiple actions run on each PR
+on:
+  pull_request:
+  push:
+    branches:
+      - 'master'
 
 jobs:
   build:
@@ -17,12 +23,15 @@ jobs:
       - name: Setup
         run: npm ci
       - name: Run eslint on changed files
+        # Always run both eslint and prettier
+        if: always()
         uses: tj-actions/eslint-changed-files@v25
         with:
           config_path: 'eslint.config.mjs'
           extra_args: '--max-warnings=0'
       - name: Run Prettier on changed files
         # Always run both eslint and prettier
+        if: always()
         uses: EPMatt/reviewdog-action-prettier@v1
         with:
           fail_on_error: true

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: 20
@@ -16,7 +16,19 @@ jobs:
         run: corepack enable
       - name: Setup
         run: npm ci
-      - name: Check Code Style
-        run: npm run lint
+      - name: Run eslint on changed files
+        uses: tj-actions/eslint-changed-files@v25
+        with:
+          config_path: 'eslint.config.mjs'
+          extra_args: '--max-warnings=0'
+      - name: Run Prettier on changed files
+        # Always run both eslint and prettier
+        uses: EPMatt/reviewdog-action-prettier@v1
+        with:
+          fail_on_error: true
+          filter_mode: file
+          level: warning
+          prettier_flags: '**/*.{js,jsx,ts,tsx}'
+          reporter: github-pr-check
       - name: Build
         run: npm run ci-build

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           config_path: 'eslint.config.mjs'
           extra_args: '--max-warnings=0'
+          reporter: github-pr-review
       - name: Run Prettier on changed files
         # Always run both eslint and prettier
         if: always()
@@ -38,6 +39,6 @@ jobs:
           filter_mode: file
           level: warning
           prettier_flags: '**/*.{js,jsx,ts,tsx}'
-          reporter: github-pr-check
+          reporter: github-pr-review
       - name: Build
         run: npm run ci-build

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -110,17 +110,6 @@ export default [
     },
   },
   {
-    files: ['src/**/*'],
-    rules: {
-      'no-restricted-imports': [
-        'error',
-        {
-          patterns: ['./*', '../*'],
-        },
-      ],
-    },
-  },
-  {
     files: ['src/**/*.js'],
     rules: {
       'react/jsx-key': 'off',

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "build": "npm run nearley && tsc -b && npm run webpack && npx tailwindcss -i ./src/client/css/stylesheet.css -o ./public/css/stylesheet.css",
-    "lint": "npm run prettier-base --check && npm run eslint -- --max-warnings 0",
+    "lint": "npx prettier --check $(npm run --silent list-files); npx eslint --max-warnings 0 $(npm run --silent list-files)",
+    "list-files": "bash -c 'shopt -s nullglob\n echo {jobs,scripts,src}/{**/*,*}.{js,jsx,ts,tsx} force_update.js webpack.*.mjs eslint.config.mjs babel.config.mjs'",
     "bash": "bash",
     "nodemon": "nodemon --max-old-space-size=8192 --ignore src/client --ignore public --ignore private --ignore temp --ignore dist/pages --ignore __tests__ src/app.js",
     "webpack": "NODE_OPTIONS=--max_old_space-size=18192 webpack --mode production --config webpack.prod.mjs",


### PR DESCRIPTION
Improve the developer experience by:

1. Only reporting on lint issues within the changed files of the PR, not across the entire repo (given there are hundreds of minor issues like unsorted imports).
2. Turn off no-restricted-imports rule because in the recent backend refactor we are using relative import paths again.
3. Reduce duplication in github actions on pull requests, as both the request and push triggered the same stuff. Now push only triggers on the master branch.

Annoyingly the best github action for prettier changed files hasn't been updated in a while and was using an old version of Reviewdog (which does the actual commenting/checks for github) that didn't check the github token permissions correctly. Instead of forking and publishing to the marketplace, copied into the repo (its MIT licensed so fine to take and modify as long as the LICENSE/copyright lines are kept).

See https://github.com/KaelenProctor/CubeCobra/pull/3 for an example of how the eslint/prettier issues are reported on the PR as comments (which also generates emails). An alternative is to use a different reporter that puts all the details into the Checks tab.

eg:
![image](https://github.com/user-attachments/assets/aa87bcd8-5e1b-494b-818d-e0d16bc24fd6)
