### PR TITLE
Lockdown deploy actions to base repo

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -19,7 +19,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.repository == 'dekkerglen/CubeCobra' }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -4,9 +4,9 @@ name: Deploy master to dev server
 
 on:
   workflow_run:
-    workflows: ["CI Tests"]
+    workflows: ['CI Tests']
     branches: [master]
-    types: 
+    types:
       - completed
 
   # Allows you to run this workflow manually from the Actions tab
@@ -25,11 +25,11 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-      
+
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-      
+
       - name: Cache node modules
         uses: actions/cache@v1
         with:
@@ -63,7 +63,7 @@ jobs:
         id: format-time
         with:
           pattern: '[:\.]+'
-          string: "${{ steps.current-time.outputs.time }}"
+          string: '${{ steps.current-time.outputs.time }}'
           replace-with: '-'
           flags: 'g'
 
@@ -75,7 +75,7 @@ jobs:
           application_name: cubecobra-beta
           environment_name: cubecobra-beta
           region: us-east-2
-          version_label: "cubecobra-${{ steps.format-time.outputs.replaced }}"
+          version_label: 'cubecobra-${{ steps.format-time.outputs.replaced }}'
           deployment_package: deploy.zip
 
       - name: Deployed!

--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -19,7 +19,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.repository == 'dekkerglen/CubeCobra' }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
See https://github.com/KaelenProctor/CubeCobra/actions/runs/12670657142/job/35310762435 for example of the dev_deploy action running on a forked repo.

Following https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-only-run-job-for-specific-repository on how to lock it down by repository name.

Given the action is failing in general because of deprecated actions/upload-artifact@v2 (needs to be v4 now), maybe these actions aren't even needed anymore?