### PR TITLE
Fix most recent card printing option being used

### DIFF
--- a/src/client/components/EditCollapse.tsx
+++ b/src/client/components/EditCollapse.tsx
@@ -237,6 +237,7 @@ const EditCollapse: React.FC<EditCollapseProps> = ({ isOpen }) => {
                 autoComplete="off"
                 data-lpignore
                 className="square-right"
+                defaultPrinting={cube.defaultPrinting}
               />
               <Button color="primary" disabled={addValue.length === 0} onClick={(e) => handleAdd(e, addValue)}>
                 Add

--- a/src/client/components/EditCollapse.tsx
+++ b/src/client/components/EditCollapse.tsx
@@ -123,7 +123,7 @@ const EditCollapse: React.FC<EditCollapseProps> = ({ isOpen }) => {
         console.error(e);
       }
     },
-    [cube.defaultPrinting, cube.defaultStatus, setAlerts, addCard, boardToEdit],
+    [csrfFetch, cube.defaultPrinting, cube.defaultStatus, setAlerts, addCard, boardToEdit],
   );
 
   const handleRemoveReplace = useCallback(
@@ -180,7 +180,17 @@ const EditCollapse: React.FC<EditCollapseProps> = ({ isOpen }) => {
         console.error(e);
       }
     },
