### PR TITLE
Update the label to "Show Total Prices" to reflect what the code was doing.

### DIFF
--- a/src/client/components/modals/CubeSettingsModal.tsx
+++ b/src/client/components/modals/CubeSettingsModal.tsx
@@ -45,7 +45,7 @@ const CubeSettingsModal: React.FC<CubeSettingsModalProps> = ({ isOpen, setOpen }
         <CSRFForm ref={formRef} formData={formData} method="POST" action={`/cube/updatesettings/${cube.id}`}>
           <Flexbox direction="col" gap="2">
             <Checkbox
-              label="Hide Total Prices"
+              label="Show Total Prices"
               checked={formData.priceVisibility === 'true'}
               setChecked={(checked) => setFormData({ ...formData, priceVisibility: `${checked}` })}
             />


### PR DESCRIPTION
# Problem
The "Hide Total Prices" checkbox in the Cube settings was inverted from what was actually occurring. When that was checked the total prices showed, and when unchecked were hidden.

# Solution
As the actual status was correct in the saved cube (PU = public, PR = private) and was toggling correctly, the simplest solution was relabeling the checkbox.

# Testing
## Before
![prices-hidden-when-modal-says-should-show](https://github.com/user-attachments/assets/4960ff05-ac52-4834-b742-7bb795379687)
![prices-showing-when-modal-says-shouldnt](https://github.com/user-attachments/assets/69720caa-9f60-4dca-b94f-4b2b678dc6b8)

## After
![prices-hidden-aligned-with-modal](https://github.com/user-attachments/assets/64a20616-2122-4a92-954f-878d8a7a9256)
![prices-showing-aligned-with-modal1](https://github.com/user-attachments/assets/73bbecf7-36b7-42f2-885e-cd812b4d22de)
