### PR TITLE
Tag color contrast between background and foreground

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,11 @@
+/* eslint-disable no-undef -- Jest is available globally in this setup file */
+
+//Mock the ML utility because when the file runs it tries to load all the models (which takes a while)
+jest.mock('src/util/ml', () => ({
+  recommend: jest.fn(),
+  build: jest.fn(),
+  draft: jest.fn(),
+  encode: jest.fn(),
+}));
+
 import '@testing-library/jest-dom';

--- a/public/css/tags.css
+++ b/public/css/tags.css
@@ -1,57 +1,69 @@
 .tag {
-	background-color: var(--header);
-	font-size: 85%;
-	padding: 0.5em .75em;
-	margin: .25em .1em;
-	display: inline-block;
-	border: 1px solid var(--border-light);
-	transition: all .1s linear;
+  background-color: var(--header);
+  font-size: 85%;
+  padding: 0.5em 0.75em;
+  margin: 0.25em 0.1em;
+  display: inline-block;
+  border: 1px solid var(--border-light);
+  transition: all 0.1s linear;
 }
 
 .tag-sort-placeholder {
   height: 44px;
-	background-color: var(--bg-hover);
+  background-color: var(--bg-hover);
   margin-left: -15px;
   margin-right: -15px;
 }
 
 .tag-sort-helper {
-	background-color: var(--bg);
-	border: 1px solid var(--border-light);
+  background-color: var(--bg);
+  border: 1px solid var(--border-light);
 }
 
-.tag-color,
-.tag-color .tdname,
-.tag-color > a {
-  color: var(--bg) !important;
-}
+/* In order to have WCAG 2.0 level AA contrast between the tag background and foreground colors,
+ * we must explicitly set the foreground color rather than based on light or dark theme. Used
+ * https://webaim.org/resources/contrastchecker/ to check contrast and found colors that fit well
+ * for the backgrounds, though had to make small color adjustments to some background to get passing
+ * grades. Targeted WCAG 2.0 level AAA which needs a 7.5 contrast ratio between text and background,
+ * compared to AA which is 4.5 ratio.
+ */
 .tag-red {
   background-color: #8e1600 !important;
+  color: #f0f0f0 !important;
 }
 .tag-brown {
   background-color: #654321 !important;
+  color: #f0f0f0 !important;
 }
 .tag-orange {
   background-color: #ff7034 !important;
+  color: #020202 !important;
 }
 .tag-yellow {
   background-color: #e0b83d !important;
+  color: #020202 !important;
 }
 .tag-green {
-  background-color: #228c22 !important;
+  background-color: #2cb52c !important;
+  color: #020202 !important;
 }
 .tag-turquoise {
-  background-color: #008081 !important;
+  background-color: #00adaf !important;
+  color: #020202 !important;
 }
 .tag-blue {
-  background-color: #115da8 !important;
+  background-color: #0e4d8b !important;
+  color: #f0f0f0 !important;
 }
 .tag-purple {
-  background-color: #663399 !important;
+  background-color: #633295 !important;
+  color: #f0f0f0 !important;
 }
 .tag-violet {
-  background-color: #b200ed !important;
+  background-color: #da6fff !important;
+  color: #020202 !important;
 }
 .tag-pink {
   background-color: #ff69b4 !important;
+  color: #020202 !important;
 }

--- a/src/client/components/WithAutocard.tsx
+++ b/src/client/components/WithAutocard.tsx
@@ -4,6 +4,8 @@ import AutocardContext from 'contexts/AutocardContext';
 import DisplayContext from 'contexts/DisplayContext';
 import Card from 'datatypes/Card';
 
