### PR TITLE
Fix another set of cycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ This will, in sequence:
 
 # Concepts
 
+More documentation on specific areas is found within the [docs](./docs) sub-folder.
+
 ## Backend
 
 ### API & Template Rendering

--- a/docs/dev-tools.md
+++ b/docs/dev-tools.md
@@ -1,0 +1,27 @@
+# Useful tools to help in the development/debugging processes
+
+## Finding cycles in JS imports
+
+Cycles in JS imports (or requires) can result in unexpected "<function> is undefined" errors at runtime, which
+[this article on circular dependencies](https://medium.com/visual-development/how-to-fix-nasty-circular-dependency-issues-once-and-for-all-in-javascript-typescript-a04c987cf0de) illustrates.
+
+A useful tool for finding those cycles is [dpdm](https://github.com/acrazing/dpdm)! It's command line takes an entry file and walks through the import tree to detect and print cycles.
+
+The straightforward command to run is `dpdm --transform --no-warning --no-tree src/app.js` which starts from src/app.js to detect cycles. The options mean:
+
+- `--transform`: Transforms Typescript to JS before analyzing, which omits type dependencies in the output
+- `--no-warning`: Doesn't print warnings, which tend to be what was skipped
+- `--no-tree`: Doesn't print the full import tree (graph)
+
+Example output when it detects cycles looks like:
+
+```
+✔ [76/76] Analyze done!
+• Circular Dependencies
+  1) src/client/utils/cardutil.ts -> src/client/utils/Util.ts
+  2) src/util/render.js -> src/util/util.js
+```
+
+These are simple cases where file A and B both import from each other. In worse cases you'd see more files in the `->` lists such as `A -> B -> C -> D` indicating at A and D are cyclic through other files.
+
+Fixing circular dependencies is often as easy as refactoring functions into their own smaller files.

--- a/src/client/components/base/CardList.tsx
+++ b/src/client/components/base/CardList.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 
 import classNames from 'classnames';
 
-import { cardId, cardName } from 'utils/cardutil';
-import { getCardColorClass } from 'utils/Util';
+import { cardId, cardName, getCardColorClass } from 'utils/cardutil';
 
 import CardType from '../../../datatypes/Card';
 import withAutocard from '../WithAutocard';

--- a/src/client/components/card/AutocardListItem.tsx
+++ b/src/client/components/card/AutocardListItem.tsx
@@ -4,7 +4,7 @@ import cx from 'classnames';
 import emojiRegex from 'emoji-regex';
 
 import DisplayContext from 'contexts/DisplayContext';
-import { getCardTagColorClass } from 'utils/Util';
+import { getCardTagColorClass } from 'utils/cardutil';
 
 import Card from '../../../datatypes/Card';
 import TagColorContext from '../../contexts/TagColorContext';

--- a/src/client/utils/Util.ts
+++ b/src/client/utils/Util.ts
@@ -1,9 +1,3 @@
-import Card from 'datatypes/Card';
-import { ColorCategory } from 'datatypes/Card';
-import { TagColor } from 'datatypes/Cube';
-
-import { cardCmc, cardColorIdentityCategory, cardType } from './cardutil';
-
 export function arraysEqual(a: any, b: any): boolean {
   if (a === b) return true;
   if (!Array.isArray(a) || !Array.isArray(b)) return false;
@@ -97,45 +91,6 @@ export function alphaCompare(a: { details: { name: string } }, b: { details: { n
   const textA = a.details.name.toUpperCase();
   const textB = b.details.name.toUpperCase();
   return textA.localeCompare(textB);
-}
-
-export function cmcColumn(card: Card): number {
-  const cmc = cardCmc(card);
-  // Round to half-integer then take ceiling to support Little Girl
-  const cmcDoubleInt = Math.round(cmc * 2);
-  let cmcInt = Math.round((cmcDoubleInt + (cmcDoubleInt % 2)) / 2);
-  if (cmcInt < 0) {
-    cmcInt = 0;
-  }
-  if (cmcInt > 7) {
-    cmcInt = 7;
-  }
-  return cmcInt;
-}
-
-function sortInto(card: Card, result: Card[][][]) {
-  const typeLine = cardType(card).toLowerCase();
-  const row = typeLine.includes('creature') ? 0 : 1;
-  const column = cmcColumn(card);
-  if (result[row][column].length === 0) {
-    result[row][column] = [card];
-  } else {
-    result[row][column].push(card);
-  }
-}
-
-export function sortDeck(deck: (any | any[])[]): any[][] {
-  const result = [new Array(8).fill([]), new Array(8).fill([])];
-  for (const item of deck) {
-    if (Array.isArray(item)) {
-      for (const card of item) {
-        sortInto(card, result);
-      }
-    } else {
-      sortInto(item, result);
-    }
-  }
-  return result;
 }
 
 export const COLORS: [string, string][] = [
@@ -234,36 +189,6 @@ export function isSamePageURL(to: string): boolean {
   }
 }
 
-const colorToColorClass: { [key in ColorCategory]: string } = {
-  White: 'white',
-  Blue: 'blue',
-  Black: 'black',
-  Red: 'red',
-  Green: 'green',
-  Colorless: 'colorless',
-  Multicolored: 'multi',
-  Hybrid: 'multi',
-  Lands: 'lands',
-};
-
-export function getCardColorClass(card: Card): string {
-  if (!card) {
-    return 'colorless';
-  }
-
-  return colorToColorClass[cardColorIdentityCategory(card)];
-}
-
-export function getCardTagColorClass(tagColors: TagColor[], card: Card): string {
-  if (tagColors) {
-    const tagColor = tagColors.find(({ tag }) => (card.tags || []).includes(tag));
-    if (tagColor && tagColor.color && tagColor.color !== 'no-color' && tagColor.color !== 'None') {
-      return `tag-color tag-${tagColor.color}`;
-    }
-  }
-  return getCardColorClass(card);
-}
-
 export function getTagColorClass(tagColors: { tag: string; color: string | null }[], tag: string): string {
   const tagColor = tagColors.find((tagColorB) => tag === tagColorB.tag);
   if (tagColor && tagColor.color && tagColor.color !== 'no-color') {
@@ -311,16 +236,12 @@ export default {
   randomElement,
   fromEntries,
   alphaCompare,
-  cmcColumn,
-  sortDeck,
   COLORS,
   getCubeId,
   getCubeDescription,
   isInternalURL,
   toNullableInt,
   isSamePageURL,
-  getCardColorClass,
-  getCardTagColorClass,
   getTagColorClass,
   wait,
   xorStrings,

--- a/src/client/utils/cardutil.ts
+++ b/src/client/utils/cardutil.ts
@@ -1,3 +1,5 @@
+import { TagColor } from 'datatypes/Cube';
+
 import Card, {
   CardDetails as CardDetailsType,
   COLOR_CATEGORIES,
@@ -591,6 +593,77 @@ export const makeSubtitle = (cards: any[]): string => {
   );
 };
 
+export function cmcColumn(card: Card): number {
+  const cmc = cardCmc(card);
+  // Round to half-integer then take ceiling to support Little Girl
+  const cmcDoubleInt = Math.round(cmc * 2);
+  let cmcInt = Math.round((cmcDoubleInt + (cmcDoubleInt % 2)) / 2);
+  if (cmcInt < 0) {
+    cmcInt = 0;
+  }
+  if (cmcInt > 7) {
+    cmcInt = 7;
+  }
+  return cmcInt;
+}
+
+export function sortInto(card: Card, result: Card[][][]) {
+  const typeLine = cardType(card).toLowerCase();
+  const row = typeLine.includes('creature') ? 0 : 1;
+  const column = cmcColumn(card);
+  if (result[row][column].length === 0) {
+    result[row][column] = [card];
+  } else {
+    result[row][column].push(card);
+  }
+}
+
+export function sortDeck(deck: (any | any[])[]): any[][] {
+  const result = [new Array(8).fill([]), new Array(8).fill([])];
+  for (const item of deck) {
+    if (Array.isArray(item)) {
+      for (const card of item) {
+        sortInto(card, result);
+      }
+    } else {
+      sortInto(item, result);
+    }
+  }
+  return result;
+}
+
+export const colorToColorClass: {
+  [key in ColorCategory]: string;
+} = {
+  White: 'white',
+  Blue: 'blue',
+  Black: 'black',
+  Red: 'red',
+  Green: 'green',
+  Colorless: 'colorless',
+  Multicolored: 'multi',
+  Hybrid: 'multi',
+  Lands: 'lands',
+};
+
+export function getCardColorClass(card: Card): string {
+  if (!card) {
+    return 'colorless';
+  }
+
+  return colorToColorClass[cardColorIdentityCategory(card)];
+}
+
+export function getCardTagColorClass(tagColors: TagColor[], card: Card): string {
+  if (tagColors) {
+    const tagColor = tagColors.find(({ tag }) => (card.tags || []).includes(tag));
+    if (tagColor && tagColor.color && tagColor.color !== 'no-color' && tagColor.color !== 'None') {
+      return `tag-color tag-${tagColor.color}`;
+    }
+  }
+  return getCardColorClass(card);
+}
+
 export default {
   cardTags,
   cardFinish,
@@ -650,4 +723,9 @@ export default {
   decodeName,
   cardsAreEquivalent,
   makeSubtitle,
+  cmcColumn,
+  sortInto,
+  sortDeck,
+  getCardColorClass,
+  getCardTagColorClass,
 };

--- a/src/router/routes/comment.ts
+++ b/src/router/routes/comment.ts
@@ -13,7 +13,7 @@ import { Request, Response } from '../../types/express';
 import { getImageData } from '../../util/imageutil';
 import util from '../../util/util';
 
-const { redirect, render } = require('../../util/render');
+const { handleRouteError, redirect, render } = require('../../util/render');
 
 export const getHandler = async (req: Request, res: Response) => {
   try {
@@ -26,7 +26,7 @@ export const getHandler = async (req: Request, res: Response) => {
 
     return render(req, res, 'CommentPage', { comment }, { title: 'Comment' });
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 };
 
@@ -51,7 +51,7 @@ export const reportHandler = async (req: Request, res: Response) => {
 
     return redirect(req, res, `/comment/${commentid}`);
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 };
 
@@ -66,7 +66,7 @@ export const getCommentsHandler = async (req: Request, res: Response) => {
       lastKey: comments.lastKey,
     });
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 };
 

--- a/src/router/routes/cube/blog.ts
+++ b/src/router/routes/cube/blog.ts
@@ -9,7 +9,7 @@ import generateMeta from '../../../util/meta';
 import { render } from '../../../util/render';
 import util from '../../../util/util';
 
-const { redirect } = require('../../../util/render');
+const { handleRouteError, redirect } = require('../../../util/render');
 
 import { FeedTypes } from '../../../datatypes/Feed';
 import UserType from '../../../datatypes/User';
@@ -122,7 +122,7 @@ export const createBlogHandler = async (req: Request, res: Response) => {
 
     return redirect(req, res, `/cube/blog/${encodeURIComponent(req.params.id)}`);
   } catch (err) {
-    return util.handleRouteError(req, res, err, `/cube/blog/${encodeURIComponent(req.params.id)}`);
+    return handleRouteError(req, res, err, `/cube/blog/${encodeURIComponent(req.params.id)}`);
   }
 };
 
@@ -147,7 +147,7 @@ export const getBlogPostHandler = async (req: Request, res: Response) => {
 
     return render(req, res, 'BlogPostPage', { post });
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 };
 
@@ -179,7 +179,7 @@ export const deleteBlogHandler = async (req: Request, res: Response) => {
     req.flash('success', 'Post Removed');
     return redirect(req, res, `/cube/blog/${encodeURIComponent(blog.cube)}`);
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 };
 
@@ -226,7 +226,7 @@ export const getBlogPostsForCubeHandler = async (req: Request, res: Response) =>
       },
     );
   } catch (err) {
-    return util.handleRouteError(req, res, err, `/cube/overview/${encodeURIComponent(req.params.id)}`);
+    return handleRouteError(req, res, err, `/cube/overview/${encodeURIComponent(req.params.id)}`);
   }
 };
 

--- a/src/router/routes/draft.ts
+++ b/src/router/routes/draft.ts
@@ -5,7 +5,7 @@ import { csrfProtection } from '../../routes/middleware';
 import { Request, Response } from '../../types/express';
 import { abbreviate, isCubeViewable } from '../../util/cubefn';
 import util from '../../util/util';
-const { redirect, render } = require('../../util/render');
+const { handleRouteError, redirect, render } = require('../../util/render');
 
 const handler = async (req: Request, res: Response) => {
   try {
@@ -43,7 +43,7 @@ const handler = async (req: Request, res: Response) => {
       },
     );
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 };
 

--- a/src/router/routes/draft/deckbuilder.ts
+++ b/src/router/routes/draft/deckbuilder.ts
@@ -5,7 +5,7 @@ import { csrfProtection } from '../../../routes/middleware';
 import { Request, Response } from '../../../types/express';
 import { abbreviate, isCubeViewable } from '../../../util/cubefn';
 import generateMeta from '../../../util/meta';
-import { redirect, render } from '../../../util/render';
+import { handleRouteError, redirect, render } from '../../../util/render';
 import util from '../../../util/util';
 
 const handler = async (req: Request, res: Response) => {
@@ -56,7 +56,7 @@ const handler = async (req: Request, res: Response) => {
       },
     );
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 };
 

--- a/src/router/routes/draft/redraft.ts
+++ b/src/router/routes/draft/redraft.ts
@@ -5,8 +5,7 @@ import { csrfProtection } from '../../../routes/middleware';
 import { Request, Response } from '../../../types/express';
 import { isCubeViewable } from '../../../util/cubefn';
 import { setupPicks } from '../../../util/draftutil';
-import { redirect } from '../../../util/render';
-import util from '../../../util/util';
+import { handleRouteError, redirect } from '../../../util/render';
 
 const handler = async (req: Request, res: Response) => {
   try {
@@ -55,7 +54,7 @@ const handler = async (req: Request, res: Response) => {
 
     return redirect(req, res, `/draft/${id}`);
   } catch (err) {
-    return util.handleRouteError(req, res, err, `/cube/playtest/${req.params.id}`);
+    return handleRouteError(req, res, err, `/cube/playtest/${req.params.id}`);
   }
 };
 

--- a/src/router/routes/draft/start.ts
+++ b/src/router/routes/draft/start.ts
@@ -9,8 +9,7 @@ import { addBasics } from '../../../routes/cube/helper';
 import { csrfProtection } from '../../../routes/middleware';
 import { NextFunction, Request, Response } from '../../../types/express';
 import { isCubeViewable } from '../../../util/cubefn';
-import { redirect } from '../../../util/render';
-import util from '../../../util/util';
+import { handleRouteError, redirect } from '../../../util/render';
 
 interface StartDraftBody {
   id?: string; // id of the format
@@ -100,7 +99,7 @@ const handler = async (req: Request, res: Response) => {
 
     return redirect(req, res, `/draft/${draftId}`);
   } catch (err) {
-    return util.handleRouteError(req, res, err, `/cube/playtest/${encodeURIComponent(req.params.id)}`);
+    return handleRouteError(req, res, err, `/cube/playtest/${encodeURIComponent(req.params.id)}`);
   }
 };
 

--- a/src/router/routes/merchandise.ts
+++ b/src/router/routes/merchandise.ts
@@ -2,8 +2,7 @@ import Stripe from 'stripe';
 
 import { csrfProtection } from '../../routes/middleware';
 import { Request, Response } from '../../types/express';
-import { redirect, render } from '../../util/render';
-import util from '../../util/util';
+import { handleRouteError, redirect, render } from '../../util/render';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
   apiVersion: '2025-01-27.acacia',
@@ -45,7 +44,7 @@ const handler = async (req: Request, res: Response) => {
       },
     );
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 };
 
@@ -82,7 +81,7 @@ const checkout = async (req: Request, res: Response) => {
 
     return redirect(req, res, session.url);
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 };
 

--- a/src/routes/cube/deck.js
+++ b/src/routes/cube/deck.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const { body } = require('express-validator');
 const { cardFromId, getIdsFromName, getMostReasonable } = require('../../util/carddb');
-const { render, redirect } = require('../../util/render');
+const { handleRouteError, render, redirect } = require('../../util/render');
 const util = require('../../util/util');
 const generateMeta = require('../../util/meta');
 const cardutil = require('../../client/utils/cardutil');
@@ -73,7 +73,7 @@ router.get('/download/xmage/:id/:seat', async (req, res) => {
     }
     return res.end();
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 });
 
@@ -131,7 +131,7 @@ router.get('/download/forge/:id/:seat', async (req, res) => {
 
     return res.end();
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 });
 
@@ -157,7 +157,7 @@ router.get('/download/txt/:id/:seat', async (req, res) => {
     }
     return res.end();
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 });
 
