### PR TITLE
Fix loose list styling so long lines do not appear on a line after the positional marker.

### DIFF
--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -1214,10 +1214,6 @@ video {
   resize: both;
 }
 
-.list-inside {
-  list-style-position: inside;
-}
-
 .list-decimal {
   list-style-type: decimal;
 }
@@ -2585,15 +2581,13 @@ img.mana-symbol-sm {
   }
 }
 
-/* Loose lists (https: //spec.commonmark.org/0.31.2/#lists) have a <p> within the list items. Using inline-block and bottom margin
-* results in a blank line after the list item, and in conjunction with list-style-position: inside on the list element itself
-* ensures the <p> content starts on the same line as the item marker (eg 1 or *). Without inline-block, the list-style-position would
-* move the item content to the next line.
+/* Loose lists (https: //spec.commonmark.org/0.31.2/#lists) have a <p> within the list items. Use bottom margin to emulate
+* a blank line after the list item. No longer using list-style-position: inside with it, so don't have to muck with inline-block
+* to prevent the <p> from starting one a new line after the marker.
 */
 
 .markdown ul p,
 .markdown ol p {
-  display: inline-block;
   margin-bottom: 1rem;
 }
 

--- a/src/client/components/Markdown.tsx
+++ b/src/client/components/Markdown.tsx
@@ -261,13 +261,13 @@ interface renderUlProps {
   children: ReactNode;
 }
 
-const renderUl: React.FC<renderUlProps> = (node) => <ul className="list-disc list-inside ps-2">{node.children}</ul>;
+const renderUl: React.FC<renderUlProps> = (node) => <ul className="list-disc ml-4 ps-2">{node.children}</ul>;
 
 interface renderOlProps {
   children: ReactNode;
 }
 
-const renderOl: React.FC<renderOlProps> = (node) => <ol className="list-decimal list-inside ps-2">{node.children}</ol>;
+const renderOl: React.FC<renderOlProps> = (node) => <ol className="list-decimal ml-4 ps-2">{node.children}</ol>;
 
 const RENDERERS = {
   // overridden defaults

--- a/src/client/css/stylesheet.css
+++ b/src/client/css/stylesheet.css
@@ -279,14 +279,12 @@ img.mana-symbol-sm {
   }
 }
 
-/* Loose lists (https: //spec.commonmark.org/0.31.2/#lists) have a <p> within the list items. Using inline-block and bottom margin
-* results in a blank line after the list item, and in conjunction with list-style-position: inside on the list element itself
-* ensures the <p> content starts on the same line as the item marker (eg 1 or *). Without inline-block, the list-style-position would
-* move the item content to the next line.
+/* Loose lists (https: //spec.commonmark.org/0.31.2/#lists) have a <p> within the list items. Use bottom margin to emulate
+* a blank line after the list item. No longer using list-style-position: inside with it, so don't have to muck with inline-block
+* to prevent the <p> from starting one a new line after the marker.
 */
 .markdown ul p,
 .markdown ol p {
-	display: inline-block;
 	margin-bottom: 1rem;
 }
 


### PR DESCRIPTION
The original fix added the spacing between list items, but for long lines the start of the text got pushed down from the marker unexpectedly. Should have tested with more realistic text.

I didn't go hog wild on checking the alignment of the list marker vs text above in the old vs new changes. It looks reasonable to me in that there is some indentation for the list itself compared to lines above.

# Testing

## Before
![old-long-loose-list-lines-breaking](https://github.com/user-attachments/assets/71a1a7b3-5ba7-424f-91b5-48755a143d17)

## After
![new-long-loose-list-lines-in-markdown](https://github.com/user-attachments/assets/c348db51-4f30-485b-980c-bb9ebb2f7a61)