-    [addValue, changedCards, boardToEdit, setAlerts, cube.defaultPrinting, cube.defaultStatus, swapCard, removeCard],
+    [
+      addValue,
+      changedCards,
+      boardToEdit,
+      setAlerts,
+      csrfFetch,
+      cube.defaultPrinting,
+      cube.defaultStatus,
+      swapCard,
+      removeCard,
+    ],
   );
 
   const submit = useCallback(async () => {

--- a/src/client/components/EditCollapse.tsx
+++ b/src/client/components/EditCollapse.tsx
@@ -25,7 +25,7 @@ interface GetCardResponse {
 
 export const getCard = async (
   csrfFetch: (input: RequestInfo, init?: RequestInit) => Promise<Response>,
-  defaultprinting: string,
+  defaultPrinting: string,
   name: string,
   setAlerts?: Dispatch<SetStateAction<UncontrolledAlertProps[]>>,
 ): Promise<CardDetails | null> => {
@@ -34,7 +34,7 @@ export const getCard = async (
       method: 'POST',
       body: JSON.stringify({
         name,
-        defaultprinting,
+        defaultPrinting,
       }),
       headers: {
         'Content-Type': 'application/json',

--- a/src/client/components/base/AutocompleteInput.tsx
+++ b/src/client/components/base/AutocompleteInput.tsx
@@ -201,6 +201,7 @@ export interface AutocompleteInputProps extends InputProps {
   onSubmit?: (event: React.FormEvent<HTMLInputElement>, match?: string) => void;
   wrapperClassName?: string;
   cubeId?: string;
+  defaultPrinting?: string;
 }
 
 const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
@@ -210,6 +211,7 @@ const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
   setValue,
   onSubmit,
   cubeId,
+  defaultPrinting = null,
   ...props
 }) => {
   const [tree, setTree] = useState<TreeNode>({});
@@ -314,7 +316,11 @@ const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
           {matches.map((match, index) => (
             <AutocardDiv
               inModal
-              image={cubeId ? `/tool/cardimageforcube/${match}/${cubeId}` : `/tool/cardimage/${match}`}
+              image={
+                cubeId
+                  ? `/tool/cardimageforcube/${match}/${cubeId}`
+                  : `/tool/cardimage/${match}` + (defaultPrinting !== null ? `?defaultPrinting=${defaultPrinting}` : '')
+              }
               key={index}
               onClick={(e) => handleClickSuggestion(e)}
               className={classNames(

--- a/src/client/components/base/AutocompleteInput.tsx
+++ b/src/client/components/base/AutocompleteInput.tsx
@@ -299,7 +299,7 @@ const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
         }
       }
     },
-    [position, acceptSuggestion, matches, showMatches, onSubmit],
+    [position, acceptSuggestion, matches, showMatches, onSubmit, value],
   );
 
   return (

--- a/src/client/components/base/AutocompleteInput.tsx
+++ b/src/client/components/base/AutocompleteInput.tsx
@@ -202,6 +202,7 @@ export interface AutocompleteInputProps extends InputProps {
   wrapperClassName?: string;
   cubeId?: string;
   defaultPrinting?: string;
+  showImages?: boolean;
 }
 
 const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
@@ -212,6 +213,7 @@ const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
   onSubmit,
   cubeId,
   defaultPrinting = null,
+  showImages = true,
   ...props
 }) => {
   const [tree, setTree] = useState<TreeNode>({});
@@ -313,27 +315,44 @@ const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
             'absolute border border-border rounded-md top-0 left-0 translate-y-9 w-full flex flex-col overflow-y-visible z-[1050]',
           )}
         >
-          {matches.map((match, index) => (
-            <AutocardDiv
-              inModal
-              image={
-                cubeId
-                  ? `/tool/cardimageforcube/${match}/${cubeId}`
-                  : `/tool/cardimage/${match}` + (defaultPrinting !== null ? `?defaultPrinting=${defaultPrinting}` : '')
-              }
-              key={index}
-              onClick={(e) => handleClickSuggestion(e)}
-              className={classNames(
-                'list-none p-2 bg-bg-accent hover:bg-bg-active cursor-pointer',
-                { 'border-t border-border': index !== 0 },
-                { 'bg-bg-active': index === position },
-                { 'rounded-t-md': index === 0 },
-                { 'rounded-b-md': index === matches.length - 1 },
-              )}
-            >
-              {match}
-            </AutocardDiv>
-          ))}
+          {matches.map((match, index) => {
+            return showImages ? (
+              <AutocardDiv
+                inModal
+                image={
+                  cubeId
+                    ? `/tool/cardimageforcube/${match}/${cubeId}`
+                    : `/tool/cardimage/${match}` +
+                      (defaultPrinting !== null ? `?defaultPrinting=${defaultPrinting}` : '')
+                }
+                key={index}
+                onClick={(e) => handleClickSuggestion(e)}
+                className={classNames(
+                  'list-none p-2 bg-bg-accent hover:bg-bg-active cursor-pointer',
+                  { 'border-t border-border': index !== 0 },
+                  { 'bg-bg-active': index === position },
+                  { 'rounded-t-md': index === 0 },
+                  { 'rounded-b-md': index === matches.length - 1 },
+                )}
+              >
+                {match}
+              </AutocardDiv>
+            ) : (
+              <div
+                key={index}
+                onClick={(e) => handleClickSuggestion(e)}
+                className={classNames(
+                  'list-none p-2 bg-bg-accent hover:bg-bg-active cursor-pointer',
+                  { 'border-t border-border': index !== 0 },
+                  { 'bg-bg-active': index === position },
+                  { 'rounded-t-md': index === 0 },
+                  { 'rounded-b-md': index === matches.length - 1 },
+                )}
+              >
+                {match}
+              </div>
+            );
+          })}
         </div>
       )}
     </div>

--- a/src/client/components/modals/AdvancedFilterModal.tsx
+++ b/src/client/components/modals/AdvancedFilterModal.tsx
@@ -133,6 +133,7 @@ const AdvancedFilterModal: React.FC<AdvancedFilterModalProps> = ({ isOpen, setOp
               data-lpignore
               className="tag-autocomplete-input"
               wrapperClassName="tag-autocomplete-wrapper"
+              showImages={false}
             />
           )}
           <Row>

--- a/src/client/pages/BulkUploadPage.tsx
+++ b/src/client/pages/BulkUploadPage.tsx
@@ -74,7 +74,7 @@ const BulkUploadPageRaw: React.FC<BulkUploadPageRawProps> = ({ missing, added })
         console.error(e);
       }
     },