@@ -171,7 +171,7 @@ router.get('/download/mtgo/:id/:seat', async (req, res) => {
     const seat = deck.seats[req.params.seat];
     return exportToMtgo(res, seat.name, seat.mainboard.flat(), seat.sideboard.flat(), deck.cards);
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 });
 
@@ -227,7 +227,7 @@ router.get('/download/arena/:id/:seat', async (req, res) => {
 
     return res.end();
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 });
 
@@ -282,7 +282,7 @@ router.get('/download/cockatrice/:id/:seat', async (req, res) => {
 
     return res.end();
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 });
 
@@ -347,7 +347,7 @@ router.get('/download/topdecked/:id/:seat', async (req, res) => {
 
     return res.end();
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 });
 
@@ -449,7 +449,7 @@ router.get('/rebuild/:id/:index', ensureAuth, async (req, res) => {
 
     return redirect(req, res, `/draft/deckbuilder/${id}`);
   } catch (err) {
-    return util.handleRouteError(req, res, err, `/404`);
+    return handleRouteError(req, res, err, `/404`);
   }
 });
 
@@ -485,7 +485,7 @@ router.post('/editdeck/:id', ensureAuth, async (req, res) => {
     req.flash('success', 'Deck saved successfully');
     return redirect(req, res, `/cube/deck/${deck.id}`);
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 });
 