+import TagColorContext from '../contexts/TagColorContext';
+
 export interface WithAutocardProps {
   card?: Card;
   image?: string;
@@ -16,11 +18,14 @@ const withAutocard = <T extends ElementType>(Tag: T) => {
     ({ card, image, inModal, ...props }, ref) => {
       const { showCustomImages } = useContext(DisplayContext);
       const { showCard, hideCard } = useContext(AutocardContext);
+      const tagColors = useContext(TagColorContext);
 
       return (
         <Tag
           ref={ref}
-          onMouseEnter={() => showCard(image ? { details: { image_normal: image } } : card, inModal, showCustomImages)}
+          onMouseEnter={() =>
+            showCard(image ? { details: { image_normal: image } } : card, inModal, showCustomImages, tagColors)
+          }
           onMouseLeave={() => hideCard()}
           {...(props as any)}
         />

--- a/src/client/components/blog/BlogPostChangelog.tsx
+++ b/src/client/components/blog/BlogPostChangelog.tsx
@@ -117,7 +117,7 @@ const BlogPostChangelog: React.FC<BlogPostChangelogProps> = ({ changelog }) => {
                 swaps.map((swap) => (
                   <Swap key={`${swap.oldCard.cardID}->${swap.card.cardID}`} oldCard={swap.oldCard} card={swap.card} />
                 ))}
-              {edits && edits.map((edit) => <Edit key={edit.oldCard.cardID} card={edit.oldCard} />)}
+              {edits && edits.map((edit) => <Edit key={edit.oldCard.cardID} card={edit.newCard} />)}
             </ul>
           </div>
         );

--- a/src/client/contexts/AutocardContext.tsx
+++ b/src/client/contexts/AutocardContext.tsx
@@ -3,8 +3,10 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { cardFinish, cardTags } from 'utils/cardutil';
 
 import Card from '../../datatypes/Card';
+import { TagColor } from '../../datatypes/Cube';
 import { Flexbox } from '../components/base/Layout';
 import Tag from '../components/base/Tag';
+import { getTagColorClass } from '../utils/Util';
 
 interface Tag {
   value: string;
@@ -98,7 +100,7 @@ const CardDiv: React.FC<CardDivProps> = ({ hidden, front, back, tags, zIndex, fo
 };
 
 export interface AutocardContextValue {
-  showCard: (card: any, inModal: boolean, showCustomImages: boolean) => void;
+  showCard: (card: any, inModal: boolean, showCustomImages: boolean, tagColors: TagColor[]) => void;
   hideCard: () => void;
   stopAutocard: boolean;
   setStopAutocard: React.Dispatch<React.SetStateAction<boolean>>;
@@ -121,7 +123,7 @@ export const AutocardContextProvider: React.FC<{ children: JSX.Element }> = ({ c
   const [zIndex, setZIndex] = useState(500);
 
   const showCard = useCallback(
-    (card: Card, inModal: boolean, showCustomImages: boolean) => {
+    (card: Card, inModal: boolean, showCustomImages: boolean, tagColors: TagColor[]) => {
       if (!stopAutocard) {
         setHidden(false);
         setFoilOverlay(cardFinish(card) === 'Foil');
@@ -130,7 +132,7 @@ export const AutocardContextProvider: React.FC<{ children: JSX.Element }> = ({ c
         setTags(
           cardTags(card).map((tag) => ({
             value: tag,
-            colorClass: '',
+            colorClass: getTagColorClass(tagColors, tag),
           })),
         );
         setZIndex(inModal ? 1500 : 500);

--- a/tests/cards/cardhistory.test.ts
+++ b/tests/cards/cardhistory.test.ts
@@ -1,5 +1,5 @@
 import CardHistory from '../../src/dynamo/models/cardhistory';
-import { getCardHistoryHandler, getZoomValue } from '../../src/router/routes/tool/cardHistory';
+import { getCardHistoryHandler, getZoomValue } from '../../src/router/routes/tool/cardhistory';
 import { Response } from '../../src/types/express';
 import { expectRegisteredRoutes } from '../test-utils/route';
 import { call } from '../test-utils/transport';


### PR DESCRIPTION
Fixes #2579

# Problem
Tag background colors did not contrast with the foreground text color well in many cases, with different colors matching poorly with the text depending on light or dark mode.

# Solution
In order to have good contrast, which I've defined as WCAG 2.0 level AAA ratio of 7.5 (which a site like https://webaim.org/resources/contrastchecker/ checks) we need to set the text color for each tag instead of depending on the theme text color. As well I had to adjust some of the background colors a bit to hit the 7.5 target.

A couple other improvements I tossed in:
1. The tags in the autocard hover now are colored basesd on the cube settings. Had to pass the TagColors of the cube through the WithAutocard component into the AutocardContext.showCard, given that AutocardContext provider is above the TagColor provider and thus would not have any tag colors initialized if it tried to use the provider.
2. In changelogs for edited cards, use the new card version instead of the old. **This makes sense to me but if it is not desired I can revert**

# Testing

## Before

Can see in light and dark themes that some of the text colors don't contrast well against the background colors:
![old-tag-colors-dark](https://github.com/user-attachments/assets/1e4fd581-96ca-493c-9b91-370ba6768af5)
![old-tag-colors-light](https://github.com/user-attachments/assets/5213aa66-f2e8-45c2-a883-e7cca05e5514)
In the list view:
![old-tag-colors-in-list-view-light](https://github.com/user-attachments/assets/d9cc937b-85a7-44a3-b3e6-2cfeef7abbcb)
![old-tag-colors-in-list-view-dark](https://github.com/user-attachments/assets/077f1abb-f193-4928-826a-044c4f74e146)

Can also see that in the autocard hover tags don't have a background color even though the card itself in the cube list does
![old-tag-colors-dont-show-in-autocard](https://github.com/user-attachments/assets/d9455514-c67c-4014-9049-aeda8caf0b0e)

In the changelog the cube shows the old version of a card. Here I added 4 tags to the card, then removed 2 of them. In the 2nd changelog it is showing the old version of the card with 4 tags when it makes more sense to show the updated state with 2 tags:
![old-changelog-edit-shows-old-version](https://github.com/user-attachments/assets/3202054f-1ed3-4efa-91d0-1b384cd9f559)

## After

Now can see the text color doesn't depend on the theme, but is chosen based on contrast to the background. In order to use only 2 text colors I had to modify slightly some of the background colors to hit the desired contrast ratio.
![new-tag-colors-light-mode](https://github.com/user-attachments/assets/e3b29f39-6ce9-4b17-aae2-2dcddb23c725)
![new-tag-colors-dark-mode](https://github.com/user-attachments/assets/0b0b11db-a4e3-4e40-bed5-f9901a8206a8)

In the table view:
![new-tag-colors-in-list-view](https://github.com/user-attachments/assets/ceba25a4-ecd1-4a28-952e-b623ba858d7d)
In the list view:
![new-tag-colors-in-table-view](https://github.com/user-attachments/assets/8525a273-2f9f-46ca-a270-dd5e7bb2062f)

### Tag colors in the autocard
![new-tag-color-in-autocard](https://github.com/user-attachments/assets/b7d87e76-5e1d-4f5b-bb30-a4785373662f)
![new-multiple-tags-in-autocard](https://github.com/user-attachments/assets/98ed6c03-2832-4bf3-a1e9-1267b2d9d48c)

### Changelog shows new version of edited card
Now in the latest changelog we see the card after 2 of the 4 tags were removed:
![new-autocard-in-changelog-shows-tags2](https://github.com/user-attachments/assets/e49b1351-41e9-4b7a-991b-b953c02bb7b2)

### Outside the cube cards page the autocard has no differences:
Cube tags:
![cube-tags-unchanged](https://github.com/user-attachments/assets/f90d1f04-2454-44b0-a463-89d140a47588)

Recommendations page
![new-autocard-outside-cube-list](https://github.com/user-attachments/assets/ca49cd8b-8264-4997-a3eb-24e508b83c18)
Autocomplete
![new-autocard-in-autocomplete](https://github.com/user-attachments/assets/bab951b2-6cfe-4fe4-bbbe-bf1da11f2b03)
Markdown
![autocard-in-markdown](https://github.com/user-attachments/assets/1e764fb1-aad9-4fbe-b181-81581e2ee0ef)
Card versions
![card-page-versions-autocard](https://github.com/user-attachments/assets/2381bb88-a3b4-4771-88fd-194046436b65)

