### PR TITLE
Fix Card link/images not rendering when within tables

### DIFF
--- a/src/client/markdown/cardlink/index.js
+++ b/src/client/markdown/cardlink/index.js
@@ -28,8 +28,18 @@ function oncard(node, index, parent) {
     node.inParagraph = true;
   }
 
-  [node.name, node.id] = node.value.split('|');
-  if (typeof node.id === 'undefined') node.id = node.name;
+  /* Per https://github.com/micromark/micromark-extension-gfm-table?tab=readme-ov-file#syntax tables don't allow
+   * pipes (|) in their cell contents unless escaped. So let's first check if there is the escaped version to split
+   * Card name and id, otherwise check for just a normal pipe
+   */
+  [node.name, node.id] = node.value.split('\\|');
+  if (typeof node.id === 'undefined') {
+    [node.name, node.id] = node.value.split('|');
+  }
+
+  if (typeof node.id === 'undefined') {
+    node.id = node.name;
+  }
 
   node.data.hName = node.type;
   node.data.hProperties = { name: node.name, id: node.id, dfc: node.dfc, inParagraph: node.inParagraph };

--- a/src/client/pages/MarkdownPage.tsx
+++ b/src/client/pages/MarkdownPage.tsx
@@ -39,7 +39,10 @@ const MarkdownPage: React.FC<MarkdownProps> = ({ loginCallback }) => (
           </Text>
           <p>
             Our Markdown syntax is based on the CommonMark specification, which includes all the common Markdown
-            constructs you may already be familiar with. <Link href="https://commonmark.org/help/" target="_blank" rel="noopener noreferrer">Learn more.</Link>
+            constructs you may already be familiar with.{' '}
+            <Link href="https://commonmark.org/help/" target="_blank" rel="noopener noreferrer">
+              Learn more.
+            </Link>
           </p>
         </CardBody>
         <CardBody className="border-top">
@@ -627,6 +630,40 @@ const MarkdownPage: React.FC<MarkdownProps> = ({ loginCallback }) => (
               </Card>
             </Col>
           </Row>
+          <br />
+          <p>To use a card link or image with an id inside a table, the pipe must be escaped with a slash.</p>
+          <Row>
+            <Col xs={12} sm={6}>
+              <Card>
+                <CardHeader>Source</CardHeader>
+                <CardBody>
+                  <p>
+                    <code>| Column A | Column B |</code>
+                    <br />
+                    <code>| - | - |</code>
+                    <br />
+                    <code>| [[!/Delver of Secrets&#92;|28059d09-2c7d-4c61-af55-8942107a7c1f]] | Image |</code>
+                    <br />
+                    <code>| [[Old Border Mystic Snake&#92;|f098a28c-5f9b-4a2c-b109-c342365eb948]] | Card link |</code>
+                    <br />
+                    <code>| [[Ambush Viper]] | Card link without id |</code>
+                  </p>
+                </CardBody>
+              </Card>
+            </Col>
+            <Col xs={12} sm={6}>
+              <Card>
+                <CardHeader>Result</CardHeader>
+                <CardBody>
+                  <Markdown
+                    markdown={
+                      '| Column A | Column B |\n| - | - |\n| [[!/Delver of Secrets\\|28059d09-2c7d-4c61-af55-8942107a7c1f]] | Image |\n| [[Old Border Mystic Snake\\|f098a28c-5f9b-4a2c-b109-c342365eb948]] | Card link |\n| [[Ambush Viper]] | Card link without id |'
+                    }
+                  />
+                </CardBody>
+              </Card>
+            </Col>
+          </Row>
         </CardBody>
         <CardBody className="border-top">
           <Text semibold md>
@@ -673,7 +710,11 @@ const MarkdownPage: React.FC<MarkdownProps> = ({ loginCallback }) => (
           <p>
             When writing a code block, specifying a language will enable syntax highlighting for that language. You can
             specify{' '}
-            <Link href="https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/AVAILABLE_LANGUAGES_HLJS.MD" target="_blank" rel="noopener noreferrer">
+            <Link
+              href="https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/AVAILABLE_LANGUAGES_HLJS.MD"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               the following languages.
             </Link>
           </p>
@@ -709,14 +750,18 @@ const MarkdownPage: React.FC<MarkdownProps> = ({ loginCallback }) => (
             Header linking
           </Text>
           <p>
-            Headers in markdown can be linked to within the page by creating anchors with fragment (#) URLs. The content of the fragment
-            is the text content of the header in lowercase, with whitespace replaced by "-" (dash) and non-letter/numbers characters removed (see examples).
-            Each heading must have unique text (within the page) for the linking to work.
+            Headers in markdown can be linked to within the page by creating anchors with fragment (#) URLs. The content
+            of the fragment is the text content of the header in lowercase, with whitespace replaced by "-" (dash) and
+            non-letter/numbers characters removed (see examples). Each heading must have unique text (within the page)
+            for the linking to work.
           </p>
           <p>Examples:</p>
           <ul>
             <li>A header with text "This is my cube" can be linked from fragment "#this-is-my-cube"</li>
-            <li>Non-letters such as emoji's or symbols will be removed: "😄 emoji ♥" can be linked from fragment "#-emoji-"</li>
+            <li>
+              Non-letters such as emoji's or symbols will be removed: "😄 emoji ♥" can be linked from fragment
+              "#-emoji-"
+            </li>
             <li>Non-ASCII letters work: "The Héroïne" can be linked from fragment "#the-héroïne"</li>
           </ul>
           <br />


### PR DESCRIPTION
Fixes #2553

# Problem
A card or image link like `[[Cartel Aristocrat|e2dec477-5764-4c0c-bb10-42d64ad2103e]]` fails to render within a table. The pipe is treated as the end of the table cell because per https://github.com/micromark/micromark-extension-gfm-table?tab=readme-ov-file#syntax the table grammar doesn't allow pipes, unless they are escaped.

Escaping the pipe works currently, but the backslash gets treated as part of the card name rendered which is ugly.

# Solution
Try breaking the card link/image on `\|` first and then `|` to get the card name or id. This gets rid of the backslash rendered in the text.

# Testing

## Before
1. Lack of escaping the pipe causes the card name and id to be treated as 2 different table cells.
2. With the escaped pipe the backslash shows in the rendered card name
![old-card-link-within-tables-fails](https://github.com/user-attachments/assets/f08dfff3-a37f-486e-8852-130979fcfc4e)

Outside a table only the backslash text shows:
![old-card-link-outside-table-okish](https://github.com/user-attachments/assets/2079dcdc-9c6f-4e12-882f-72f21a4d7628)

## After

Within a table the extra slash no longer shows:
![new-card-link-within-tables-escaping-nicer](https://github.com/user-attachments/assets/648d0ceb-69ed-403c-9afc-dbd662305592)

Same outside the table:
![new-card-link-outside-tables-escaping-nicer](https://github.com/user-attachments/assets/62bfbfc2-80a8-4d6c-a7db-c5bebfa80fff)

Added markdown example for how to properly escape card images/links in tables:
![new-markdown-on-card-links-within-tables](https://github.com/user-attachments/assets/315e559e-1af9-4d92-b3f4-fa789436a6b8)