@@ -499,7 +499,7 @@ router.post('/submitdeck/:id', body('skipDeckbuilder').toBoolean(), async (req, 
 
     return redirect(req, res, `/draft/deckbuilder/${draftid}`);
   } catch (err) {
-    return util.handleRouteError(req, res, err, `/cube/playtest/${encodeURIComponent(req.params.id)}`);
+    return handleRouteError(req, res, err, `/cube/playtest/${encodeURIComponent(req.params.id)}`);
   }
 });
 
@@ -609,7 +609,7 @@ router.post('/uploaddecklist/:id', ensureAuth, async (req, res) => {
 
     return redirect(req, res, `/draft/deckbuilder/${id}`);
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 });
 
@@ -654,7 +654,7 @@ router.get('/:id', async (req, res) => {
       },
     );
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 });
 

--- a/src/routes/cube/download.js
+++ b/src/routes/cube/download.js
@@ -3,7 +3,6 @@ const express = require('express');
 const sortutil = require('../../client/utils/Sort');
 const filterutil = require('../../client/filtering/FilterCards');
 const { cardFromId } = require('../../util/carddb');
-const util = require('../../util/util');
 
 const { isCubeViewable } = require('../../util/cubefn');
 const { writeCard, CSV_HEADER, exportToMtgo } = require('./helper');

