### PR TITLE
Fix failures in drafting when cards have non-integer mana values (cmc).

### DIFF
--- a/src/client/components/DeckbuilderNavbar.tsx
+++ b/src/client/components/DeckbuilderNavbar.tsx
@@ -2,11 +2,11 @@ import React, { useCallback, useContext, useMemo, useRef } from 'react';
 
 import { ChevronUpIcon, ThreeBarsIcon } from '@primer/octicons-react';
 
-import { cardCmc, cardOracleId, cardType } from 'utils/cardutil';
+import { cardOracleId } from 'utils/cardutil';
 
 import Card from '../../datatypes/Card';
 import Draft from '../../datatypes/Draft';
-import { setupPicks } from '../../util/draftutil';
+import { getCardDefaultRowColumn, setupPicks } from '../../util/draftutil';
 import { CSRFContext } from '../contexts/CSRFContext';
 import useToggle from '../hooks/UseToggle';
 import Button from './base/Button';
@@ -102,18 +102,17 @@ const DeckbuilderNavbar: React.FC<DeckbuilderNavbarProps> = ({
 
       for (const index of newMainboard) {
         const card = cards[index];
-        const row = cardType(card).toLowerCase().includes('creature') || cardType(card).includes('Basic') ? 0 : 1;
-        const column = Math.max(0, Math.min(cardCmc(card), 7));
+        const { row, col } = getCardDefaultRowColumn(card);
 
-        formattedMainboard[row][column].push(index);
+        formattedMainboard[row][col].push(index);
       }
 
       for (const index of pool) {
         if (!basics.includes(index)) {
           const card = cards[index];
-          const column = Math.max(0, Math.min(cardCmc(card), 7));
+          const { col } = getCardDefaultRowColumn(card);
 
-          formattedSideboard[0][column].push(index);
+          formattedSideboard[0][col].push(index);
         }
       }
 
@@ -122,7 +121,7 @@ const DeckbuilderNavbar: React.FC<DeckbuilderNavbarProps> = ({
     } else {
       console.error(json);
     }
-  }, [mainboard, sideboard, basics, cards, setDeck, setSideboard]);
+  }, [csrfFetch, mainboard, sideboard, basics, cards, setDeck, setSideboard]);
 
   const controls = (
     <>

--- a/src/router/routes/draft/finish.ts
+++ b/src/router/routes/draft/finish.ts
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
 import { setupPicks } from '../../..//util/draftutil';
-import { cardCmc, cardOracleId } from '../../../client/utils/cardutil';
+import { cardOracleId } from '../../../client/utils/cardutil';
 import DraftType, { DraftStep } from '../../../datatypes/Draft';
 import Draft from '../../../dynamo/models/draft';
 import { csrfProtection } from '../../../routes/middleware';
@@ -137,9 +137,9 @@ const handler = async (req: Request, res: Response) => {
       for (const index of pool) {
         if (!draft.basics.includes(index)) {
           const card = draft.cards[index];
-          const column = Math.max(0, Math.min(cardCmc(card), 7));
+          const { col } = getCardDefaultRowColumn(card);
 
-          formattedSideboard[0][column].push(index);
+          formattedSideboard[0][col].push(index);
         }
       }
 

--- a/src/router/routes/draft/finish.ts
+++ b/src/router/routes/draft/finish.ts
@@ -1,12 +1,13 @@
 import Joi from 'joi';
 
 import { setupPicks } from '../../..//util/draftutil';
-import { cardCmc, cardOracleId, cardType } from '../../../client/utils/cardutil';
+import { cardCmc, cardOracleId } from '../../../client/utils/cardutil';
 import DraftType, { DraftStep } from '../../../datatypes/Draft';
 import Draft from '../../../dynamo/models/draft';
 import { csrfProtection } from '../../../routes/middleware';
 import { NextFunction, Request, Response } from '../../../types/express';
 import { deckbuild } from '../../../util/draftbots';
+import { getCardDefaultRowColumn } from '../../../util/draftutil';
 
 export interface Seat {
   picks: number[];
@@ -128,10 +129,9 @@ const handler = async (req: Request, res: Response) => {
 
       for (const index of newMainboard) {
         const card = draft.cards[index];
-        const row = cardType(card).includes('Creature') || cardType(card).includes('Basic') ? 0 : 1;
-        const column = Math.max(0, Math.min(cardCmc(card), 7));
+        const { row, col } = getCardDefaultRowColumn(card);
 
-        formattedMainboard[row][column].push(index);
+        formattedMainboard[row][col].push(index);
       }
 
       for (const index of pool) {

--- a/src/util/draftutil.ts
+++ b/src/util/draftutil.ts
@@ -1,5 +1,6 @@
 import { cardCmc, cardType } from '../client/utils/cardutil';
 import { cmcColumn } from '../client/utils/Util';
+import Card from '../datatypes/Card';
 import Draft, { DraftStep } from '../datatypes/Draft';
 
 interface Step {
@@ -251,11 +252,21 @@ export const getDrafterState = (draft: Draft, seatNumber: number, pickNumber: nu
   return states[seatNumber];
 };
 
-export const getDefaultPosition = (card: any, picks: any[][][]): [number, number, number] => {
-  const row = cardType(card).toLowerCase().includes('creature') ? 0 : 1;
-  const col = cmcColumn(card);
+export const getDefaultPosition = (card: Card, picks: any[][][]): [number, number, number] => {
+  const { row, col } = getCardDefaultRowColumn(card);
   const colIndex = picks[row][col].length;
   return [row, col, colIndex];
+};
+
+export const getCardDefaultRowColumn = (card: Card): { row: number; col: number } => {
+  const isCreature = cardType(card).toLowerCase().includes('creature');
+  //Some cards, like Assault//Battery, have a CMC that is a decimal (and then there are un-cards). cmcColumn normalizes between 0 and 8
+  const cmc = cmcColumn(card);
+
+  const row = isCreature ? 0 : 1;
+  const col = Math.max(0, Math.min(7, cmc));
+
+  return { row, col };
 };
 
 export const stepListToTitle = (steps: DraftStep[]): string => {


### PR DESCRIPTION
* Human's would get error picking it (in theory bots too if auto-picking)
* Draft could not finish if a bot had the card in their pool
* Deck build for me would fail if in your pool.

# Testing
1. Exported cube https://cubecobra.com/cube/playtest/old_border to my local using CSV. 
2. Started a draft
3. Just happened to pick Assault//Battery and got React error about unable to do board[row][col].push(..)
4. Debugged to discover the CMC was 2.5!
5. Same error occurred in the deckbuild "Build for me"
6. Did a new draft and did not choose Assault//Battery thus a bot must pick it since its a 360 cube
7. Draft completed