### PR TITLE
Make external images within text centering markdown, display in row instead of vertically

### DIFF
--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -2604,6 +2604,12 @@ img.mana-symbol-sm {
   touch-action: none;
 }
 
+/* Make external images within centering blocks display beside it each instead of stacked vertically */
+
+.markdown .text-center img.max-w-full {
+  display: inline-block;
+}
+
 @media (min-width: 640px) {
   .sm\:container {
     width: 100%;

--- a/src/client/css/stylesheet.css
+++ b/src/client/css/stylesheet.css
@@ -298,3 +298,8 @@ img.mana-symbol-sm {
 .no-touch-action {
   touch-action: none;
 }
+
+/* Make external images within centering blocks display beside it each instead of stacked vertically */
+.markdown .text-center img.max-w-full {
+	display: inline-block;
+}


### PR DESCRIPTION
Fixes #2484 (what is left of it)

# Testing

## Before
When within the `>>> <<<` centering:
![old-external-images-stacking](https://github.com/user-attachments/assets/f0e1df00-8138-4c54-919e-6155b836d5de)

Without centering:
![old-external-images-outside-centering-stacks](https://github.com/user-attachments/assets/568151aa-e571-4093-961e-d21de869c34e)

## After
When within the `>>> <<<` centering:
![new-external-images-centered](https://github.com/user-attachments/assets/a31f44a8-47fa-496b-90e8-9972d9f90229)

Without centering is the same:
![new-external-images-outside-centering-still-stacks](https://github.com/user-attachments/assets/efeaa703-828e-4c89-aea7-e8eee83ce53c)
