### PR TITLE
Pretend to be curl so that imgur doesn't return 429 errors for custom images.

### DIFF
--- a/src/util/cubefn.js
+++ b/src/util/cubefn.js
@@ -314,6 +314,10 @@ const generateSamplepackImage = async (sources = [], width, height) => {
 
       const res = await fetch(source.src, fetchOptions);
 
+      if (!res.ok) {
+        console.log(`Failed to fetch image: ${source.src}. Response statuses: ${res.status}, ${res.statusText}`);
+      }
+
       return {
         input: await sharp(Buffer.from(await res.arrayBuffer()))
           .resize({ width: source.width, height: source.height })

--- a/src/util/cubefn.js
+++ b/src/util/cubefn.js
@@ -305,7 +305,14 @@ async function compareCubes(cardsA, cardsB) {
 const generateSamplepackImage = async (sources = [], width, height) => {
   const images = await Promise.all(
     sources.map(async (source) => {
-      const res = await fetch(source.src);
+      const fetchOptions = source.src.includes('imgur') ? {
+        headers: {
+          //Imgur returns a 429 error using the default node-fetch useragent, but it is happy with curl!
+          "User-Agent": "curl/8.5.0"
+        }
+      } : {};
+
+      const res = await fetch(source.src, fetchOptions);
 
       return {
         input: await sharp(Buffer.from(await res.arrayBuffer()))

--- a/src/util/cubefn.js
+++ b/src/util/cubefn.js
@@ -315,6 +315,7 @@ const generateSamplepackImage = async (sources = [], width, height) => {
       const res = await fetch(source.src, fetchOptions);
 
       if (!res.ok) {
+        // eslint-disable-next-line no-console
         console.log(`Failed to fetch image: ${source.src}. Response statuses: ${res.status}, ${res.statusText}`);
       }
 


### PR DESCRIPTION
# After
The salt flats is a custom image from imgur `https://i.imgur.com/cywlnIM.png`
![salt-falts-imgur](https://github.com/user-attachments/assets/6cf580d8-d15c-43fa-851c-f60099d54cfd)

Generated sample pack image
![pack-image](https://github.com/user-attachments/assets/f055e26e-27a0-4bf0-9984-75160018f51a)

# Idea
I was also playing around with handling the fetch better, but didn't get far. So I've just added logging about the request failure so we can track. eg
![image](https://github.com/user-attachments/assets/5fd0cad4-f222-423d-9d7f-f24d2e3f2564)


Sharp has the ability to write text such as via SVG, so my thinking was on a failure we could at least write the card name on a blank piece of cardboard. Which would look something like (but better) than:
![placeholder](https://github.com/user-attachments/assets/2202e1f1-72ae-4ee8-848a-5da245349c6a)
I have never worked with SVGs before and in my quick testing its challenging to center the text and deal with wrapping, so it might be overkill.