### PR TITLE
Fix deck delete button

### DIFF
--- a/src/client/components/DeckPreview.tsx
+++ b/src/client/components/DeckPreview.tsx
@@ -57,7 +57,12 @@ const DeckPreview: React.FC<DeckPreviewProps> = ({ deck, nextURL }) => {
           </Text>
         </Flexbox>
         {canEdit && (
-          <DeleteModalButton color="secondary" outline modalprops={{ deck, cubeID: deck.cube, nextURL }}>
+          <DeleteModalButton
+            color="secondary"
+            outline
+            modalprops={{ deck, cubeID: deck.cube, nextURL }}
+            stopProgagation={true}
+          >
             <XIcon size={16} className="mx-1" />
           </DeleteModalButton>
         )}

--- a/src/client/components/WithModal.tsx
+++ b/src/client/components/WithModal.tsx
@@ -6,11 +6,13 @@ export interface WithModalProps<U> {
   className?: string;
   modalprops?: Omit<U, 'setOpen' | 'isOpen' | 'toggle'>;
   altClick?: () => void;
+  //Commonly would set stopProgagation to true if the button to open the modal lives within another clickable block like a row
+  stopProgagation?: boolean;
 }
 
 const withModal = <T extends ElementType, U>(Tag: T, ModalTag: ComponentType<U>) => {
   const Result: React.FC<WithModalProps<U> & ComponentProps<T>> = (allProps: WithModalProps<U> & ComponentProps<T>) => {
-    const { children, className, modalprops = {}, altClick } = allProps;
+    const { children, className, modalprops = {}, altClick, stopProgagation } = allProps;
     const [isOpen, setIsOpen] = useState(false);
     const toggle = useCallback(
       (event?: MouseEvent<HTMLElement>) => {
@@ -29,10 +31,14 @@ const withModal = <T extends ElementType, U>(Tag: T, ModalTag: ComponentType<U>)
           return altClick();
         }
 
+        if (stopProgagation) {
+          event.stopPropagation();
+        }
+
         event.preventDefault();
         return toggle();
       },
-      [altClick, toggle],
+      [altClick, stopProgagation, toggle],
     );
 
     return (

--- a/src/client/components/base/Button.tsx
+++ b/src/client/components/base/Button.tsx
@@ -38,20 +38,20 @@ const Button: React.FC<ButtonProps> = ({
       'text-button-text': ['primary', 'danger', 'accent', 'secondary'].includes(color) && !outline,
       'text-button-text-secondary': !['primary', 'danger', 'accent', 'secondary'].includes(color) && !outline,
       'text-button-primary bg-transparent border border-button-primary hover:bg-button-primary hover:text-button-text':
-        outline && color == 'primary',
+        outline && color === 'primary',
       'bg-button-primary border-button-primary hover:bg-button-primary-active hover:border-button-primary-active':
-        !outline && color == 'primary',
+        !outline && color === 'primary',
       'text-button-danger bg-transparent border border-button-danger hover:bg-button-danger hover:text-button-text':
-        outline && color == 'danger',
+        outline && color === 'danger',
       'bg-button-danger border-button-danger hover:bg-button-danger-active hover:border-button-danger-active':
-        !outline && color == 'danger',
+        !outline && color === 'danger',
       'text-button-accent bg-transparent border border-button-accent hover:bg-button-accent hover:text-button-text':
-        outline && color == 'accent',
+        outline && color === 'accent',
       'bg-button-accent border-button-accent hover:bg-button-accent-active hover:border-button-accent-active':
-        !outline && color == 'accent',
+        !outline && color === 'accent',
       'text-button-secondary bg-transparent border border-button-secondary hover:bg-button-secondary hover:text-button-text':
-        outline && color == 'secondary',
-      'bg-button-secondary border-button-secondary hover:bg-button-secondary-active': !outline && color == 'secondary',
+        outline && color === 'secondary',
+      'bg-button-secondary border-button-secondary hover:bg-button-secondary-active': !outline && color === 'secondary',
       'opacity-50 cursor-not-allowed': disabled,
       'focus:ring-2 focus:ring-focus-ring focus:ring-opacity-50 focus:border-focus-ring': true,
       'w-full': block,
@@ -71,7 +71,6 @@ const Button: React.FC<ButtonProps> = ({
     <button
       className={classes}
       onClick={(e) => {
-        type !== 'submit' && e.preventDefault();
         if (onClick) {
           onClick(e);
         }


### PR DESCRIPTION
# Problem
Clicking button to delete deck navigates to the deck before you can take action in the modal

# Solution
Prevent the click event on the delete button from triggering the row click action

# Testing

## Before
![old-deleting-deck-opens-modal-then-leaves](https://github.com/user-attachments/assets/0040ab19-047a-4c80-96f5-468875316ce9)

## After
![new-deleting-deck-opens-modal-without-leaving](https://github.com/user-attachments/assets/26b81b98-8460-4455-861c-a1fdad393f7a)
