### PR TITLE
Fix Cube's default format on removal of custom formats

### DIFF
--- a/src/client/components/CustomDraftCard.tsx
+++ b/src/client/components/CustomDraftCard.tsx
@@ -18,13 +18,13 @@ const DeleteFormatButton = withModal(Button, ConfirmActionModal);
 
 interface CustomDraftCardProps {
   format: DraftFormat;
-  defaultDraftFormat: number;
+  defaultFormat: number;
   formatIndex: number;
 }
 
 const range = (lo: number, hi: number): number[] => Array.from(Array(hi - lo).keys()).map((n) => n + lo);
 
-const CustomDraftCard: React.FC<CustomDraftCardProps> = ({ format, defaultDraftFormat, formatIndex }) => {
+const CustomDraftCard: React.FC<CustomDraftCardProps> = ({ format, defaultFormat, formatIndex }) => {
   const { cube, canEdit } = useContext(CubeContext);
   const [seats, setSeats] = useState(format?.defaultSeats?.toString() || '8');
   const formRef = React.createRef<HTMLFormElement>();
@@ -42,7 +42,7 @@ const CustomDraftCard: React.FC<CustomDraftCardProps> = ({ format, defaultDraftF
       <CSRFForm method="POST" key="createDraft" action={`/draft/start/${cube.id}`} formData={formData} ref={formRef}>
         <CardHeader>
           <Text lg semibold>
-            {defaultDraftFormat === formatIndex && 'Default Format: '}
+            {defaultFormat === formatIndex && 'Default Format: '}
             {format.title} (Custom Draft)
           </Text>
         </CardHeader>
@@ -71,7 +71,7 @@ const CustomDraftCard: React.FC<CustomDraftCardProps> = ({ format, defaultDraftF
                 <EditFormatButton block modalprops={{ formatIndex }} color="accent" className="whitespace-nowrap">
                   <span className="whitespace-nowrap">Edit</span>
                 </EditFormatButton>
-                {defaultDraftFormat !== formatIndex && (
+                {defaultFormat !== formatIndex && (
                   <Button
                     block
                     color="accent"

--- a/src/client/components/StandardDraftCard.tsx
+++ b/src/client/components/StandardDraftCard.tsx
@@ -9,10 +9,10 @@ import Text from './base/Text';
 import CSRFForm from './CSRFForm';
 
 interface StandardDraftCardProps {
-  defaultDraftFormat: number;
+  defaultFormat: number;
 }
 
-const StandardDraftCard: React.FC<StandardDraftCardProps> = ({ defaultDraftFormat }) => {
+const StandardDraftCard: React.FC<StandardDraftCardProps> = ({ defaultFormat: defaultFormat }) => {
   const { cube, canEdit } = useContext(CubeContext);
   const [packs, setPacks] = useState('3');
   const [cards, setCards] = useState('15');
@@ -34,7 +34,7 @@ const StandardDraftCard: React.FC<StandardDraftCardProps> = ({ defaultDraftForma
       <CSRFForm method="POST" action={`/draft/start/${cube.id}`} formData={formData} ref={formRef}>
         <CardHeader>
           <Text lg semibold>
-            {defaultDraftFormat === -1 && 'Default Format: '}Standard Draft
+            {defaultFormat === -1 && 'Default Format: '}Standard Draft
           </Text>
         </CardHeader>
         <CardBody>
@@ -55,7 +55,7 @@ const StandardDraftCard: React.FC<StandardDraftCardProps> = ({ defaultDraftForma
             <Button block color="primary" onClick={() => formRef.current?.submit()}>
               Start Draft
             </Button>
-            {canEdit && defaultDraftFormat !== -1 && (
+            {canEdit && defaultFormat !== -1 && (
               <Button
                 block
                 color="accent"

--- a/src/client/drafting/createdraft.ts
+++ b/src/client/drafting/createdraft.ts
@@ -136,7 +136,11 @@ const createAsfanFn = (cards: Card[], duplicates: boolean = false): AsfanFn => {
 };
 
 export const getDraftFormat = (params: DraftParams, cube: Cube): DraftFormat => {
-  if (params.id >= 0) {
+  /* Even if there is an draft ID, ensure that it exists in the cube. Relates to a bug
+   * where deleting the custom draft format that was marked as default, didn't update the cube
+   * back to not having a default format.
+   */
+  if (params.id >= 0 && cube.formats.at(params.id)) {
     return cube.formats[params.id];
   }
   return createDefaultDraftFormat(params.packs, params.cards || 15);

--- a/src/client/pages/CubePlaytestPage.tsx
+++ b/src/client/pages/CubePlaytestPage.tsx
@@ -35,7 +35,7 @@ const CreateCustomFormatLink = withModal(Link, CustomDraftFormatModal);
 
 const CubePlaytestPage: React.FC<CubePlaytestPageProps> = ({ cube, decks, decksLastKey, loginCallback = '/' }) => {
   const user = useContext(UserContext);
-  const defaultDraftFormat = cube.defaultFormat ?? -1;
+  const defaultFormat = cube.defaultFormat ?? -1;
 
   // Sort formats alphabetically.
   const formatsSorted = useMemo(
@@ -43,15 +43,15 @@ const CubePlaytestPage: React.FC<CubePlaytestPageProps> = ({ cube, decks, decksL
       cube.formats
         .map((format, index) => ({ ...format, index }))
         .sort((a, b) => {
-          if (a.index === defaultDraftFormat) {
+          if (a.index === defaultFormat) {
             return -1;
           }
-          if (b.index === defaultDraftFormat) {
+          if (b.index === defaultFormat) {
             return 1;
           }
           return a.title.localeCompare(b.title);
         }),
-    [cube.formats, defaultDraftFormat],
+    [cube.formats, defaultFormat],
   );
 
   return (
@@ -77,16 +77,16 @@ const CubePlaytestPage: React.FC<CubePlaytestPageProps> = ({ cube, decks, decksL
             <Col xs={12} md={6} xl={6}>
               <Flexbox direction="col" gap="2">
                 <SamplePackCard />
-                {defaultDraftFormat === -1 && <StandardDraftCard defaultDraftFormat={defaultDraftFormat} />}
+                {defaultFormat === -1 && <StandardDraftCard defaultFormat={defaultFormat} />}
                 {formatsSorted.map((format) => (
                   <CustomDraftCard
                     key={format.index}
                     format={format}
-                    defaultDraftFormat={defaultDraftFormat}
+                    defaultFormat={defaultFormat}
                     formatIndex={format.index}
                   />
                 ))}
-                {defaultDraftFormat !== -1 && <StandardDraftCard defaultDraftFormat={defaultDraftFormat} />}
+                {defaultFormat !== -1 && <StandardDraftCard defaultFormat={defaultFormat} />}
                 <Card>
                   <CardHeader>
                     <Text semibold lg>

--- a/src/dynamo/models/cube.js
+++ b/src/dynamo/models/cube.js
@@ -384,7 +384,7 @@ const exportData = {
     [FIELDS.CATEGORY_OVERRIDE]: cube.overrideCategory ? cube.categoryOverride : null,
     [FIELDS.CATEGORY_PREFIXES]: cube.overrideCategory ? cube.categoryPrefixes : null,
     [FIELDS.TAG_COLORS]: cube.tag_colors.map((item) => ({ color: item.color, tag: item.tag })),
-    [FIELDS.DEFAULT_DRAFT_FORMAT]: cube.defaultDraftFormat,
+    [FIELDS.DEFAULT_DRAFT_FORMAT]: cube.defaultFormat,
     [FIELDS.NUM_DECKS]: cube.numDecks,
     [FIELDS.DESCRIPTION]: cube.description,
     [FIELDS.IMAGE_NAME]: cube.image_name,

--- a/src/routes/cube/index.js
+++ b/src/routes/cube/index.js
@@ -1464,9 +1464,13 @@ router.get('/format/remove/:cubeid/:index', ensureAuth, param('index').toInt(), 
 
     cube.formats.splice(index, 1);
     // update defaultFormat if necessary
-    if (index === cube.defaultDraftFormat) {
+    if (index === cube.defaultFormat) {
+      //When the current default format is deleted, revert to no default specified
       cube.defaultFormat = -1;
-    } else if (index < cube.defaultDraftFormat) {
+    } else if (index < cube.defaultFormat) {
+      /* If the format deleted isn't the default but is a custom format before it in the list, shift
+       * the default format index to keep the alignment
+       */
       cube.defaultFormat -= 1;
     }
 


### PR DESCRIPTION
# Problem
Deleting a custom draft format, which had been set as the cube's default, did not reset the cube's default format. Then the default format could point nothing causing failures in sample pack creation (which uses the cube's default draft format for pack creation).

# Solution
Typo in the cube property name, was "defaultDraftFormat" instead of "defaultFormat". A clear win for typescript as that would have been typed checked at development time.
A related improvement in getDraftFormat() is to check that the format specified exists in the cube's formats, otherwise use the standard draft format.
Lastly replaced all "defaultDraftFormat" with "defaultFormat" to have alignment. It is probable that "defaultDraftFormat" was read from the front-end components to use in the backend routes resulting in the mismatch.

# Testing

## Before

After setting a custom draft as the default format, can see from the react props formats is an array of length 1 and defaultFormat points to the 0th index of that array.
![old-default-format](https://github.com/user-attachments/assets/5b99263d-e652-40a6-82f2-49715d049c5d)
After deleting the default format we can see the formats array is empty but defaultFormat was still zero thus the mismatch.
![old-default-format-incorrect-after-deletion](https://github.com/user-attachments/assets/5709c929-9b47-44d2-b9c5-ad655dfd5dea)
Then trying to create the sample pack fails with error, since getDraftFormat() returns undefined instead of an object
![old-failed-to-samplepack-with-invalid-default-format](https://github.com/user-attachments/assets/35dc7349-39d1-4df2-bed6-79ca9209c955)

## After

Same as before, after setting a custom draft as the default format we see alignment between defaultFormat and the formats array.
![new-default-format](https://github.com/user-attachments/assets/e926d1c2-b451-4325-bbfc-4f3a7185bbcc)
After deleting the default format, we see defaultFormat reset to -1.
![new-default-format-after-deletion](https://github.com/user-attachments/assets/1746950d-1b23-41bb-97ae-9e18b231e41d)

In this case created 3 custom formats A, B, and C. Set B to the default.
![new-default-format-in-middle](https://github.com/user-attachments/assets/086bcbf9-2f6e-4738-9e2e-cea65e312b67)
Deleted format A, and the defaultFormat index correctly shifted in the new formats array.
![new-default-format-still-matches](https://github.com/user-attachments/assets/c66d33c9-5fb1-4c4d-a4e2-af3cfb7d9c70)

