### PR TITLE
Mobile view improvements in the Cube pages

### DIFF
--- a/src/client/components/FilterCollapse.tsx
+++ b/src/client/components/FilterCollapse.tsx
@@ -94,13 +94,28 @@ const FilterCollapse: React.FC<FilterCollapseProps> = ({
               }
             }}
           />
-          <Button color="primary" onClick={() => setFilterInput(searchFilterInput || '')}>
-            <span className="px-4 whitespace-nowrap">{buttonLabel}</span>
-          </Button>
+          <ResponsiveDiv md>
+            <Button color="primary" onClick={() => setFilterInput(searchFilterInput || '')}>
+              <span className="px-4 whitespace-nowrap">{buttonLabel}</span>
+            </Button>
+          </ResponsiveDiv>
+          <ResponsiveDiv md baseVisible={true}>
+            <Button color="primary" onClick={() => setFilterInput(searchFilterInput || '')} className="h-full">
+              <span className="px-1 whitespace-nowrap">{buttonLabel}</span>
+            </Button>
+          </ResponsiveDiv>
           {showReset && (
             <ResponsiveDiv md>
               <Button color="danger" onClick={reset} className="h-full">
                 <span className="px-4 whitespace-nowrap">Reset</span>
+              </Button>
+            </ResponsiveDiv>
+          )}
+          {/* For mobile */}
+          {showReset && (
+            <ResponsiveDiv md baseVisible={true}>
+              <Button color="danger" onClick={reset} className="h-full">
+                <span className="px-1 whitespace-nowrap">Reset</span>
               </Button>
             </ResponsiveDiv>
           )}

--- a/src/client/components/cube/CubeSubtitle.tsx
+++ b/src/client/components/cube/CubeSubtitle.tsx
@@ -4,12 +4,16 @@ import { Flexbox } from 'components/base/Layout';
 import ResponsiveDiv from 'components/base/ResponsiveDiv';
 import Text from 'components/base/Text';
 import CubeContext from 'contexts/CubeContext';
-import { getCubeDescription } from 'utils/Util';
+import { getCubeCardCountSnippet, getCubeDescription } from 'utils/Util';
 
 const CubeSubtitle: React.FC = () => {
   const { cube, unfilteredChangedCards } = useContext(CubeContext);
 
   const subtitle = useMemo(() => getCubeDescription(cube, unfilteredChangedCards), [cube, unfilteredChangedCards]);
+  const mobileSubtitle = useMemo(
+    () => getCubeCardCountSnippet(cube, unfilteredChangedCards),
+    [cube, unfilteredChangedCards],
+  );
 
   return (
     <Flexbox direction="row" gap="2" alignItems="end" className="py-2">
@@ -18,6 +22,9 @@ const CubeSubtitle: React.FC = () => {
       </Text>
       <ResponsiveDiv md>
         <Text md>({subtitle})</Text>
+      </ResponsiveDiv>
+      <ResponsiveDiv md baseVisible={true}>
+        <Text md>({mobileSubtitle} Cube)</Text>
       </ResponsiveDiv>
     </Flexbox>
   );

--- a/src/client/utils/Util.ts
+++ b/src/client/utils/Util.ts
@@ -174,23 +174,38 @@ export function getCubeId(cube: { shortId?: string; id: string }): string {
   return cube.shortId || cube.id;
 }
 
-export function getCubeDescription(
+export function getCubeCardCountSnippet(
   cube: { categoryPrefixes?: string[]; categoryOverride?: string; cardCount?: number },
   changedCards?: { mainboard?: any[] },
 ): string {
-  const overridePrefixes =
-    cube.categoryPrefixes && cube.categoryPrefixes.length > 0 ? `${cube.categoryPrefixes.join(' ')} ` : '';
-
   const cardCount =
     changedCards && changedCards.mainboard && changedCards.mainboard?.length > 0
       ? changedCards.mainboard.length
       : cube.cardCount;
 
+  return `${cardCount} Card`;
+}
+
+export function getCubeCategoryDescriptionSnippet(cube: {
+  categoryPrefixes?: string[];
+  categoryOverride?: string;
+  cardCount?: number;
+}): string {
+  const overridePrefixes =
+    cube.categoryPrefixes && cube.categoryPrefixes.length > 0 ? `${cube.categoryPrefixes.join(' ')} ` : '';
+
   if (cube.categoryOverride) {
-    return `${cardCount} Card ${overridePrefixes}${cube.categoryOverride} Cube`;
+    return `${overridePrefixes}${cube.categoryOverride} Cube`;
   }
 
-  return `${cardCount} Card ${overridePrefixes}Cube`;
+  return `${overridePrefixes}Cube`;
+}
+
+export function getCubeDescription(
+  cube: { categoryPrefixes?: string[]; categoryOverride?: string; cardCount?: number },
+  changedCards?: { mainboard?: any[] },
+): string {
+  return `${getCubeCardCountSnippet(cube, changedCards)} ${getCubeCategoryDescriptionSnippet(cube)}`;
 }
 
 export function isInternalURL(to: string): boolean {


### PR DESCRIPTION
# Problems
1. The Cube card count does not show on mobile
2. The Reset filters button does not show on mobile

# Testing

## Before
Card count not showing. Nor the cube categories:
![card-count-not-on-mobile](https://github.com/user-attachments/assets/7d27a6a9-ffcc-494b-8cd8-4512ff6b7f67)
In comparison to desktop, with a hugely long subtitle:
![cube-card-count-all-categories-desktop](https://github.com/user-attachments/assets/e480bc0d-0794-4155-9c42-6acde5111deb)

Reset button not showing in mobile:
![old-mobile-filter-without-reset](https://github.com/user-attachments/assets/8f2ee665-664a-46cb-8e57-3e185d80c6e0)

## After

Card count showing. Not including the categories because those can be very long and thus hard to fit on mobile. The card count is pretty constrained on how long it will be.
![mobile-card-count-shows](https://github.com/user-attachments/assets/1b165947-53ae-4cfa-aaa7-4c894fb224bb)

Reset button showing on mobile:
![new-mobile-filter-with-reset](https://github.com/user-attachments/assets/ec775d0d-b566-401c-bb34-958c31f9d20e)

How it looks on various mobile sizes:

Iphone 12 (390px)
![new-mobile-filter-with-reset-iphone12-390px](https://github.com/user-attachments/assets/710feb8b-351e-4728-9cbb-9ae46fb7bcae)
550px:
![new-mobile-filter-with-rest-550px-widge](https://github.com/user-attachments/assets/8710f1a2-cad9-4767-baa8-73a9a61b679e)

**I was thinking that it might make sense to force the buttons to a new flex row, which might help with very small devices such that the input is short enough the placeholder text isn't visible**