### PR TITLE
Fix playtest page error when not logged in

### DIFF
--- a/src/client/components/RenderToRoot.tsx
+++ b/src/client/components/RenderToRoot.tsx
@@ -35,7 +35,7 @@ const RenderToRoot = <P,>(Element: ComponentType<P>): ComponentType<P> => {
           <AutocardContextProvider>
             <AdsContext.Provider value={reactProps.nitroPayEnabled}>
               <DomainContext.Provider value={reactProps.domain}>
-                <UserContext.Provider value={reactProps.user}>
+                <UserContext.Provider value={reactProps.user || null}>
                   <Element {...reactProps} />
                 </UserContext.Provider>
               </DomainContext.Provider>

--- a/src/client/pages/CubeBlogPage.tsx
+++ b/src/client/pages/CubeBlogPage.tsx
@@ -33,7 +33,7 @@ const CubeBlogPage: React.FC<CubeBlogPageProps> = ({ cube, lastKey, posts, login
 
   return (
     <MainLayout loginCallback={loginCallback}>
-      <CubeLayout cube={cube} activeLink="blog" hasControls={user != null && cube.owner.id == user.id}>
+      <CubeLayout cube={cube} activeLink="blog" hasControls={!!user && cube.owner.id === user.id}>
         <Controls>
           <Flexbox direction="row" justify="start" gap="4" alignItems="center" className="py-2 px-4">
             <CreateBlogModalLink color="primary" modalprops={{ cubeID: cube.id, post: null }}>

--- a/src/client/pages/CubeOverviewPage.tsx
+++ b/src/client/pages/CubeOverviewPage.tsx
@@ -51,12 +51,7 @@ const CubeOverview: React.FC<CubeOverviewProps> = ({
 
   return (
     <MainLayout>
-      <CubeLayout
-        cards={cards}
-        cube={cube}
-        activeLink="overview"
-        hasControls={user != null && cube.owner.id == user.id}
-      >
+      <CubeLayout cards={cards} cube={cube} activeLink="overview" hasControls={!!user && cube.owner.id === user.id}>
         <Flexbox direction="col" gap="2" className="mb-2">
           {user && cube.owner.id === user.id && (
             <Controls>

--- a/src/client/pages/CubePlaytestPage.tsx
+++ b/src/client/pages/CubePlaytestPage.tsx
@@ -56,7 +56,7 @@ const CubePlaytestPage: React.FC<CubePlaytestPageProps> = ({ cube, decks, decksL
 
   return (
     <MainLayout loginCallback={loginCallback}>
-      <CubeLayout cube={cube} activeLink="playtest" hasControls={user !== null && cube.owner.id === user.id}>
+      <CubeLayout cube={cube} activeLink="playtest" hasControls={!!user && cube.owner.id === user.id}>
         <Flexbox direction="col" gap="2" className="mb-2">
           {user && cube.owner.id === user.id && (
             <Controls>


### PR DESCRIPTION
# Problem
Reported on Discord. The issue came because when not logged in the User in the UserContext is undefined, though it is typed as either User or null.

In most pages the difference between undefined and null doesn't matter as the check is non-strict like `bool = user` or `user != null` but in the playtest page was doing strict `user !== null`.

# Solution
1. Update the page to use a non-strict check. Followed other page examples and in this case did `!!user`
2. Updated the UserContext value from reactProps so that it defaults to null. Thus the type in UserContext is accurate now, and undefined shouldn't be possible

I check all the usages of UserContext in the React components to double check, which lead me to a couple other minor updates for null checks for consistency.

# Testing

## Before
Page error on playtest:
![old-playtest-page-fails-not-logged-in](https://github.com/user-attachments/assets/7d3c41ad-c8ff-4555-9c2b-22f4692a6b82)

Can see via React Dev tools that the user provider has undefined instead of the expected null:
![old-user-context-is-undefined-when-not-logged-in](https://github.com/user-attachments/assets/5510fa9e-3ce4-44fd-a489-f4e60ea7ff1b)

## After
Playtest page loads when not logged in:
![new-playtest-page-loads-not-logged-in](https://github.com/user-attachments/assets/d4e9aeac-8694-414e-8202-af12341a195e)

User context is null when not logged in:
![new-user-context-is-null-when-not-logged-in](https://github.com/user-attachments/assets/578654ba-25a4-4786-8a02-20d4d40df395)

In comparison the user context is an object when logged in:
![new-user-context-is-object-when-logged-in](https://github.com/user-attachments/assets/24490199-3cd0-4d9a-a86b-643cfbccd802)


