### PR TITLE
Fix split card image hover

### DIFF
--- a/src/client/components/base/AutocompleteInput.tsx
+++ b/src/client/components/base/AutocompleteInput.tsx
@@ -180,11 +180,13 @@ export const treeCache: Record<string, Promise<TreeNode | null>> = {};
 const fetchTree = async (treeUrl: string, treePath: string): Promise<TreeNode | null> => {
   const response = await fetch(treeUrl);
   if (!response.ok) {
+    // eslint-disable-next-line no-console
     console.error(`Failed to fetch autocomplete tree: ${response.status}`);
     return null;
   }
   const json = await response.json();
   if (json.success !== 'true') {
+    // eslint-disable-next-line no-console
     console.error('Error getting autocomplete tree.');
     return null;
   }
@@ -229,6 +231,7 @@ const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
         }
         setTree((await treeCache[treeUrl]) ?? {});
       } catch (e) {
+        // eslint-disable-next-line no-console
         console.error('Error getting autocomplete tree.', e);
       }
     };
@@ -323,7 +326,7 @@ const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
                   cubeId
                     ? `/tool/cardimageforcube/${encodeURIComponent(match)}/${cubeId}`
                     : `/tool/cardimage/${encodeURIComponent(match)}` +
-                    (defaultPrinting !== null ? `?defaultPrinting=${defaultPrinting}` : '')
+                      (defaultPrinting !== null ? `?defaultPrinting=${defaultPrinting}` : '')
                 }
                 key={index}
                 onClick={(e) => handleClickSuggestion(e)}

--- a/src/client/components/base/AutocompleteInput.tsx
+++ b/src/client/components/base/AutocompleteInput.tsx
@@ -321,9 +321,9 @@ const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
                 inModal
                 image={
                   cubeId
-                    ? `/tool/cardimageforcube/${match}/${cubeId}`
-                    : `/tool/cardimage/${match}` +
-                      (defaultPrinting !== null ? `?defaultPrinting=${defaultPrinting}` : '')
+                    ? `/tool/cardimageforcube/${encodeURIComponent(match)}/${cubeId}`
+                    : `/tool/cardimage/${encodeURIComponent(match)}` +
+                    (defaultPrinting !== null ? `?defaultPrinting=${defaultPrinting}` : '')
                 }
                 key={index}
                 onClick={(e) => handleClickSuggestion(e)}


### PR DESCRIPTION
# Problem
Card names containing slash cause only part of the name to get to the backend lookup of the image, resulting in a failed lookup of the card image (from scryfall).

# Solution
URL encode the card name, similar to how its done in other areas.

# Testin
## Before
![error-split-card-image](https://github.com/user-attachments/assets/cf692f0b-bc6a-4128-9616-eab79579b30a)
## After
![fixed-split-card-image](https://github.com/user-attachments/assets/dda89241-2840-4ec4-9d37-fc1d6201315e)
