### PR TITLE
Ignore ALB health checks in the redirect from HTTP to HTTPS logic.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -35,8 +35,9 @@ app.use(compression());
 //If this isn't a local developer environment, improve security by only allowing HTTPS
 if (process.env?.NODE_ENV !== 'development') {
   app.use((req, res, next) => {
-    //Redirect to HTTPS for security, assuming the AWS ALB isn't forwarding the HTTPS request along
-    if (req.headers['x-forwarded-proto'] !== 'https') {
+    //Redirect to HTTPS for security, assuming the AWS ALB isn't forwarding the HTTPS request along nor is it the ALB health check request
+    const userAgent = req.get('User-Agent') || '';
+    if (req.headers['x-forwarded-proto'] !== 'https' && !userAgent.includes('ELB-HealthChecker')) {
       /* Use DOMAIN environment variable instead of relying on req.headers.host.
        * That protects us from uncontrolled redirects to another domain, which is a type of
        * HTTP Host header attack (see https://portswigger.net/web-security/host-header#how-to-prevent-http-host-header-attacks)


### PR DESCRIPTION
Additional testing locally showed me that moving the health check above this middleware did not prevent the http->https logic from occurring. So in order for the health check to return a response instead of a location redirect we must ignore the health check user agent as well as x-forward-proto.

# Testing

## Before

Code as is:
`curl -vvv http://localhost:5000/landing` -> redirect to https
`curl -H 'x-forwarded-proto: https' -vvv http://localhost:5000/landing` -> html response
`curl -H 'User-agent: ELB-HealthChecker/2.0' -vvv http://localhost:5000/landing` -> Redirect to https

With healthcheck above this middleware: Same

## After

`curl -vvv http://localhost:5000/landing` -> redirect to https
`curl -H 'x-forwarded-proto: https' -vvv http://localhost:5000/landing` -> html response
`curl -H 'User-agent: ELB-HealthChecker/2.0' -vvv http://localhost:5000/landing` -> html response