### PR TITLE
Improve custom draft modal formatting on mobile

### DIFF
--- a/src/client/components/CustomPackCard.tsx
+++ b/src/client/components/CustomPackCard.tsx
@@ -5,7 +5,7 @@ import { ChevronDownIcon, ChevronUpIcon } from '@primer/octicons-react';
 import { buildDefaultSteps, DEFAULT_STEPS, DraftAction, Pack } from '../../datatypes/Draft';
 import useToggle from '../hooks/UseToggle';
 import Button from './base/Button';
-import { Card, CardBody, CardFooter, CardHeader } from './base/Card';
+import { Card, CardFooter, CardHeader } from './base/Card';
 import Collapse from './base/Collapse';
 import Input from './base/Input';
 import { Flexbox } from './base/Layout';
@@ -51,7 +51,7 @@ const CustomPackCard: React.FC<CustomPackCardProps> = ({
   const steps = useMemo(() => pack.steps ?? buildDefaultSteps(pack.slots.length), [pack]);
   return (
     <Card key={packIndex} className="mb-4 pack-outline">
-      <CardHeader>
+      <CardHeader className="px-2">
         <Flexbox direction="row" gap="2" className="w-full" justify="between">
           <Text semibold lg>
             Pack {packIndex + 1} - {pack.slots.length} cards
@@ -63,13 +63,13 @@ const CustomPackCard: React.FC<CustomPackCardProps> = ({
           )}
         </Flexbox>
       </CardHeader>
-      <CardBody className="p-1">
+      <div className="p-1">
         <Card key="slots" className="mb-3 m-2">
           <CardHeader onClick={toggleSlotsOpen}>
             <CollapsibleCardTitle isOpen={slotsOpen}>Card Slots</CollapsibleCardTitle>
           </CardHeader>
           <Collapse isOpen={slotsOpen}>
-            <CardBody>
+            <div className="p-2">
               <Flexbox direction="col" gap="2">
                 {pack.slots.map((filter, slotIndex) => (
                   <Flexbox direction="row" gap="2" className="w-full" key={slotIndex} alignItems="center">
@@ -101,8 +101,8 @@ const CustomPackCard: React.FC<CustomPackCardProps> = ({
                   </Flexbox>
                 ))}
               </Flexbox>
-            </CardBody>
-            <CardFooter>
+            </div>
+            <CardFooter className="px-2">
               <Button
                 className="me-2"
                 color="accent"
@@ -121,7 +121,7 @@ const CustomPackCard: React.FC<CustomPackCardProps> = ({
             <CollapsibleCardTitle isOpen={stepsOpen}>Steps for Drafting</CollapsibleCardTitle>
           </CardHeader>
           <Collapse isOpen={stepsOpen}>
-            <CardBody>
+            <div className="p-2">
               <Flexbox direction="col" gap="2">
                 {steps.map((step, stepIndex) => (
                   <Flexbox direction="row" gap="2" className="w-full" key={stepIndex} alignItems="center">
@@ -168,7 +168,7 @@ const CustomPackCard: React.FC<CustomPackCardProps> = ({
                   </Flexbox>
                 ))}
               </Flexbox>
-            </CardBody>
+            </div>
             <CardFooter>
               <Button
                 className="me-2"
@@ -180,7 +180,7 @@ const CustomPackCard: React.FC<CustomPackCardProps> = ({
             </CardFooter>
           </Collapse>
         </Card>
-      </CardBody>
+      </div>
       <CardFooter>
         <Button color="accent" onClick={copyPack}>
           Duplicate Pack

--- a/src/client/components/base/RadioButtonGroup.tsx
+++ b/src/client/components/base/RadioButtonGroup.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import classNames from 'classnames';
+
 import { Flexbox } from './Layout';
 
 interface RadioButtonGroupProps {
@@ -7,9 +9,16 @@ interface RadioButtonGroupProps {
   selected: string;
   setSelected: (selected: string) => void;
   options: { value: string; label: string }[];
+  allowOptionTextWrapping?: boolean;
 }
 
-const RadioButtonGroup: React.FC<RadioButtonGroupProps> = ({ label, selected, setSelected, options }) => {
+const RadioButtonGroup: React.FC<RadioButtonGroupProps> = ({
+  label,
+  selected,
+  setSelected,
+  options,
+  allowOptionTextWrapping = true,
+}) => {
   return (
     <Flexbox direction="col" gap="2">
       {label && <label className="block text-sm font-medium text-text">{label}</label>}
@@ -21,7 +30,9 @@ const RadioButtonGroup: React.FC<RadioButtonGroupProps> = ({ label, selected, se
             checked={selected === option.value}
             onChange={() => setSelected(option.value)}
           />
-          <span className="text-text whitespace-nowrap">{option.label}</span>
+          <span className={classNames('text-text', { 'whitespace-nowrap': !allowOptionTextWrapping })}>
+            {option.label}
+          </span>
         </label>
       ))}
     </Flexbox>

--- a/src/client/components/modals/CustomDraftFormatModal.tsx
+++ b/src/client/components/modals/CustomDraftFormatModal.tsx
@@ -33,7 +33,7 @@ const CustomDraftFormatModal: React.FC<CustomDraftFormatModalProps> = ({ isOpen,
       id: `${formatIndex}`,
       serializedFormat: JSON.stringify(format),
     };
-  }, [format]);
+  }, [format, formatIndex]);
 
   return (
     <Modal isOpen={isOpen} setOpen={setOpen} lg>

--- a/src/client/components/modals/CustomDraftFormatModal.tsx
+++ b/src/client/components/modals/CustomDraftFormatModal.tsx
@@ -63,6 +63,7 @@ const CustomDraftFormatModal: React.FC<CustomDraftFormatModalProps> = ({ isOpen,
               label="Multiples"
               selected={format.multiples ? 'true' : 'false'}
               setSelected={(value) => setFormat({ ...format, multiples: value === 'true' })}
+              allowOptionTextWrapping={true}
               options={[
                 { value: 'true', label: 'Allow any number of copies of each card in the draft (e.g. set draft)' },
                 {


### PR DESCRIPTION
The `whitespace-nowrap` on the radio button text caused the modal not to shrink to fit the mobile viewport. The forced width caused the entire modal width to be large.

# Testing

## Before
Mobile:
![old-custom-draft-modal-mobile](https://github.com/user-attachments/assets/db609eae-c54d-40f9-91f4-6b2cf4f166cc)

Desktop (re padding difference):
![old-desktop-padding](https://github.com/user-attachments/assets/6327fcd0-4d8c-4ddb-94ef-98c3a51726e0)

## After
Mobile:
![new-custom-draft-modal-mobile1](https://github.com/user-attachments/assets/06c229b4-c705-404a-a1fe-607a2bae5e20)
![new-mobile-padding](https://github.com/user-attachments/assets/c62c22df-fdcd-45af-95b2-db13ccfbf959)

Desktop (re padding difference):
![new-desktop-padding](https://github.com/user-attachments/assets/031f9b32-5a4f-4aed-82dd-08d7c7d3fbb6)
