### PR TITLE
Tag suggestions now up to date as tags are modified and committed

### DIFF
--- a/src/client/contexts/CubeContext.tsx
+++ b/src/client/contexts/CubeContext.tsx
@@ -12,22 +12,23 @@ import React, {
 
 import { Object } from 'core-js';
 
+import { cardName, normalizeName } from 'utils/Card';
+import { deepCopy } from 'utils/Util';
+
 import { UncontrolledAlertProps } from '../components/base/Alert';
 import CardModal from '../components/card/CardModal';
 import GroupModal from '../components/GroupModal';
-import DisplayContext from './DisplayContext';
-import UserContext from './UserContext';
 import Card, { BoardType, boardTypes, Changes } from '../datatypes/Card';
 import CardDetails from '../datatypes/CardDetails';
 import Cube, { TagColor } from '../datatypes/Cube';
 import useLocalStorage from '../hooks/useLocalStorage';
 import useMount from '../hooks/UseMount';
 import useQueryParam from '../hooks/useQueryParam';
-import { cardName, normalizeName } from 'utils/Card';
-import { deepCopy } from 'utils/Util';
-import FilterContext from './FilterContext';
-import { CSRFContext } from './CSRFContext';
 import ChangesContext from './ChangesContext';
+import { CSRFContext } from './CSRFContext';
+import DisplayContext from './DisplayContext';
+import FilterContext from './FilterContext';
+import UserContext from './UserContext';
 
 export interface CubeWithCards extends Cube {
   cards: {
@@ -290,7 +291,7 @@ export function CubeContextProvider({
         console.error('Request failed.');
       }
     },
-    [showTagColors],
+    [csrfFetch, setShowTagColors],
   );
 
   useEffect(() => {
@@ -335,7 +336,7 @@ export function CubeContextProvider({
       setVersionDict(json.dict);
     };
     getData();
-  }, [cube.cards, loadVersionDict]);
+  }, [csrfFetch, cube.cards, loadVersionDict]);
 
   const addCard = useCallback(
     (card: Card, board: BoardType) => {
@@ -728,7 +729,7 @@ export function CubeContextProvider({
       setModalSelection([]);
       setLoading(false);
     },
-    [clearChanges, changes, cube, useBlog, unfilteredChangedCards],
+    [csrfFetch, changes, cube, useBlog, unfilteredChangedCards, clearChanges, setVersion, version],
   );
 
   const bulkEditCard = useCallback(
@@ -864,7 +865,7 @@ export function CubeContextProvider({
 
       setLoading(false);
     },
-    [cube, setCube],
+    [csrfFetch, cube, setCube],
   );
 
   const saveSorts = useCallback(async () => {
@@ -890,7 +891,7 @@ export function CubeContextProvider({
       },
     });
     setLoading(false);
-  }, [sortPrimary, defaultSorts, sortSecondary, sortTertiary, sortQuaternary, cube]);
+  }, [sortPrimary, defaultSorts, sortSecondary, sortTertiary, sortQuaternary, cube, csrfFetch]);
 
   const resetSorts = useCallback(() => {
     setSortPrimary(cube.defaultSorts?.[0] || 'Color Category');

--- a/src/client/contexts/CubeContext.tsx
+++ b/src/client/contexts/CubeContext.tsx
@@ -243,18 +243,18 @@ export function CubeContextProvider({
   const allTags = useMemo(() => {
     const tags = new Set<string>();
 
-    for (const [board, list] of Object.entries(cards)) {
-      if (board !== 'id') {
-        for (const card of list) {
-          for (const tag of card.tags || []) {
-            tags.add(tag);
-          }
-        }
+    //Use cube.cards instead of cards to get the most up-to-date tags, as "cards" is only the initial state
+    const mainboard = cube?.cards?.mainboard || [];
+    const maybeboard = cube?.cards?.maybeboard || [];
+
+    for (const card of [...mainboard, ...maybeboard]) {
+      for (const tag of card.tags || []) {
+        tags.add(tag);
       }
     }
 
     return [...tags];
-  }, [cards]);
+  }, [cube.cards]);
 
   const [tagColors, setTagColors] = useState<TagColor[]>([
     ...(cube.tagColors || []),


### PR DESCRIPTION
# Problem
Feature request from Discord. When tags are added to cards and saved, the tag autocomplete suggestions are not updated (a page reloaded is needed). The suggestions being up to date will streamline the process of adding tags to cards.

# Solution
The allTags variable that provides the Tag autocomplete suggestions was only created from the initial "cards" variable passed into CubeContext. Switching to cube.cards results in allTags updating when the cards are changed such as from the commitment of tag changes.

In theory we could update the tags before the cards changes are saved, but that would be additional effort that I didn't figure out how to do. 

# Testing

## Before
Examples of tags added+saved but autocompletes not updating:
![new-saved-tags-dont-autocomplete3](https://github.com/user-attachments/assets/ca21c5cb-a9d5-4d4f-8ce0-8470b99e1d00)
![new-saved-tags-dont-autocomplete2](https://github.com/user-attachments/assets/48798d8e-ed72-4f38-ae86-51d15449ea59)
![new-saved-tags-dont-autocomplete](https://github.com/user-attachments/assets/b78e505c-a99e-46fd-b812-7083ae2b1802)

## After
Examples of tags added+saved but autocompletes not updating:
![new-saved-tags-autocomplete3](https://github.com/user-attachments/assets/8d7dfae4-b3fa-4dcf-a52a-4a479d8e3629)
![new-saved-tags-autocomplete2](https://github.com/user-attachments/assets/a9de932b-d74a-41df-a5be-a271cb1e25de)
![new-saved-tags-autocomplete1](https://github.com/user-attachments/assets/9d5261cc-6c90-45a4-a14a-47c744cf549c)

Similarly removing a tag from all cards with it updates the autocomplete.
![new-saved-tags-autocomplete4](https://github.com/user-attachments/assets/b9b25f26-c929-4a15-bdf1-b558ca5e465b)