--- a/src/routes/cube/download.js
+++ b/src/routes/cube/download.js
@@ -7,7 +7,7 @@ const util = require('../../util/util');
 
 const { isCubeViewable } = require('../../util/cubefn');
 const { writeCard, CSV_HEADER, exportToMtgo } = require('./helper');
-const { redirect } = require('../../util/render');
+const { handleRouteError, redirect } = require('../../util/render');
 
 // Bring in models
 const Cube = require('../../dynamo/models/cube');
@@ -61,7 +61,7 @@ router.get('/cubecobra/:id', async (req, res) => {
     }
     return res.end();
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 });
 
@@ -99,7 +99,7 @@ router.get('/csv/:id', async (req, res) => {
 
     return res.end();
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 });
 
@@ -133,7 +133,7 @@ router.get('/forge/:id', async (req, res) => {
     }
     return res.end();
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 });
 
@@ -159,7 +159,7 @@ router.get('/mtgo/:id', async (req, res) => {
 
     return exportToMtgo(res, cube.name, mainboard, maybeboard);
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 });
 
@@ -190,7 +190,7 @@ router.get('/xmage/:id', async (req, res) => {
     }
     return res.end();
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 });
 
@@ -227,7 +227,7 @@ router.get('/plaintext/:id', async (req, res) => {
 
     return res.end();
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 });
 

