### PR TITLE
Add transform button to the Card modal so you can see the back face of a card

### DIFF
--- a/src/client/components/card/CardModal.tsx
+++ b/src/client/components/card/CardModal.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { ColorChecksAddon } from '../ColorCheck';
-import FoilCardImage from '../FoilCardImage';
 import TagInput from '../TagInput';
 import TextBadge from '../TextBadge';
 import Badge from '../base/Badge';
@@ -39,6 +38,12 @@ import {
 import { getLabels } from 'utils/Sort';
 import Tag from '../base/Tag';
 import { getTagColorClass } from 'utils/Util';
+import { ArrowSwitchIcon } from '@primer/octicons-react';
+import ImageFallback, { ImageFallbackProps } from 'components/ImageFallback';
+import FoilOverlay, { FoilOverlayProps } from '../FoilOverlay';
+
+type FoilCardImageProps = FoilOverlayProps & ImageFallbackProps;
+const FoilCardImage: React.FC<FoilCardImageProps> = FoilOverlay(ImageFallback);
 
 export interface CardModalProps {
   isOpen: boolean;
@@ -92,6 +97,7 @@ const CardModal: React.FC<CardModalProps> = ({
   );
 
   const disabled = !canEdit || card.markedForDelete;
+  const [imageUsed, setImageUsed] = useState(card?.details?.image_normal);
 
   return (
     <Modal xl isOpen={isOpen} setOpen={setOpen}>
@@ -104,7 +110,30 @@ const CardModal: React.FC<CardModalProps> = ({
           <Row>
             <Col xs={12} sm={4}>
               <Flexbox direction="col" gap="2">
-                <FoilCardImage card={card} finish={card.finish} />
+                <FoilCardImage
+                  card={card}
+                  className="w-full"
+                  src={imageUsed}
+                  fallbackSrc="/content/default_card.png"
+                  alt={cardName(card)}
+                />
+                {card?.details?.image_flip && (
+                  <Button
+                    className="mt-1"
+                    color="accent"
+                    outline
+                    block
+                    onClick={() => {
+                      if (imageUsed === card?.details?.image_normal) {
+                        setImageUsed(card?.details?.image_flip);
+                      } else {
+                        setImageUsed(card?.details?.image_normal);
+                      }
+                    }}
+                  >
+                    <ArrowSwitchIcon size={16} /> Transform
+                  </Button>
+                )}
                 <Flexbox direction="row" gap="2" wrap="wrap">
                   {card.details?.prices && Number.isFinite(cardPrice(card)) && (
                     <TextBadge name="Price" className="mt-2 me-2">

--- a/src/client/components/card/CardModal.tsx
+++ b/src/client/components/card/CardModal.tsx
@@ -1,21 +1,8 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
-import { ColorChecksAddon } from '../ColorCheck';
-import TagInput from '../TagInput';
-import TextBadge from '../TextBadge';
-import Badge from '../base/Badge';
-import Button from '../base/Button';
-import Input from '../base/Input';
-import { Col, Flexbox, Row } from '../base/Layout';
-import { Modal, ModalBody, ModalHeader } from '../base/Modal';
-import Select from '../base/Select';
-import Spinner from '../base/Spinner';
-import Text from '../base/Text';
-import TextArea from '../base/TextArea';
-import Tooltip from '../base/Tooltip';
-import Card, { BoardType } from '../../datatypes/Card';
-import { TagColor } from '../../datatypes/Cube';
-import TagData from '../../datatypes/TagData';
+import { ArrowSwitchIcon } from '@primer/octicons-react';
+
+import ImageFallback, { ImageFallbackProps } from 'components/ImageFallback';
 import { getTCGLink } from 'utils/Affiliate';
 import {
   cardCmc,
@@ -36,11 +23,26 @@ import {
   normalizeName,
 } from 'utils/Card';
 import { getLabels } from 'utils/Sort';
-import Tag from '../base/Tag';
 import { getTagColorClass } from 'utils/Util';
-import { ArrowSwitchIcon } from '@primer/octicons-react';
-import ImageFallback, { ImageFallbackProps } from 'components/ImageFallback';
+
+import Card, { BoardType } from '../../datatypes/Card';
+import { TagColor } from '../../datatypes/Cube';
+import TagData from '../../datatypes/TagData';
+import Badge from '../base/Badge';
+import Button from '../base/Button';
+import Input from '../base/Input';
+import { Col, Flexbox, Row } from '../base/Layout';
+import { Modal, ModalBody, ModalHeader } from '../base/Modal';
+import Select from '../base/Select';
+import Spinner from '../base/Spinner';
+import Tag from '../base/Tag';
+import Text from '../base/Text';
+import TextArea from '../base/TextArea';
+import Tooltip from '../base/Tooltip';
+import { ColorChecksAddon } from '../ColorCheck';
 import FoilOverlay, { FoilOverlayProps } from '../FoilOverlay';
+import TagInput from '../TagInput';
+import TextBadge from '../TextBadge';
 
 type FoilCardImageProps = FoilOverlayProps & ImageFallbackProps;
 const FoilCardImage: React.FC<FoilCardImageProps> = FoilOverlay(ImageFallback);
@@ -370,7 +372,7 @@ const CardModal: React.FC<CardModalProps> = ({
                     readOnly={!canEdit}
                     addTag={(tag: TagData) => {
                       //Prevent duplicate tags from being added
-                      let existingTags = cardTags(card);
+                      const existingTags = cardTags(card);
                       if (!existingTags.includes(tag.text)) {
                         updateField('tags', [...cardTags(card), tag.text]);
                       }

--- a/src/client/components/card/CardModal.tsx
+++ b/src/client/components/card/CardModal.tsx
@@ -99,7 +99,15 @@ const CardModal: React.FC<CardModalProps> = ({
   );
 
   const disabled = !canEdit || card.markedForDelete;
+
+  const [prevCardID, setPrevCardID] = useState(card.cardID);
   const [imageUsed, setImageUsed] = useState(card?.details?.image_normal);
+  //When the card id changes then update the image used. If we just checked card, it would be different
+  //if any field in the modal is edited, which would lead the image to reset to the front face.
+  if (prevCardID !== card.cardID) {
+    setPrevCardID(card.cardID);
+    setImageUsed(card?.details?.image_normal);
+  }
 
   return (
     <Modal xl isOpen={isOpen} setOpen={setOpen}>


### PR DESCRIPTION
Feature suggestion from Discord. The card tool page (eg https://cubecobra.com/tool/card/a3ff628a-ef8e-45c4-84e7-a33ec28f025a) already had the transform button to flip the image to the back face.

# Testing
I tested every type of card layout filterable in CubeCobra, though of course only some have back faces. Like the card tool page, if the card is the back face is does not have the transform button to go to the front side (eg last screenshot).

Gif:
![card-modal-transform](https://github.com/user-attachments/assets/330b40d5-67b6-4966-935e-1e6087568da1)

Other types of card with backfaces showing the transform button:
![card-modal-dfc-transform](https://github.com/user-attachments/assets/49045359-299f-4b28-aace-ff65b75f6abe)
![art-card-and-other-variant-transforms](https://github.com/user-attachments/assets/36d17aa7-c6ba-4b81-a03d-64284796dd11)

A back face cannot be transformed to the front.
![back-sides-dont-have-transform](https://github.com/user-attachments/assets/ba0daec9-92d5-4fbd-873e-65cd41f97701)