### PR TITLE
Fix firefox desktop Tag color select (dropdown) getting stuck with dragging

### DIFF
--- a/src/client/components/base/Select.tsx
+++ b/src/client/components/base/Select.tsx
@@ -22,6 +22,7 @@ interface SelectProps {
   id?: string;
   dense?: boolean;
   disabled?: boolean;
+  onPointerDown?: React.PointerEventHandler<HTMLSelectElement>;
 }
 
 const Select: React.FC<SelectProps> = ({
@@ -35,6 +36,7 @@ const Select: React.FC<SelectProps> = ({
   dense,
   className = '',
   disabled,
+  onPointerDown,
 }) => {
   const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     if (disabled) {
@@ -69,7 +71,14 @@ const Select: React.FC<SelectProps> = ({
           </a>
         )}
       </Flexbox>
-      <select className={classes} defaultValue={defaultValue} onChange={handleChange} id={id} value={value}>
+      <select
+        onPointerDown={onPointerDown}
+        className={classes}
+        defaultValue={defaultValue}
+        onChange={handleChange}
+        id={id}
+        value={value}
+      >
         {options.map((option) => (
           <option key={option.value} value={option.value}>
             {option.label}

--- a/src/client/components/base/Select.tsx
+++ b/src/client/components/base/Select.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import classNames from 'classnames';
 
 import { Flexbox } from './Layout';

--- a/src/client/components/modals/TagColorsModal.tsx
+++ b/src/client/components/modals/TagColorsModal.tsx
@@ -23,24 +23,36 @@ interface TagColorRowProps {
   id: string;
 }
 
-const TagColorRow: React.FC<TagColorRowProps> = ({ tag, tagClass, value, onChange, id }) => (
-  <SortableItem id={id} className="p-2 no-touch-action">
-    <Card>
-      <Flexbox direction="row" justify="between">
-        <Flexbox direction="row" justify="start" alignItems="center">
-          <GrabberIcon size={16} className="cursor-grab" />
-          <Tag text={tag} colorClass={tagClass} />
+const TagColorRow: React.FC<TagColorRowProps> = ({ tag, tagClass, value, onChange, id }) => {
+  /* In Firefox when the select is clicked it was also triggering the sortable context, such that
+   * while the options are open the whole row is moving around. And once the option is chosen its still
+   * dragging, like a burr you cannot shake off. Stopping the onPointerDown event from propagating is
+   * the solution I found.
+   */
+  const preventDragStart = (event: React.PointerEvent<HTMLSelectElement>) => {
+    event.stopPropagation();
+  };
+
+  return (
+    <SortableItem id={id} className="p-2 no-touch-action">
+      <Card>
+        <Flexbox direction="row" justify="between" className="cursor-grab">
+          <Flexbox direction="row" justify="start" alignItems="center">
+            <GrabberIcon size={16} className="cursor-grab" />
+            <Tag text={tag} colorClass={tagClass} />
+          </Flexbox>
+          <Select
+            options={TAG_COLORS.map(([name, v]) => ({ value: v || 'none', label: name }))}
+            value={value || 'none'}
+            setValue={onChange}
+            dense
+            onPointerDown={preventDragStart}
+          />
         </Flexbox>
-        <Select
-          options={TAG_COLORS.map(([name, v]) => ({ value: v || 'none', label: name }))}
-          value={value || 'none'}
-          setValue={onChange}
-          dense
-        />
-      </Flexbox>
-    </Card>
-  </SortableItem>
-);
+      </Card>
+    </SortableItem>
+  );
+};
 
 interface TagColorsModalProps {
   isOpen: boolean;


### PR DESCRIPTION
# Problem
Bug reported in discord. When choosing the tag color from the dropdown it also starts the dragging action from the Sortable context. The row kinda gets stuck on the mouse and almost has to be shaked off like a burr.

In my testing across Chrome, Firefox, and Edge desktop/mobile this issue only occurred in Firefox desktop. Based on the DND github issues it also might have been an issue with Safari but I don't have that to test.

# Solution
It's more of a hacky solution as I couldn't figure out a root cause. But stopping the onPointerDown event on the select from propagating prevents the sortable from starting the drag, while still allowing the select to open and have its option chosen.

I also adjusted the styling so cursor-grab applies to the entire row. Before it was just the grabber and tag text, the rest of the row didn't use the grabble mouse icon.

# Testing

## Before
Firefox desktop: see how the row gets stuck to the cursor
![broken-firefox-desktop-tag-select](https://github.com/user-attachments/assets/91bab233-3415-4723-a84c-fdf044e235f2)

## After
Firefox desktop, no longer gets stuck; mobile works as before
![fixed-firefox-desktop-tag-select](https://github.com/user-attachments/assets/93d8f5cb-3d8a-4061-a9c8-de3cee200a12)
![fixed-firefox-mobile-tag-select](https://github.com/user-attachments/assets/0d97dc83-8726-48f0-82b0-2ea33f492b3a)

Chrome desktop/mobile
![fixed-chrome-desktop-tag-select](https://github.com/user-attachments/assets/791b03e9-6b47-45cb-bbe6-d4d737c2633c)
![fixed-chrome-mobile-tag-select](https://github.com/user-attachments/assets/2fded331-a35b-480f-9174-58a23eccd58a)

Edge desktop/mobile
![fixed-edge-desktop-tag-select](https://github.com/user-attachments/assets/e0fb790c-2ad9-4854-b975-12678bdd60ad)
![fixed-edge-mobile-tag-select](https://github.com/user-attachments/assets/7c987b9a-5bb4-43dc-9167-c9a88b6a8bdf)
