### PR TITLE
Fix #2554 when card (or details) colors is a string not an array, eg "BR" vs ["B", "R"]

### DIFF
--- a/src/client/utils/cardutil.ts
+++ b/src/client/utils/cardutil.ts
@@ -75,7 +75,7 @@ export function cardsAreEquivalent(a?: Card, b?: Card): boolean {
     a.type_line === b.type_line &&
     a.status === b.status &&
     a.cmc === b.cmc &&
-    arraysEqual(a.colors, b.colors) &&
+    arraysEqual(cardColors(a), cardColors(b)) &&
     arraysEqual(a.tags, b.tags) &&
     a.finish === b.finish &&
     a.imgUrl === b.imgUrl &&
@@ -393,7 +393,26 @@ export const detailsToCard = (details: CardDetailsType): Card => {
   };
 };
 
-export const cardColors = (card: Card): string[] => card.colors ?? card.details?.colors ?? [];
+export const cardColors = (card: Card): string[] => {
+  //Old data may have colors (or details.colors) as a string like WBG instead of [W, B, G]
+  if (card.colors) {
+    if (typeof card.colors === 'string') {
+      return [...card.colors];
+    }
+
+    return card.colors;
+  }
+
+  if (card.details) {
+    if (typeof card.details.colors === 'string') {
+      return [...card.details.colors];
+    }
+
+    return card.details.colors;
+  }
+
+  return [];
+};
 
 export const cardLanguage = (card: Card): string => card.details?.language ?? '';
 

--- a/src/routes/cube/helper.js
+++ b/src/routes/cube/helper.js
@@ -197,12 +197,13 @@ function writeCard(res, card, maybe) {
     imgBackUrl = '';
   }
 
+  const colorColors = cardutil.cardColors(card);
   const colorCategory = cardutil.convertFromLegacyCardColorCategory(card.colorCategory);
 
   res.write(`"${name.replaceAll(/"/g, '""')}",`);
   res.write(`${card.cmc || cmc},`);
   res.write(`"${card.type_line.replace('—', '-')}",`);
-  res.write(`${(card.colors || colorIdentity || []).join('')},`);
+  res.write(`${colorColors.join('')},`);
   res.write(`"${cardFromId(card.cardID).set}",`);
   res.write(`"${cardFromId(card.cardID).collector_number}",`);
   res.write(`${card.rarity && card.rarity !== 'undefined' ? card.rarity : rarity},`);