-    [cube.defaultPrinting, cube.defaultStatus, setAlerts, addCard],
+    [csrfFetch, cube.defaultPrinting, cube.defaultStatus, setAlerts, addCard],
   );
 
   return (

--- a/src/client/pages/BulkUploadPage.tsx
+++ b/src/client/pages/BulkUploadPage.tsx
@@ -114,6 +114,7 @@ const BulkUploadPageRaw: React.FC<BulkUploadPageRawProps> = ({ missing, added })
                       value={addValue}
                       setValue={setAddValue}
                       placeholder="Card to Add"
+                      defaultPrinting={cube.defaultPrinting}
                     />
                   </Col>
                   <Col xs={4}>

--- a/src/routes/tools_routes.js
+++ b/src/routes/tools_routes.js
@@ -315,11 +315,13 @@ router.get('/cardimage/:id', async (req, res) => {
   try {
     let { id } = req.params;
 
+    const defaultPrinting = req?.query?.defaultPrinting;
+
     // if id is a cardname, redirect to the default version for that card
     const possibleName = cardutil.decodeName(id);
     const ids = getIdsFromName(possibleName);
     if (ids) {
-      id = getMostReasonable(possibleName).scryfall_id;
+      id = getMostReasonable(possibleName, defaultPrinting).scryfall_id;
     }
 
     // if id is a foreign id, redirect to english version

--- a/src/util/carddb.ts
+++ b/src/util/carddb.ts
@@ -238,8 +238,8 @@ export function getMostReasonable(cardName: string, printing = 'recent', filter?
 
   ids = cards.map((card) => card.details.scryfall_id);
 
-  // Ids are stored in reverse chronological order, so reverse if we want first printing.
-  if (printing !== 'recent') {
+  // Ids have been sorted from oldest to newest. So reverse if we want the newest printing.
+  if (printing === 'recent') {
     ids = [...ids];
     ids.reverse();
   }


### PR DESCRIPTION
# Problem
As reported in Discord the Default printing option of recent vs first wasn't working correctly.

# Solution
A couple different things are play:
1. Pass the setting through to the `cardimage/:id` backend call in the Autocomplete hover
2. Correct the passing of defaultPrinting through to the `cube/api/getcardforcube` API
3. Correct the sort for recent vs first. Sorting by Release date is from oldest to newest, not newest to oldest as the code/comment thought

As a bonus I also turned off the autocomplete hover images from the Tag autocomplete in the Advanced search modal. Those always showed the card back since a tag isn't a card.

# Testing
There are no differences in the following autocompletes because they use they pre-populate/search all card editions:
* Cube Overview image
* Profile image
* Card for a package
* Customize basics
* Edit article/video - Though I didn't test this as I haven't setup my user locally to be a content contributor

No changes to the remove card part of editing a cube, as that uses the exact card edition in the cube.

## Before

Always used the oldest printing regardless of what your cube's default printing setting was. Screenshot from when cube printing = most recent but its using Serra angel from Alpha
![oldest-printing-showing-when-most-recent-is-active](https://github.com/user-attachments/assets/f3ab5c58-caad-4dab-8545-3f4c0f98ec59)


Card back showing when using Tag autocomplete:
![current-card-back-image-when-hovering-tags](https://github.com/user-attachments/assets/f029c54e-a71e-4cee-bcdc-04033e0b86ae)


## After

With Cube set to first printing:
![first-printing2](https://github.com/user-attachments/assets/080e417f-1b73-4e9c-bc17-ee2eaa0cdf64)
![first-printing-bulk](https://github.com/user-attachments/assets/e947e956-47c5-446b-9a74-af0ffb80c305)

With Cube set to recent printing:
![most-recent-printing](https://github.com/user-attachments/assets/4727dd48-865a-4f0b-9f72-87baf068faca)
![most-recent-printing-bulk](https://github.com/user-attachments/assets/fd66d1c5-c86a-4be4-8b66-f56f32f9a113)

No card images when using Tag autocomplete:
![no-card-back-image-when-hovering-tags](https://github.com/user-attachments/assets/6352bae8-2a58-44ba-abfc-766c4d795c97)

