### PR TITLE
Adjust plain name search grammar so that apostrophe and colons in names aren't rejected

### DIFF
--- a/nearley/values.ne
+++ b/nearley/values.ne
@@ -167,7 +167,7 @@ noQuoteStringValue ->
     | "and"i [^ \t\n"'\\=<>:] 
     | "o"i [^rR \t\n"'\\=<>:]
     | "or"i [^ \t\n"'\\=<>:]
-    ) [^ \t\n"'\\=<>:]:* {% ([startChars, chars]) => startChars.concat(chars).join('').toLowerCase() %}
+    ) [^ \t\n"\\=<>]:* {% ([startChars, chars]) => startChars.concat(chars).join('').toLowerCase() %}
 # "
 
 manaCostOpValue -> equalityOperator manaCostValue {% ([op, value]) => manaCostOperation(op, value) %}

--- a/src/client/generated/filtering/cardFilters.js
+++ b/src/client/generated/filtering/cardFilters.js
@@ -1364,7 +1364,7 @@ var grammar = {
     {"name": "noQuoteStringValue$subexpression$2$subexpression$5", "symbols": [/[oO]/, /[rR]/], "postprocess": function(d) {return d.join(""); }},
     {"name": "noQuoteStringValue$subexpression$2", "symbols": ["noQuoteStringValue$subexpression$2$subexpression$5", /[^ \t\n"'\\=<>:]/]},
     {"name": "noQuoteStringValue$ebnf$1", "symbols": []},
-    {"name": "noQuoteStringValue$ebnf$1", "symbols": ["noQuoteStringValue$ebnf$1", /[^ \t\n"'\\=<>:]/], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
+    {"name": "noQuoteStringValue$ebnf$1", "symbols": ["noQuoteStringValue$ebnf$1", /[^ \t\n"\\=<>]/], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
     {"name": "noQuoteStringValue", "symbols": ["noQuoteStringValue$subexpression$2", "noQuoteStringValue$ebnf$1"], "postprocess": ([startChars, chars]) => startChars.concat(chars).join('').toLowerCase()},
     {"name": "manaCostOpValue", "symbols": ["equalityOperator", "manaCostValue"], "postprocess": ([op, value]) => manaCostOperation(op, value)},
     {"name": "manaCostValue$ebnf$1", "symbols": ["manaSymbol"]},


### PR DESCRIPTION
This allows name searching, without needing quotes, for names like:
* Jace, Vryn's Prodigy
* Circle of Protection: Black

For the details of the grammar I referenced https://github.com/dekkerglen/CubeCobra/pull/1647. From that it looks pretty safe to me to remove the apostrophe and colon exclusions from the last part of noQuoteStringValue which is trying to match all the remaining text in the token, after and/or are past. @lunakv if you are still active I'd love to hear your thoughts on the change

# Testing

## Before

Searching using double or single quoted

Searching in cube:

![old-cop-1](https://github.com/user-attachments/assets/d48eb521-ce06-43cf-809c-294b5b7332ea)
![old-cop-fail](https://github.com/user-attachments/assets/a6a9bc78-a985-48cc-b7b0-c7c2f635a71f)


![old-jace-search1](https://github.com/user-attachments/assets/f1b4c489-834d-479b-b615-19c0d09d86c9)
![old-jace-search-fail](https://github.com/user-attachments/assets/d5a7cf46-49f8-4798-8209-4ac05e6ffc5f)
![old-jace-search2](https://github.com/user-attachments/assets/8fc867b5-9664-4756-a2d1-91f4c4a91c78)

Card search
![old-apostorphe-search-fail](https://github.com/user-attachments/assets/074d2357-4fd8-4bd0-995f-f5eef3fe01e9)
![old-cop-card-search](https://github.com/user-attachments/assets/27086309-8250-493b-8e2f-78070922063c)


## After

Now searching for cards with apostrophe and colon in their name works without quotes.

![new-cop-card-search](https://github.com/user-attachments/assets/275e59d5-7402-4abf-96e2-3ce34680bde5)
![new-apostorphe-search-fail](https://github.com/user-attachments/assets/84dd2b95-9369-44d9-a1c8-2df98833034c)
![new-cop](https://github.com/user-attachments/assets/0c137ca8-8192-4556-8375-a4a405bc0e20)
![new-jace](https://github.com/user-attachments/assets/457faa4c-4cd3-49be-9d00-fea1ddec102d)

## Additional testing
I gathered all the unique characters in card names using:
```
jq '.[]' cubecobra/private/names.json -r | awk '{for(i=1;i<=NF;i++)if(!a[$i]++)print $i}' FS=""  | sort
```
Then using scryfall I grabbed one or two cards whose name contains non-alphabetic characters giving me a list of:

- Jace, Vryn's Prodigy
- "Ach! Hans, Run!" (quotes literal)
- Busted!
- Minsc & Boo, Timeless Heroes
- Hazmat Suit (Used)
- +2 mace
- Jace, Wielder of Mysteries
- Abzan Kin-Guard
- Mr. Orfeo, the Boulder
- T-45 Power Armor
- Borrowing 100,000 Arrows
- Circle of Protection: Black
- TL;DR
- Question Elemental?
- _____ Goblin
- The Ultimate Nightmare of Wizards of the Coast® Customer Service
- Ratonhnhaké꞉ton

After the change of those only `Hazmat Suit (Used)` and `Ratonhnhaké꞉ton` don't work, see below.

# Some expressions that don't pass still

* `name:'Circle of protection: red'` - It parses correctly but returns 2 results from the filter parser, and the code only expects 1. Interestingly `name:"Circle of protection: red"` works
* `Hazmat Suit (Used)` - Similarly fails because of 2 results
* `n:Circle of protection: black` - Again 2 results
* `'Jace, Vryn's Prodigy'` - Fails to parse
* `Ratonhnhaké꞉ton` - They filter parses but the name_lower of Ratonhnhaké꞉ton replaced the é with e as part of the normalization (from update_cards using cardutil.normalizeName), so in the comparison function it doesn't match.