### PR TITLE
Fix collector numbers containing a star causing invalid character error (for Mana Pool links)

### DIFF
--- a/src/client/utils/Affiliate.ts
+++ b/src/client/utils/Affiliate.ts
@@ -55,8 +55,13 @@ export const getBulkManaPoolLink = (cards: Card[]): string => {
   const cardString = cards
     .map((card) => `${cardName(card)} [${cardSet(card)}] ${cardCollectorNumber(card)}`)
     .join('\n');
-  // base64 encode the card string
-  const encodedCardString = btoa(cardString);
+
+  /* base64 encode the card string
+   * Because the collector number may contain non-latin characters like ★ and btoa only works with latin1 character set,
+   * we use the solution in https://stackoverflow.com/a/70714541 to encode before btoa in order to have valid characters.
+   * Even though unescape is deprecated, it works in all browsers at this time
+   */
+  const encodedCardString = btoa(unescape(encodeURIComponent(cardString)));
   return `https://manapool.com/add-deck?ref=cubecobra&deck=${encodedCardString}`;
 };
 

--- a/tests/affiliate/links.test.ts
+++ b/tests/affiliate/links.test.ts
@@ -1,4 +1,10 @@
-import { getCardMarketLink, getTCGLink, tcgplayerAffiliate } from 'utils/Affiliate';
+import {
+  getBulkManaPoolLink,
+  getCardMarketLink,
+  getManaPoolLink,
+  getTCGLink,
+  tcgplayerAffiliate,
+} from 'utils/Affiliate';
 
 import { createCard, createCardDetails } from '../test-utils/data';
 
@@ -32,5 +38,42 @@ describe('CardMarket', () => {
     expect(getCardMarketLink(card)).toEqual(
       'https://www.cardmarket.com/en/Magic/Products/Singles/Seventh-Edition/Birds-of-Paradise',
     );
+  });
+});
+
+describe('ManaPool', () => {
+  it('should generate a valid link for a card with a Mana Pool', () => {
+    const card = createCard({
+      details: createCardDetails({ name: 'Birds of Paradise', set: '6ED', collector_number: '217' }),
+    });
+
+    expect(getManaPoolLink(card)).toEqual('https://manapool.com/card/6ed/217/birds-of-paradise?ref=cubecobra');
+  });
+
+  it('should generate a valid link for a card with a Mana Pool, for a promo collector', () => {
+    const card = createCard({
+      details: createCardDetails({ name: 'Birds of Paradise', set: '7ed', collector_number: '231★' }),
+    });
+
+    expect(getManaPoolLink(card)).toEqual('https://manapool.com/card/7ed/231★/birds-of-paradise?ref=cubecobra');
+  });
+
+  it('should generate a valid link for a deck with a Mana Pool', () => {
+    const cards = [
+      createCard({
+        details: createCardDetails({ name: 'Birds of Paradise', set: '7ed', collector_number: '231★' }),
+      }),
+      createCard({
+        details: createCardDetails({ name: 'Oko, Thief of Crowns', set: 'ELD', collector_number: '197' }),
+      }),
+    ];
+
+    let cardDetails = '';
+    cardDetails += `Birds of Paradise [7ed] 231★\n`;
+    cardDetails += `Oko, Thief of Crowns [ELD] 197`;
+
+    const encodedDeck = btoa(cardDetails);
+
+    expect(getBulkManaPoolLink(cards)).toEqual(`https://manapool.com/add-deck?ref=cubecobra&deck=${encodedDeck}`);
   });
 });

--- a/tests/affiliate/links.test.ts
+++ b/tests/affiliate/links.test.ts
@@ -72,7 +72,7 @@ describe('ManaPool', () => {
     cardDetails += `Birds of Paradise [7ed] 231★\n`;
     cardDetails += `Oko, Thief of Crowns [ELD] 197`;
 
-    const encodedDeck = btoa(cardDetails);
+    const encodedDeck = btoa(unescape(encodeURIComponent(cardDetails)));
 
     expect(getBulkManaPoolLink(cards)).toEqual(`https://manapool.com/add-deck?ref=cubecobra&deck=${encodedDeck}`);
   });


### PR DESCRIPTION
# Problem
Reported on https://cubecobra.com/cube/overview/sd5. Used dev tools debug to get the deck string that failed, which highlighted the ★ characters in some collector numbers which indicates a promo. Such as `Avatar of Discord [pdis] 140★`

# Solution
Googled and found stack overflow solution to first encode the ★ (any non-ascii characters really) into ascii characters for btoa to encode.

For the example above the resulting link to Mana Pool is https://manapool.com/add-deck?deck=QXZhdGFyIG9mIERpc2NvcmQgW3BkaXNdIDE0MOKYhQ&ref=cubecobra which correctly contains the ★ in the collector number.

I'll backfill the coverage of the rest of affiliate.ts in a second PR.