### PR TITLE
Fix duplicate card removals that also remove unintended cards

### DIFF
--- a/src/client/contexts/CubeContext.tsx
+++ b/src/client/contexts/CubeContext.tsx
@@ -848,10 +848,16 @@ export function CubeContextProvider({
         if (!newChanges[remove.board]) {
           newChanges[remove.board] = { adds: [], removes: [], swaps: [], edits: [] };
         }
-        newChanges[remove.board]?.removes?.push({
-          index: remove.index,
-          oldCard: cube.cards[remove.board][remove.index],
-        });
+
+        const removes = newChanges[remove.board]?.removes || [];
+        const removeIndex = removes.findIndex((e) => e.index === remove.index);
+        //Don't add the same card to the removals list
+        if (removeIndex === -1 && removes) {
+          newChanges[remove.board]?.removes?.push({
+            index: remove.index,
+            oldCard: cube.cards[remove.board][remove.index],
+          });
+        }
       }
 
       setChanges(newChanges);

--- a/src/client/contexts/CubeContext.tsx
+++ b/src/client/contexts/CubeContext.tsx
@@ -534,9 +534,14 @@ export function CubeContextProvider({
             // @ts-expect-error ts is incorrectly erroring here
             newChanges[card.board].removes = [];
           }
+
+          //Instead of defaulting findIndex to -1 using `... || -1`, default the removes to an empty array.
+          //If the found index was 0, that is falsey so `... || -1` would trigger and the card wouldn't be found
+          const edits = newChanges[card.board]?.edits || [];
+
           // if this card has been edited, remove the edit
-          const editIndex = newChanges[card.board]?.edits?.findIndex((e) => e.index === card.index) || -1;
-          if (editIndex !== -1) {
+          const editIndex = edits.findIndex((e) => e.index === card.index);
+          if (editIndex !== -1 && edits) {
             newChanges[card.board]?.edits?.splice(editIndex, 1);
           }
 
@@ -792,9 +797,10 @@ export function CubeContextProvider({
           };
           delete newCard.details;
 
-          // if this card has already been edited, overwrite the edit
-          const index = newChanges[edit.board]?.edits?.findIndex((e) => e.index === edit.index) || -1;
           const edits = newChanges[edit.board]?.edits || [];
+
+          // if this card has already been edited, overwrite the edit
+          const index = edits.findIndex((e) => e.index === edit.index);
           if (index !== -1 && edits) {
             edits[index].newCard = newCard;
           } else {
@@ -813,8 +819,9 @@ export function CubeContextProvider({
       const newChanges = deepCopy(changes);
 
       for (const edit of list) {
-        const editIndex = newChanges[edit.board]?.edits?.findIndex((e) => e.index === edit.index) || -1;
-        if (editIndex !== -1) {
+        const edits = newChanges[edit.board]?.edits || [];
+        const editIndex = edits.findIndex((e) => e.index === edit.index);
+        if (editIndex !== -1 && edits) {
           newChanges[edit.board]?.edits?.splice(editIndex, 1);
         }
       }
@@ -831,8 +838,9 @@ export function CubeContextProvider({
       for (const remove of list) {
         // if this card has been edited, remove the edit
         if (newChanges[remove.board]?.edits) {
-          const editIndex = newChanges[remove.board]?.edits?.findIndex((e) => e.index === remove.index) || -1;
-          if (editIndex !== -1) {
+          const edits = newChanges[remove.board]?.edits || [];
+          const editIndex = edits.findIndex((e) => e.index === remove.index);
+          if (editIndex !== -1 && edits) {
             newChanges[remove.board]?.edits?.splice(editIndex, 1);
           }
         }
@@ -857,8 +865,9 @@ export function CubeContextProvider({
       const newChanges = deepCopy(changes);
 
       for (const remove of list) {
-        const removeIndex = newChanges[remove.board]?.removes?.findIndex((e) => e.index === remove.index) || -1;
-        if (removeIndex !== -1) {
+        const removes = newChanges[remove.board]?.removes || [];
+        const removeIndex = removes.findIndex((e) => e.index === remove.index);
+        if (removeIndex !== -1 && removes) {
           newChanges[remove.board]?.removes?.splice(removeIndex, 1);
         }
       }

--- a/src/client/pages/CubeListPage.tsx
+++ b/src/client/pages/CubeListPage.tsx
@@ -78,7 +78,7 @@ const CubeListPageRaw: React.FC = () => {
                   {boardcards.length === 0 &&
                     (cardFilter ? (
                       <Text semibold md>
-                        No {boardname == 'mainboard' ? 'Mainboard' : 'Maybeboard'} cards match filter.
+                        No {boardname === 'mainboard' ? 'Mainboard' : 'Maybeboard'} cards match filter.
                       </Text>
                     ) : (
                       <Text semibold md>

--- a/src/datatypes/Card.ts
+++ b/src/datatypes/Card.ts
@@ -144,11 +144,16 @@ export type FilterValues = {
 export const boardTypes = ['mainboard', 'maybeboard'] as const;
 export type BoardType = (typeof boardTypes)[number];
 
+export type CubeCardChange = { index: number; oldCard: Card };
+export type CubeCardRemove = CubeCardChange;
+export type CubeCardSwap = CubeCardChange & { card: Card };
+export type CubeCardEdit = CubeCardChange & { newCard: Card };
+
 export type BoardChanges = {
   adds?: Card[];
-  removes?: { index: number; oldCard: Card }[];
-  swaps?: { index: number; card: Card; oldCard: Card }[];
-  edits?: { index: number; newCard: Card; oldCard: Card }[];
+  removes?: CubeCardRemove[];
+  swaps?: CubeCardSwap[];
+  edits?: CubeCardEdit[];
 };
 
 export interface Changes {


### PR DESCRIPTION
Fixes #2482

# Problem
Bulk removal of a group does not check whether the card is already in the removal set, nor if it is in the edits/swaps. If the same card (by the cube index not card name) is in the removal set multiple times then when the backend removes the cards (which it does in decreasing index order to keep the indexes accurate) it will remove the card in question, and then whatever card was after it because that card now has the same index.

# Solution
Added to the bulk removal a check if the card already in the removal set by card index. Also check if the card is in the edits or swaps sets, and if so then remove from there as well. That aligns the bulk remove behaviour with single card remove.

## Thoughts
* Should we make the logic exact by having single remove/add/edit call the bulk versions of the action?
* There are some cases not handled such as if stage swapping card A for B and then edit A. Currently both the swap and edit are in the changelist. Do we want to define all these cases better or leave it?
* Should the frontend/backend be updated to construct Sets of the add, remove, edit, swap changes? That would (in theory) also have prevented the original problem

# Testing

## Before

Edit a card and then bulk remove the group, the edited card stays alongside it being removed:
![old-edit-card-then-bulk-remove-has-duplicates](https://github.com/user-attachments/assets/f1cd81da-c03c-4cab-b404-20a9dd9220b5)

Reverting a bulk removal leaves the first card in the changest still being removed:
![old-revert-bulk-removal-leaves-one](https://github.com/user-attachments/assets/8f77e07d-47cb-402b-a651-d70396ee195a)

Delete a card and then bulk remove the group, the card is listed twice in the removes:
![old-delete-card-then-bulk-remove-has-duplicates](https://github.com/user-attachments/assets/f3c4fd3a-23a5-4aa2-8f30-1d78ae3375b7)

### Original case reproduction
Here I have a cube with 3 red cards in the list and after those cards are Railway Brawler and then Fabled Passage.
![cube-cards-order](https://github.com/user-attachments/assets/0028408a-750a-4c08-a6c8-4c6f066d0aba)

When I delete lightning bolt and then the red cards group and save, you can see that Railway Brawler also was removed.
![old-removed-with-duplicate-also-removed-railway-brawler](https://github.com/user-attachments/assets/b8280d84-ee56-4f50-be0f-baf38281d492)

Then after a page reload can see the cards list again without Railway Brawler:
![cube-cards-order-after-reload](https://github.com/user-attachments/assets/5230d889-d391-44e3-b245-f5e0c059605b)


## After

Edit a card and then bulk remove the group, edit is replaced by remove:
![new-edit-card-then-bulk-remove-no-duplicates](https://github.com/user-attachments/assets/1584044b-635a-4e00-ae8a-cd55ed572836)

Reverting a bulk removal leaves clean slate:
![new-bulk-remove-revert-clean-slate](https://github.com/user-attachments/assets/3b627d44-8277-4563-bc5c-d1b9d3466a6b)

Delete a card and then bulk remove the group, the card is listed once:
![new-delete-card-then-bulk-remove-no-duplicates](https://github.com/user-attachments/assets/edc54d3d-8d56-4b26-85ec-7272cc1e77d1)

