### PR TITLE
Fix trashing adding cards to your mainboard, instead of removing them

### DIFF
--- a/src/client/components/CustomDraftCard.tsx
+++ b/src/client/components/CustomDraftCard.tsx
@@ -26,7 +26,7 @@ const range = (lo: number, hi: number): number[] => Array.from(Array(hi - lo).ke
 
 const CustomDraftCard: React.FC<CustomDraftCardProps> = ({ format, defaultDraftFormat, formatIndex }) => {
   const { cube, canEdit } = useContext(CubeContext);
-  const [seats, setSeats] = useState('8');
+  const [seats, setSeats] = useState(format?.defaultSeats?.toString() || '8');
   const formRef = React.createRef<HTMLFormElement>();
 
   const formData = useMemo(
@@ -34,7 +34,7 @@ const CustomDraftCard: React.FC<CustomDraftCardProps> = ({ format, defaultDraftF
       seats: `${seats}`,
       id: `${formatIndex}`,
     }),
-    [seats],
+    [formatIndex, seats],
   );
 
   return (

--- a/src/client/components/CustomPackCard.tsx
+++ b/src/client/components/CustomPackCard.tsx
@@ -107,7 +107,7 @@ const CustomPackCard: React.FC<CustomPackCardProps> = ({
                 className="me-2"
                 color="accent"
                 onClick={() => {
-                  setPack({ ...pack, slots: [...pack.slots, ''] });
+                  setPack({ ...pack, slots: [...pack.slots, '*'] });
                 }}
                 data-pack-index={packIndex}
               >

--- a/src/client/pages/CubeDraftPage.tsx
+++ b/src/client/pages/CubeDraftPage.tsx
@@ -197,7 +197,7 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
             if (currentStep.action === 'pick') {
               newState.seats[i].picks.unshift(state.seats[i].pack[pick]);
             } else if (currentStep.action === 'trash') {
-              newState.seats[i].picks.unshift(state.seats[i].pack[pick]);
+              newState.seats[i].trashed.unshift(state.seats[i].pack[pick]);
             }
             newState.seats[i].pack.splice(pick, 1);
           }

--- a/src/client/pages/CubeDraftPage.tsx
+++ b/src/client/pages/CubeDraftPage.tsx
@@ -114,14 +114,18 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
     async (index: number, location: location, row: number, col: number) => {
       //first update mainboard or sideboard so it's snappy
       const { board, setter } = getLocationReferences(location);
-      board[row][col].push(state.seats[0].pack[index]);
-      setter(board);
 
       setLoading(true);
       const newState = { ...state };
 
       // look at the current step
       const currentStep = newState.stepQueue[0];
+
+      //The board only changes when ther is a pick (human or auto) action
+      if (currentStep.action.includes('pick')) {
+        board[row][col].push(state.seats[0].pack[index]);
+        setter(board);
+      }
 
       // if amount is more than 1
       if (currentStep.amount && currentStep.amount > 1) {


### PR DESCRIPTION
# Problem
As reported in Discord, trashing a card is adding to your mainboard instead of disappearing.

# Solution
Any pick was being added to the mainboard right away, but that should only be done on a pick or auto pick action.

A couple other fixes/improvements done at the same time:
1. Custom draft seat number now correctly shows in the UI instead of defaulting to 8
2. When adding a card slot in a custom draft default the filter to "*"
3. Doesn't matter in to humans, but correctly assigning trashed picks to the bot seats "trash" buckets

## Minor concern
I noted is that the bot draft predictions use the index of the pack, rather than the index of the randomly sorted cube. Assuming you can't do anything with the bot seat information then its meaningless, but if you could see again the bot draft they could easily have duplicate cards.
Possible fixes:
1. Pass to the batch predict both the card oracle id and card index in the draft cards, and have the index returned in the response.
2. Lookup the index of the card in the sorted draft cards using the chosen oracle id the bot is picking

# Testing
Did most of the testing with a custom draft where in pack 1 had 11 cards and steps:
1. Pick
4. Trash 2
5. Pick 2
6. Random trash 1
7. Random pick 2
8. Random trash 2
9. Pick

Other packs were just 5 cards and all picks.

## Before
Can see a difference in the number of trashed cards between the Human in seat 0 and the bots in seats 1 through 3. Human correctly has 5 trashed cards based on the setup above, whereas the bots only have 3. Can see they have more picks than the human as well, as the trashed cards (not from random) got put into picks.
![old-non-auto-trash-bots-actually-picking](https://github.com/user-attachments/assets/0897c643-b709-45f9-9166-f9a30b1e8b4a)

Trashing cards (manual or auto) place them into your mainboard:
![old-trashing-adds-to-mainboard](https://github.com/user-attachments/assets/05814a27-c629-4a45-a5cb-25f8f117785e)

## After
Draft seat numbers showing correct:
![new-draft-seats-correct](https://github.com/user-attachments/assets/de29779a-2196-41ab-9b72-4841fd6b525d)

The bot seat's trash and pick piles are the expected size, matching the humans.
![new-bot-trash-piles-expected-size](https://github.com/user-attachments/assets/5fc047ca-a324-405a-a0fc-698396f588a1)

Trashing a card is not adding to your mainboard
![new-trash-and-auto-trash-arent-adding-to-mainboard](https://github.com/user-attachments/assets/1d2cfad4-3ab9-40fd-abe2-5a61ab9efe7d)

Trashing and picking with amounts more than 1 are also correct:
![new-amounts-more-than-one-trashing-and-picking-correctly](https://github.com/user-attachments/assets/2ca986d8-83c9-4a2e-afa4-d2d34be1b9fc)