--- a/src/routes/cube/helper.js
+++ b/src/routes/cube/helper.js
@@ -1,5 +1,5 @@
 const { getIdsFromName, getMostReasonable, cardFromId } = require('../../util/carddb');
-const { render, redirect } = require('../../util/render');
+const { handleRouteError, render, redirect } = require('../../util/render');
 const util = require('../../util/util');
 const cardutil = require('../../client/utils/cardutil');
 const { CSVtoCards } = require('../../util/cubefn');
@@ -97,7 +97,7 @@ async function updateCubeAndBlog(req, res, cube, cards, cardsToWrite, changelog,
 
     return redirect(req, res, `/cube/list/${encodeURIComponent(req.params.id)}`);
   } catch (err) {
-    return util.handleRouteError(req, res, err, `/cube/list/${encodeURIComponent(req.params.id)}`);
+    return handleRouteError(req, res, err, `/cube/list/${encodeURIComponent(req.params.id)}`);
   }
 }
 

--- a/src/routes/patreon_routes.js
+++ b/src/routes/patreon_routes.js
@@ -5,12 +5,11 @@ const patreon = require('patreon');
 const express = require('express');
 
 const { ensureAuth } = require('./middleware');
-const util = require('../util/util');
 
 import { PatronLevels, PatronStatuses } from '../datatypes/Patron';
 const Patron = require('../dynamo/models/patron');
 const User = require('../dynamo/models/user');
-const { redirect } = require('../util/render');
+const { handleRouteError, redirect } = require('../util/render');
 
 const patreonAPI = patreon.patreon;
 const patreonOAuth = patreon.oauth;
@@ -39,7 +38,7 @@ router.get('/unlink', ensureAuth, async (req, res) => {
     req.flash('success', `Patron account has been unlinked.`);
     return redirect(req, res, '/user/account?nav=patreon');
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/user/account?nav=patreon');
+    return handleRouteError(req, res, err, '/user/account?nav=patreon');
   }
 });
 

