### PR TITLE
Token Tracker improvements

### DIFF
--- a/src/jobs/update_cards.ts
+++ b/src/jobs/update_cards.ts
@@ -241,10 +241,12 @@ async function writeFile(filepath: string, data: any) {
   });
 }
 
+const miscTokens = ['Manifest', 'A Mysterious Creature']
+
 function getScryfallTokensForCard(card: ScryfallCard) {
   const allParts = card.all_parts || [];
   return allParts
-    .filter((element) => element.component === 'token' || element.type_line.includes('Emblem') || element.type_line.includes('Dungeon') || (element.type_line.includes('Card') && !element.name.includes('Checklist')))
+    .filter((element) => element.component === 'token' || element.type_line.includes('Emblem') || element.type_line.includes('Dungeon') || (element.type_line.includes('Card') && !element.name.includes('Checklist')) || miscTokens.includes(element.name))
     .map(({ id }) => id);
 }
 

--- a/src/jobs/update_cards.ts
+++ b/src/jobs/update_cards.ts
@@ -253,7 +253,7 @@ const specialCaseTokens = {
 function getScryfallTokensForCard(card: ScryfallCard) {
   const allParts = card.all_parts || [];
   return allParts
-    .filter((element) => element.component === 'token' || element.type_line.startsWith('Emblem'))
+    .filter((element) => element.component === 'token' || element.type_line.startsWith('Emblem') || Object.keys(specialCaseTokens).includes(element.name))
     .map(({ id }) => id);
 }
 

--- a/src/jobs/update_cards.ts
+++ b/src/jobs/update_cards.ts
@@ -244,7 +244,7 @@ async function writeFile(filepath: string, data: any) {
 function getScryfallTokensForCard(card: ScryfallCard) {
   const allParts = card.all_parts || [];
   return allParts
-    .filter((element) => element.component === 'token' || element.type_line.startsWith('Emblem'))
+    .filter((element) => element.component === 'token' || element.type_line.includes('Emblem') || element.type_line.includes('Dungeon') || (element.type_line.includes('Card') && !element.name.includes('Checklist')))
     .map(({ id }) => id);
 }
 

--- a/src/jobs/update_cards.ts
+++ b/src/jobs/update_cards.ts
@@ -248,6 +248,7 @@ const specialCaseTokens = {
   "City's Blessing": 'ba64ed3e-93c5-406f-a38d-65cc68472122',
   "The Monarch": '40b79918-22a7-4fff-82a6-8ebfe6e87185',
   "Energy Reserve": 'a446b9f8-cb22-408a-93ff-bee44a0dccc0',
+  "Day // Night": '9c0f7843-4cbb-4d0f-8887-ec823a9238da',
 };
 
 function getScryfallTokensForCard(card: ScryfallCard) {
@@ -444,6 +445,9 @@ function getTokens(card: ScryfallCard, catalogCard: CardDetails) {
     }
     if (catalogCard.oracle_text.includes('{E}')) {
       mentionedTokens.push(specialCaseTokens["Energy Reserve"]);
+    }
+    if (catalogCard.oracle_text.includes('becomes day') || catalogCard.oracle_text.includes('becomes night') || catalogCard.oracle_text.includes('Daybound')) {
+      mentionedTokens.push(specialCaseTokens["Day // Night"]);
     }
 
     if (catalogCard.oracle_text.includes('emblem')) {

--- a/src/jobs/update_cards.ts
+++ b/src/jobs/update_cards.ts
@@ -241,7 +241,9 @@ async function writeFile(filepath: string, data: any) {
   });
 }
 
-const miscTokens = ['Manifest', 'A Mysterious Creature']
+// These tokens don't match any of the filters below. The first 4 are "face down" tokens, and Halfling is a "Tolkien" creature
+// This list was calculated with a script that parsed every scryfall object that was part of a 'token' set that didn't match the below filters
+const miscTokens = ['Manifest', 'A Mysterious Creature', 'Cyberman', 'Morph', 'Halfling']
 
 function getScryfallTokensForCard(card: ScryfallCard) {
   const allParts = card.all_parts || [];

--- a/src/jobs/update_cards.ts
+++ b/src/jobs/update_cards.ts
@@ -241,22 +241,21 @@ async function writeFile(filepath: string, data: any) {
   });
 }
 
-const specialCaseTokens = {
-  Food: 'bf36408d-ed85-497f-8e68-d3a922c388a0',
-  Treasure: 'e6fa7d35-9a7a-40fc-9b97-b479fc157ab0',
-  "Poison Counter": '470618f6-f67f-44c6-a086-285632508915',
-  "City's Blessing": 'ba64ed3e-93c5-406f-a38d-65cc68472122',
-  "The Monarch": '40b79918-22a7-4fff-82a6-8ebfe6e87185',
-  "Energy Reserve": 'a446b9f8-cb22-408a-93ff-bee44a0dccc0',
-  "Day // Night": '9c0f7843-4cbb-4d0f-8887-ec823a9238da',
-};
-
 function getScryfallTokensForCard(card: ScryfallCard) {
   const allParts = card.all_parts || [];
   return allParts
-    .filter((element) => element.component === 'token' || element.type_line.startsWith('Emblem') || Object.keys(specialCaseTokens).includes(element.name))
+    .filter((element) => element.component === 'token' || element.type_line.startsWith('Emblem'))
     .map(({ id }) => id);
 }
+
+const specialCaseTokens = {
+  Food: 'bf36408d-ed85-497f-8e68-d3a922c388a0',
+  Treasure: 'e6fa7d35-9a7a-40fc-9b97-b479fc157ab0',
+  Poison: '470618f6-f67f-44c6-a086-285632508915',
+  "City's Blessing": 'ba64ed3e-93c5-406f-a38d-65cc68472122',
+  Monarch: '40b79918-22a7-4fff-82a6-8ebfe6e87185',
+  Energy: 'a446b9f8-cb22-408a-93ff-bee44a0dccc0',
+};
 
 function arraySetEqual<T>(target: T[], candidate: T[]) {
   let isValid = candidate.length === target.length;
@@ -438,16 +437,13 @@ function getTokens(card: ScryfallCard, catalogCard: CardDetails) {
       mentionedTokens.push(specialCaseTokens["City's Blessing"]);
     }
     if (catalogCard.oracle_text.includes('poison counter')) {
-      mentionedTokens.push(specialCaseTokens["Poison Counter"]);
+      mentionedTokens.push(specialCaseTokens.Poison);
     }
     if (catalogCard.oracle_text.includes('you become the monarch')) {
-      mentionedTokens.push(specialCaseTokens["The Monarch"]);
+      mentionedTokens.push(specialCaseTokens.Monarch);
     }
     if (catalogCard.oracle_text.includes('{E}')) {
-      mentionedTokens.push(specialCaseTokens["Energy Reserve"]);
-    }
-    if (catalogCard.oracle_text.includes('becomes day') || catalogCard.oracle_text.includes('becomes night') || catalogCard.oracle_text.includes('Daybound')) {
-      mentionedTokens.push(specialCaseTokens["Day // Night"]);
+      mentionedTokens.push(specialCaseTokens.Energy);
     }
 
     if (catalogCard.oracle_text.includes('emblem')) {

--- a/src/jobs/update_cards.ts
+++ b/src/jobs/update_cards.ts
@@ -246,6 +246,7 @@ const miscTokens = ['Manifest', 'A Mysterious Creature']
 function getScryfallTokensForCard(card: ScryfallCard) {
   const allParts = card.all_parts || [];
   return allParts
+    // the 'Card' type includes helper cards that aren't technically tokens like Monarch, Day-Night tracker, etc. Exclude "CheckLists" for flip cards
     .filter((element) => element.component === 'token' || element.type_line.includes('Emblem') || element.type_line.includes('Dungeon') || (element.type_line.includes('Card') && !element.name.includes('Checklist')) || miscTokens.includes(element.name))
     .map(({ id }) => id);
 }

--- a/src/jobs/update_cards.ts
+++ b/src/jobs/update_cards.ts
@@ -241,13 +241,6 @@ async function writeFile(filepath: string, data: any) {
   });
 }
 
-function getScryfallTokensForCard(card: ScryfallCard) {
-  const allParts = card.all_parts || [];
-  return allParts
-    .filter((element) => element.component === 'token' || element.type_line.startsWith('Emblem'))
-    .map(({ id }) => id);
-}
-
 const specialCaseTokens = {
   Food: 'bf36408d-ed85-497f-8e68-d3a922c388a0',
   Treasure: 'e6fa7d35-9a7a-40fc-9b97-b479fc157ab0',
@@ -256,6 +249,13 @@ const specialCaseTokens = {
   "The Monarch": '40b79918-22a7-4fff-82a6-8ebfe6e87185',
   "Energy Reserve": 'a446b9f8-cb22-408a-93ff-bee44a0dccc0',
 };
+
+function getScryfallTokensForCard(card: ScryfallCard) {
+  const allParts = card.all_parts || [];
+  return allParts
+    .filter((element) => element.component === 'token' || element.type_line.startsWith('Emblem'))
+    .map(({ id }) => id);
+}
 
 function arraySetEqual<T>(target: T[], candidate: T[]) {
   let isValid = candidate.length === target.length;
@@ -437,13 +437,13 @@ function getTokens(card: ScryfallCard, catalogCard: CardDetails) {
       mentionedTokens.push(specialCaseTokens["City's Blessing"]);
     }
     if (catalogCard.oracle_text.includes('poison counter')) {
-      mentionedTokens.push(specialCaseTokens.Poison);
+      mentionedTokens.push(specialCaseTokens["Poison Counter"]);
     }
     if (catalogCard.oracle_text.includes('you become the monarch')) {
-      mentionedTokens.push(specialCaseTokens.Monarch);
+      mentionedTokens.push(specialCaseTokens["The Monarch"]);
     }
     if (catalogCard.oracle_text.includes('{E}')) {
-      mentionedTokens.push(specialCaseTokens.Energy);
+      mentionedTokens.push(specialCaseTokens["Energy Reserve"]);
     }
 
     if (catalogCard.oracle_text.includes('emblem')) {

--- a/src/jobs/update_cards.ts
+++ b/src/jobs/update_cards.ts
@@ -251,10 +251,10 @@ function getScryfallTokensForCard(card: ScryfallCard) {
 const specialCaseTokens = {
   Food: 'bf36408d-ed85-497f-8e68-d3a922c388a0',
   Treasure: 'e6fa7d35-9a7a-40fc-9b97-b479fc157ab0',
-  Poison: '470618f6-f67f-44c6-a086-285632508915',
+  "Poison Counter": '470618f6-f67f-44c6-a086-285632508915',
   "City's Blessing": 'ba64ed3e-93c5-406f-a38d-65cc68472122',
-  Monarch: '40b79918-22a7-4fff-82a6-8ebfe6e87185',
-  Energy: 'a446b9f8-cb22-408a-93ff-bee44a0dccc0',
+  "The Monarch": '40b79918-22a7-4fff-82a6-8ebfe6e87185',
+  "Energy Reserve": 'a446b9f8-cb22-408a-93ff-bee44a0dccc0',
 };
 
 function arraySetEqual<T>(target: T[], candidate: T[]) {


### PR DESCRIPTION
Fixes #1221

I noticed a bug where if Scryfall lists both a "token" and other "special case" trackers in the card parts, the "special case" will get ignored by the token tracker.

For example, "Forth Eorlingas" has both "rebel" tokens and "Monarch" tracker, but the "Monarch" will get ignored because it will use the rebel token as the complete list and ignore the "special case" logic.

Also added the Day Night tracker to the special trackers list since it was missing.

Wanted to put together a quick PR since it looks like an easy fix; I haven't set up my local environment so not sure how to test it.