### PR TITLE
Example of AND filters in the custom draft card slot UI.

### DIFF
--- a/src/client/components/modals/CustomDraftFormatModal.tsx
+++ b/src/client/components/modals/CustomDraftFormatModal.tsx
@@ -85,7 +85,8 @@ const CustomDraftFormatModal: React.FC<CustomDraftFormatModalProps> = ({ isOpen,
               Card values can either be single tags or filter parameters or a comma separated list to create a ratio
               (e.g. 3:1 rare to mythic could be <code>rarity:rare, rarity:rare, rarity:rare, rarity:mythic</code>). tags
               can be specified <code>tag:yourtagname</code> or simply <code>yourtagname</code>. <code>*</code> can be
-              used to match any card.
+              used to match any card. Space separated filters act as an AND, eg <code>set:inv r:common</code> matches a
+              card from the Invasion set AND is a common.
             </Text>
             {(format.packs ?? []).map((pack, packIndex) => (
               <CustomPackCard


### PR DESCRIPTION
From question in Discord and Dekkaru's answer:

![new-draft-filter-text](https://github.com/user-attachments/assets/7cb09760-42ee-4ad4-97ab-a8b2d3be7510)

To test I set card slot to be `set:afr r:mythic` in a local cube and verified across multople custom draft starts that the first card in the packs matched (I set a single pack and 2 drafters for simplicity)