--- a/src/routes/patreon_routes.js
+++ b/src/routes/patreon_routes.js
@@ -220,6 +220,7 @@ router.get('/redirect', ensureAuth, async (req, res) => {
       return redirect(req, res, '/user/account?nav=patreon');
     })
     .catch((err) => {
+      // eslint-disable-next-line no-console -- Debugging
       console.error(err);
       req.logger.error(err.message, err.stack, JSON.stringify(err));
 

--- a/src/routes/root.js
+++ b/src/routes/root.js
@@ -1,13 +1,12 @@
 const express = require('express');
 
-const util = require('../util/util');
 const Cube = require('../dynamo/models/cube');
 const CubeHash = require('../dynamo/models/cubeHash');
 const Draft = require('../dynamo/models/draft');
 const Content = require('../dynamo/models/content');
 const Feed = require('../dynamo/models/feed');
 
-const { render, redirect } = require('../util/render');
+const { handleRouteError, render, redirect } = require('../util/render');
 const { csrfProtection, ensureAuth } = require('./middleware');
 const { isCubeListed } = require('../util/cubefn');
 
@@ -60,7 +59,7 @@ router.get('/dashboard', ensureAuth, async (req, res) => {
       featured,
     });
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/landing');
+    return handleRouteError(req, res, err, '/landing');
   }
 });
 

--- a/src/routes/tools_routes.js
+++ b/src/routes/tools_routes.js
@@ -20,7 +20,7 @@ const { makeFilter, filterCardsDetails } = require('../client/filtering/FilterCa
 const generateMeta = require('../util/meta');
 const util = require('../util/util');
 const { csrfProtection } = require('./middleware');
-const { render, redirect } = require('../util/render');
+const { handleRouteError, render, redirect } = require('../util/render');
 
 const CardHistory = require('../dynamo/models/cardhistory');
 const Cube = require('../dynamo/models/cube');
@@ -132,7 +132,7 @@ router.get('/topcards', async (req, res) => {
       },
     );
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 });
 
@@ -205,7 +205,7 @@ router.get('/card/:id', async (req, res) => {
   } catch (err) {
     // eslint-disable-next-line no-console -- Error debugging
     console.error(err);
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 });
 
@@ -325,7 +325,7 @@ router.get('/cardimageforcube/:id/:cubeid', async (req, res) => {
 
     return redirect(req, res, card.image_normal);
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 });
 
@@ -360,7 +360,7 @@ router.get('/cardimageflip/:id', async (req, res) => {
 
     return redirect(req, res, card.image_flip);
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 });
 

--- a/src/routes/users_routes.js
+++ b/src/routes/users_routes.js
@@ -7,7 +7,7 @@ const { isCubeListed } = require('../util/cubefn');
 const util = require('../util/util');
 const fq = require('../util/featuredQueue');
 import sendEmail from '../util/email';
-const { render, redirect } = require('../util/render');
+const { handleRouteError, render, redirect } = require('../util/render');
 
 // Bring in models
 const User = require('../dynamo/models/user');
@@ -126,7 +126,7 @@ router.get('/report/:id', ensureAuth, async (req, res) => {
 
     return redirect(req, res, `/user/view/${req.params.id}`);
   } catch (err) {
-    return util.handleRouteError(req, res, err, `/user/view/${req.params.id}`);
+    return handleRouteError(req, res, err, `/user/view/${req.params.id}`);
   }
 });
 
@@ -222,7 +222,7 @@ router.post(
       req.flash('success', `Password recovery email sent to ${recoveryEmail}`);
       return redirect(req, res, '/user/lostpassword');
     } catch (err) {
-      return util.handleRouteError(req, res, err, `/user/lostpassword`);
+      return handleRouteError(req, res, err, `/user/lostpassword`);
     }
   },
 );
@@ -274,7 +274,7 @@ router.post(
       req.flash('success', 'Password updated successfully');
       return redirect(req, res, '/user/login');
     } catch (err) {
-      return util.handleRouteError(req, res, err, `/user/login`);
+      return handleRouteError(req, res, err, `/user/login`);
     }
   },
 );
@@ -368,7 +368,7 @@ router.post(
       req.flash('success', 'Account successfully created. Please check your email for a verification link to login.');
       return redirect(req, res, '/user/login');
     } catch (err) {
-      util.handleRouteError(req, res, err, '/user/register');
+      handleRouteError(req, res, err, '/user/register');
     }
   },
 );
@@ -393,7 +393,7 @@ router.get('/register/confirm/:id/:token', async (req, res) => {
     req.flash('success', 'Email verified. You can now login.');
     return redirect(req, res, '/user/login');
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/user/login');
+    return handleRouteError(req, res, err, '/user/login');
   }
 });
 
