### PR TITLE
Application level HTTP to HTTPS redirection

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -218,13 +218,16 @@ app.post('/healthcheck', (req, res) => {
 app.use((req, res, next) => {
   if (req.user && req.user.roles.includes('Banned')) {
     req.session.destroy(() => {
-      req.flash('danger', 'Your account has been banned, please contact CubeCobra staff if you believe this is in error.');
+      req.flash(
+        'danger',
+        'Your account has been banned, please contact CubeCobra staff if you believe this is in error.',
+      );
       return res.redirect('/');
     });
   }
 
   next();
-}); 
+});
 
 app.use(router);
 

--- a/src/app.js
+++ b/src/app.js
@@ -32,6 +32,22 @@ const app = express();
 // gzip middleware
 app.use(compression());
 
+//If this isn't a local developer environment, improve security by only allowing HTTPS
+if (process.env?.NODE_ENV !== 'development') {
+  app.use((req, res) => {
+    //Tell the browser to automatically use HTTPS in the future (for next 1 year)
+    res.setHeader('Strict-Transport-Security', 'max-age=31536000');
+    //Redirect to HTTPS for security
+    if (req.headers['x-forwarded-proto'] !== 'https') {
+      /* Use DOMAIN environment variable instead of relying on req.headers.host.
+       * That protects us from uncontrolled redirects to another domain, which is a type of
+       * HTTP Host header attack (see https://portswigger.net/web-security/host-header#how-to-prevent-http-host-header-attacks)
+       */
+      res.redirect('https://' + process.env.DOMAIN + req.url);
+    }
+  });
+}
+
 // request timeout middleware
 app.use((req, res, next) => {
   req.setTimeout(60 * 1000, () => {

--- a/src/app.js
+++ b/src/app.js
@@ -34,16 +34,18 @@ app.use(compression());
 
 //If this isn't a local developer environment, improve security by only allowing HTTPS
 if (process.env?.NODE_ENV !== 'development') {
-  app.use((req, res) => {
-    //Tell the browser to automatically use HTTPS in the future (for next 1 year)
-    res.setHeader('Strict-Transport-Security', 'max-age=31536000');
-    //Redirect to HTTPS for security
+  app.use((req, res, next) => {
+    //Redirect to HTTPS for security, assuming the AWS ALB isn't forwarding the HTTPS request along
     if (req.headers['x-forwarded-proto'] !== 'https') {
       /* Use DOMAIN environment variable instead of relying on req.headers.host.
        * That protects us from uncontrolled redirects to another domain, which is a type of
        * HTTP Host header attack (see https://portswigger.net/web-security/host-header#how-to-prevent-http-host-header-attacks)
        */
       res.redirect('https://' + process.env.DOMAIN + req.url);
+    } else {
+      //If the request has good security, tell the browser to automatically use HTTPS in the future (for next 1 year)
+      res.setHeader('Strict-Transport-Security', 'max-age=31536000');
+      next();
     }
   });
 }


### PR DESCRIPTION
Tweaked the code @dekkerglen provided in a couple ways:
1) Inverted the NODE_ENV check because NODE_ENV isn't currently set in production, and we want the redirect to apply now and after NODE_ENV gets set to "production"
2) For security prevent some HTTP Host headers attacks by using `process.env.domain` instead of `req.headers.host` to construct the https absolute URL for redirection
    1) I remember having this issue at my last job from a pen test report (with an ALB actually)
    2) The recommended solutions are to either ignore requests where the host isn't expected, or code-in which domain to redirect to
    3) Choose the latter

# Testing
1. Set my local to NODE_ENV=production and go to http://localhost:8080/.... See browser redirect to https://
![image](https://github.com/user-attachments/assets/eddb31b1-61b3-4f41-82f7-579c51f0bda5)
No Strict-Transport-Security header set since that isn't supposed to be part of an HTTP response.

2. Set my local to NODE_ENV=production and make a request with `x-forwarded-for: https` header, as if the request was sent from AWS ALB
```
//Pretending to be AWS ALB forwarding and HTTP request
curl -H 'x-forwarded-proto: https' -vvv http://localhost:5000/landing
* Host localhost:5000 was resolved.
....
< HTTP/1.1 200 OK
< X-Powered-By: Express
< Strict-Transport-Security: max-age=31536000
< Content-Type: text/html; charset=utf-8
< Content-Length: 94569
< ETag: W/"17169-lvwIC2mbH6F6CbwZyunfEGziLug"
< Set-Cookie: connect.sid=s%3AdZuHBtYnBQrMfZ9tkhthBCqYW63qPCWW.2nUPNRjSAEqjmsrPMHw3nwxGe3fxGlMSnCIbqcnRgqw; Path=/; Expires=Mon, 02 Feb 2026 19:22:56 GMT; HttpOnly
< Vary: Accept-Encoding
< Date: Mon, 03 Feb 2025 19:22:56 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
```
Here we can see Strict-Transport-Security is active.

4. Set my local to NODE_ENV=development and go to http://localhost:8080/...., no redirect (page loads)
![http-response-headers](https://github.com/user-attachments/assets/99de7bc3-b8f8-4e4f-a5de-cb9b44576d7d)

5. Remove NODE_ENV from my env/docker and go to http://localhost:8080/...., same effect as test case 1 (redirect to https)

# Security

When using `req.headers.host` in the creation of the absolute redirect URL an attacker can override the host header to make the redirect go anywhere.

Note: To accurately test this I had to bypass webpack dev server and make requests straight to node (which requires changing the bind from 127.0.0.1 to 0.0.0.0 but that is minor).

A normal request and response, which redirects to https://localhost
```
curl -vvv http://localhost:5000/landing -o foobar
* Host localhost:5000 was resolved.
...
< HTTP/1.1 302 Found
< X-Powered-By: Express
< Strict-Transport-Security: max-age=31536000
< Location: https://localhost:5000/landing
< Vary: Accept, Accept-Encoding
< Content-Type: text/plain; charset=utf-8
< Content-Length: 52
< Date: Mon, 03 Feb 2025 18:39:08 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
```

But if an attacker overrides the host header like below, the user will be redirected away. To be honest I don't recall exactly how an attacker can craft this in order to mess with a person using CubeCobra, but then again since the prevention is easy by using the environment variables its just good to do.
```
curl --header 'Host: evilcorp.com' -vvv http://localhost:5000/landing -o foobar
* Host localhost:5000 was resolved.
...
< HTTP/1.1 302 Found
< X-Powered-By: Express
< Strict-Transport-Security: max-age=31536000
< Location: https://evilcorp.com/landing
< Vary: Accept, Accept-Encoding
< Content-Type: text/plain; charset=utf-8
< Content-Length: 50
< Date: Mon, 03 Feb 2025 18:39:54 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
```