--- a/src/routes/cube/helper.js
+++ b/src/routes/cube/helper.js
@@ -184,7 +184,7 @@ function writeCard(res, card, maybe) {
   if (!card.type_line) {
     card.type_line = cardFromId(card.cardID).type;
   }
-  const { name, rarity, colorcategory, cmc, color_identity: colorIdentity } = cardFromId(card.cardID);
+  const { name, rarity, colorcategory, cmc } = cardFromId(card.cardID);
   let { imgUrl, imgBackUrl } = card;
   if (imgUrl) {
     imgUrl = `"${imgUrl}"`;

--- a/src/routes/cube/index.js
+++ b/src/routes/cube/index.js
@@ -5,6 +5,7 @@ const RSS = require('rss');
 
 const { CARD_STATUSES } = require('../../datatypes/Card');
 
+const cardutil = require('../../client/utils/cardutil');
 const miscutil = require('../../client/utils/Util');
 const {
   getIdsFromName,
@@ -1298,7 +1299,7 @@ router.post(
         // sort by color
         const details = cardFromId(card.cardID);
         const type = card.type_line || details.type;
-        const colors = card.colors || details.colors;
+        const colors = cardutil.cardColors(card);
 
         if (type.toLowerCase().includes('land')) {
           index1 = 7;

--- a/src/routes/cube/index.js
+++ b/src/routes/cube/index.js
@@ -154,7 +154,7 @@ router.get('/report/:id', ensureAuth, async (req, res) => {
       'Thank you for the report! Our moderators will review the report can decide whether to take action.',
     );
 
-    return redirect(req, res,  `/cube/overview/${req.params.id}`);
+    return redirect(req, res, `/cube/overview/${req.params.id}`);
   } catch (err) {
     return util.handleRouteError(req, res, err, `/cube/overview/${req.params.id}`);
   }
@@ -162,8 +162,8 @@ router.get('/report/:id', ensureAuth, async (req, res) => {
 
 router.get('/recents', async (req, res) => {
   const result = await Cube.getByVisibility(Cube.VISIBILITY.PUBLIC);
-  
-  
+
+
 
   return render(req, res, 'RecentlyUpdateCubesPage', {
     items: result.items.filter((cube) =>
@@ -385,7 +385,7 @@ router.post('/editoverview', ensureAuth, async (req, res) => {
       req.flash('danger', 'Cannot update the cube overview for an empty cube. Please add cards to the cube first.');
       return redirect(req, res, '/cube/overview/' + cube.id);
     }
-    
+
     if (util.hasProfanity(updatedCube.name)) {
       req.flash('danger', 'Could not update cube, the name contains a banned word. If you feel this was a mistake, please contact us.');
       return redirect(req, res, '/cube/overview/' + cube.id);
@@ -825,7 +825,7 @@ router.post('/getmoredecks/:id', async (req, res) => {
       decks: query.items,
       lastKey: query.lastKey,
     });
-  } catch(e) {
+  } catch (e) {
     return res.status(500).send({
       error: e,
       success: 'false',
@@ -996,7 +996,7 @@ router.get('/samplepackimage/:id/:seed', async (req, res) => {
 
     const cards = await Cube.getCards(cube.id);
 
-    
+
     const imageBuffer = await cachePromise(`/samplepack/${req.params.id}/${req.params.seed}`, async () => {
       let pack;
       try {
@@ -1063,7 +1063,7 @@ router.post('/bulkuploadfile/:id', ensureAuth, async (req, res) => {
 
     // decode base64
     const list = Buffer.from(encodedFile, 'base64').toString('utf8');
-    
+
     const cube = await Cube.getById(req.params.id);
 
     if (!isCubeViewable(cube, req.user)) {

--- a/src/util/cubefn.js
+++ b/src/util/cubefn.js
@@ -6,7 +6,7 @@ const fetch = require('node-fetch');
 const _ = require('lodash')
 const sharp = require('sharp');
 const Cube = require('../dynamo/models/cube');
-const { convertFromLegacyCardColorCategory } = require('../client/utils/cardutil');
+const { cardColors, convertFromLegacyCardColorCategory } = require('../client/utils/cardutil');
 const { cardFromId, allVersions, reasonableId } = require('../util/carddb');
 
 const util = require('./util');
@@ -48,7 +48,9 @@ function cardsAreEquivalent(card, details) {
   if (!util.arraysEqual(card.tags, details.tags)) {
     return false;
   }
-  if (!util.arraysEqual(card.colors, details.colors)) {
+  const cardColors = typeof card.colors === 'string' ? [...card.colors] : card.colors;
+  const detailsColors = typeof details.colors === 'string' ? [...details.colors] : details.colors;
+  if (!util.arraysEqual(cardColors, detailsColors)) {
     return false;
   }
   if (card.finish && details.finish && card.finish !== details.finish) {


### PR DESCRIPTION
Fixes #2554 

# Problem
In the reported cube (which has since been updated) a number of cards had card.colors as a string instead of an array of characters. I assume this was how the code used to work as we already fixed a similar issue with color identity.

# Solution
Like in the color identity situation, the fix is to convert string card/detail colors to an array.

# Testing
To set this up I grabbed one of my cube's CSVs from local S3 and updated a few cards from array colors to string. In testing I used Mayhem devil whose colors was set to "BR".

See from console that 4 cards in my test cube have string values for card.colors:
![cards-with-string-colors](https://github.com/user-attachments/assets/1450612a-9856-4814-8ba3-97598e1f1526)

## Before

Analytics tab for colors breaks trying to map on a string:
![old-analytics-color-string-fail](https://github.com/user-attachments/assets/8b6f0048-340c-4acd-b95d-6f3be12541ba)

Exporting the cube to CSV fails because cannot join on a string:
![old-color-string-export-to-csv-fails](https://github.com/user-attachments/assets/5bf3e78a-fa4a-4113-975c-2c847b5cc68b)

Interestingly in sealed pack generation it uses colors length to determine column, and that still worked because both array and strings have a length and can be accessed by index. And it only really checks if length is 0 or 1 or not.
![old-color-string-sealed-is-fine](https://github.com/user-attachments/assets/d6fdd4ed-232b-4a63-ae71-a5ab49b248a1)

Similarly the cardsAreEquivalent used in version mismatch detecting also works in most of the time because the arraysEqual function first checks `a == b` which is fine with strings or arrays. Even if a or b was an array and the other a string, that would just end up saying the cards are no equivalent rather than having an error.
![old-version-mismatch-color-string-works](https://github.com/user-attachments/assets/0c536336-126e-4852-bf07-406eb291995a)

## After

Color analysis worked even though cards with string color:
![new-color-analysis](https://github.com/user-attachments/assets/7947de8a-990e-4841-ad5d-b4d3d7708096)

Color analysis CSV download works:
![new-color-analysis-csv](https://github.com/user-attachments/assets/680beab0-438c-422f-954e-d4c3fb143998)

Sealed pack generation still works:
![new-sealed-with-card-string-colors](https://github.com/user-attachments/assets/77ef3fef-ff49-4d6c-965c-8f4b6acd600a)

Card modal works with string colors, though that isn't interesting because that uses color identity:
![new-card-with-string-color-in-card-modal](https://github.com/user-attachments/assets/a7088820-a81d-4c61-aeaf-62adf0f1309a)