@@ -471,7 +471,7 @@ router.get('/view/:id', async (req, res) => {
       following,
     });
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 });
 
@@ -497,7 +497,7 @@ router.get('/decks/:userid', async (req, res) => {
       lastKey: decks.lastEvaluatedKey,
     });
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 });
 
@@ -560,7 +560,7 @@ router.get('/blog/:userid', async (req, res) => {
       },
     );
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/404');
+    return handleRouteError(req, res, err, '/404');
   }
 });
 
@@ -697,7 +697,7 @@ router.post('/updateuserinfo', ensureAuth, [...usernameValid], flashValidationEr
     req.flash('success', 'User information updated.');
     return redirect(req, res, '/user/account');
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/user/account');
+    return handleRouteError(req, res, err, '/user/account');
   }
 });
 
@@ -760,7 +760,7 @@ router.get('/social', ensureAuth, async (req, res) => {
       },
     );
   } catch (err) {
-    return util.handleRouteError(req, res, err, '/');
+    return handleRouteError(req, res, err, '/');
   }
 });
 

--- a/src/util/draftutil.ts
+++ b/src/util/draftutil.ts
@@ -1,5 +1,4 @@
-import { cardCmc, cardType } from '../client/utils/cardutil';
-import { cmcColumn } from '../client/utils/Util';
+import { cardCmc, cardType, cmcColumn } from '../client/utils/cardutil';
 import Card from '../datatypes/Card';
 import Draft, { DraftStep } from '../datatypes/Draft';
 

--- a/src/util/render.js
+++ b/src/util/render.js
@@ -83,7 +83,14 @@ const render = (req, res, page, reactProps = {}, options = {}) => {
   });
 };
 
+const handleRouteError = function (req, res, err, reroute) {
+  req.logger.error(err.message, err.stack);
+  req.flash('danger', err.message);
+  redirect(req, res, reroute);
+};
+
 module.exports = {
   render,
   redirect,
+  handleRouteError,
 };

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -1,6 +1,5 @@
 const shuffleSeed = require('shuffle-seed');
 const Notification = require('../dynamo/models/notification');
-const { redirect } = require('./render');
 
 const Filter = require('bad-words');
 const filter = new Filter();
@@ -262,7 +261,7 @@ function fromEntries(entries) {
   return obj;
 }
 
-async function addNotification(to/*: User*/, from/*: User*/, url, text) {
+async function addNotification(to /*: User*/, from /*: User*/, url, text) {
   if (to.username === from.username) {
     return; // we don't need to give notifications to ourselves
   }
@@ -289,12 +288,6 @@ function wrapAsyncApi(route) {
       });
     }
   };
-}
-
-function handleRouteError(req, res, err, reroute) {
-  req.logger.error(err.message, err.stack);
-  req.flash('danger', err.message);
-  redirect(req, res, reroute);
 }
 
 function toNonNullArray(arr) {
@@ -353,7 +346,6 @@ module.exports = {
   },
   addNotification,
   wrapAsyncApi,
-  handleRouteError,
   toNonNullArray,
   flatten,
   mapNonNull,

--- a/tests/comments/api.test.ts
+++ b/tests/comments/api.test.ts
@@ -48,12 +48,12 @@ jest.mock('../../src/dynamo/models/notice', () => {
 });
 
 jest.mock('../../src/util/render', () => ({
+  handleRouteError: jest.fn(),
   redirect: jest.fn(),
   render: jest.fn(),
 }));
 
 jest.mock('../../src/util/util', () => ({
-  handleRouteError: jest.fn(),
   addNotification: jest.fn(),
 }));
 
@@ -107,7 +107,7 @@ describe('Get Comment', () => {
   it('handles errors gracefully', async () => {
     const error = new Error('Something went wrong');
     (Comment.getById as jest.Mock).mockRejectedValue(error);
-    (routeUtil.handleRouteError as jest.Mock).mockImplementation(() => {});
+    (util.handleRouteError as jest.Mock).mockImplementation(() => {});
 
     await call(getHandler)
       .withFlash(flashMock)
@@ -115,7 +115,7 @@ describe('Get Comment', () => {
       .send();
 
     expect(Comment.getById).toHaveBeenCalledWith('12345');
-    expect(routeUtil.handleRouteError).toHaveBeenCalledWith(expect.anything(), expect.anything(), error, '/404');
+    expect(util.handleRouteError).toHaveBeenCalledWith(expect.anything(), expect.anything(), error, '/404');
     expect(flashMock).not.toHaveBeenCalled();
     expect(util.redirect).not.toHaveBeenCalled();
     expect(util.render).not.toHaveBeenCalled();
@@ -168,7 +168,7 @@ describe('Report Comment', () => {
       })
       .send();
 
-    expect(routeUtil.handleRouteError).toHaveBeenCalledWith(expect.anything(), expect.anything(), error, '/404');
+    expect(util.handleRouteError).toHaveBeenCalledWith(expect.anything(), expect.anything(), error, '/404');
   });
 });
 
@@ -228,7 +228,7 @@ describe('Get Comments', () => {
       .send();
 
     expect(Comment.queryByParentAndType).toHaveBeenCalledWith('parent123', 'lastKey123');
-    expect(routeUtil.handleRouteError).toHaveBeenCalledWith(expect.anything(), expect.anything(), mockError, '/404');
+    expect(util.handleRouteError).toHaveBeenCalledWith(expect.anything(), expect.anything(), mockError, '/404');
     expect(res.status).not.toHaveBeenCalledWith(200);
   });
 });

--- a/tests/cube/blog/api.test.ts
+++ b/tests/cube/blog/api.test.ts
@@ -11,7 +11,6 @@ import {
 } from '../../../src/router/routes/cube/blog';
 import { Response } from '../../../src/types/express';
 import * as util from '../../../src/util/render';
-import * as routeUtil from '../../../src/util/util';
 import { createBlogPost, createCube, createUser } from '../../test-utils/data';
 import { expectRegisteredRoutes } from '../../test-utils/route';
 import { call } from '../../test-utils/transport';
@@ -23,6 +22,7 @@ jest.mock('../../../src/util/util', () => ({
 
 jest.mock('../../../src/util/render', () => ({
   ...jest.requireActual('../../../src/util/render'),
+  handleRouteError: jest.fn(),
   redirect: jest.fn(),
   render: jest.fn(),
 }));
@@ -44,12 +44,6 @@ jest.mock('../../../src/dynamo/models/blog', () => ({
 jest.mock('../../../src/dynamo/models/feed', () => ({
   ...jest.requireActual('../../../src/dynamo/models/feed'),
   batchPut: jest.fn(),
-}));
-
-jest.mock('../../../src/util/util', () => ({
-  ...jest.requireActual('../../../src/util/util'),
-  handleRouteError: jest.fn(),
-  addNotification: jest.fn(),
 }));
 
 describe('Create Blog Post', () => {
@@ -183,12 +177,7 @@ describe('Create Blog Post', () => {
       .withParams({ id: '12345' })
       .send();
 
-    expect(routeUtil.handleRouteError).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.anything(),
-      error,
-      '/cube/blog/12345',
-    );
+    expect(util.handleRouteError).toHaveBeenCalledWith(expect.anything(), expect.anything(), error, '/cube/blog/12345');
   });
 });
 
@@ -292,7 +281,7 @@ describe('Get Blog Post', () => {
 
     await call(getBlogPostHandler).withParams({ id: 'blog-id' }).send();
 
-    expect(routeUtil.handleRouteError).toHaveBeenCalledWith(expect.anything(), expect.anything(), error, '/404');
+    expect(util.handleRouteError).toHaveBeenCalledWith(expect.anything(), expect.anything(), error, '/404');
     expect(util.render).not.toHaveBeenCalled();
   });
 });
@@ -420,7 +409,7 @@ describe('View Blog Posts', () => {
 
     await call(getBlogPostsForCubeHandler).withFlash(flashMock).withParams({ id: 'cube-id' }).send();
 
-    expect(routeUtil.handleRouteError).toHaveBeenCalledWith(
+    expect(util.handleRouteError).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),
       error,


### PR DESCRIPTION
While doing other testing ran into the issue where "redirect" was not defined due to cyclic dependencies, so I went ahead and resolve those. The two cycles dpdm found were:
```
  1) src/client/utils/cardutil.ts -> src/client/utils/Util.ts
  2) src/util/render.js -> src/util/util.js
```
The latter was introduced by myself when I did some email refactoring and added the getBaseUrl() function.

# Resolutions
For `src/client/utils/cardutil.ts -> src/client/utils/Util.ts` moved a few methods from Util.ts to cardutil.ts as they mostly were card related anyways. Some could have been moved to deck utils I guess (though actually I think nothing calls sortDeck..)

For `src/util/render.js -> src/util/util.js` moved handleRouteError from util.js to render.js, as it makes sense for the actions of a route (render, redirect, handleRouteError) to be in the same spot.

# Testing
Simple regression testing. Added breakpoints in the backend and frontend to validate that the updated imports worked.
