### PR TITLE
Affiliate test coverage to 100%

### DIFF
--- a/src/client/utils/Affiliate.ts
+++ b/src/client/utils/Affiliate.ts
@@ -28,7 +28,7 @@ export const getCardMarketLink = (card: Card): string =>
     .replace(/[:,."']/g, '')}/${cardName(card).replace(/ /g, '-').replace(/:/g, '').replace(/\./g, '')}`;
 
 export const getCardHoarderLink = (card: Card): string =>
-  `https://www.cardhoarder.com/cards?data%5Bsearch%5D=${cardName(card)}?affiliate_id=cubecobra&utm_source=cubecobra&utm_campaign=affiliate&utm_medium=card`;
+  `https://www.cardhoarder.com/cards?data%5Bsearch%5D=${encodeURIComponent(cardName(card))}?affiliate_id=cubecobra&utm_source=cubecobra&utm_campaign=affiliate&utm_medium=card`;
 
 const ck = (str: string): string =>
   str

--- a/tests/affiliate/links.test.ts
+++ b/tests/affiliate/links.test.ts
@@ -1,5 +1,6 @@
 import {
   getBulkManaPoolLink,
+  getCardHoarderLink,
   getCardMarketLink,
   getManaPoolLink,
   getTCGLink,
@@ -75,5 +76,19 @@ describe('ManaPool', () => {
     const encodedDeck = btoa(unescape(encodeURIComponent(cardDetails)));
 
     expect(getBulkManaPoolLink(cards)).toEqual(`https://manapool.com/add-deck?ref=cubecobra&deck=${encodedDeck}`);
+  });
+});
+
+describe('Card Hoarder', () => {
+  it('should generate a valid link for a card with a Card Hoarder', () => {
+    const card = createCard({
+      details: createCardDetails({ name: 'Oko, Thief of Crowns', set: 'ELD', collector_number: '197' }),
+    });
+
+    const encodedCardName = 'Oko%2C%20Thief%20of%20Crowns';
+
+    expect(getCardHoarderLink(card)).toEqual(
+      `https://www.cardhoarder.com/cards?data%5Bsearch%5D=${encodedCardName}?affiliate_id=cubecobra&utm_source=cubecobra&utm_campaign=affiliate&utm_medium=card`,
+    );
   });
 });

--- a/tests/affiliate/links.test.ts
+++ b/tests/affiliate/links.test.ts
@@ -31,6 +31,12 @@ describe('TCGPlayer', () => {
 
     expect(getTCGLink(token)).toEqual(`${tcgplayerAffiliate}?u=${encodeURI(uri)}`);
   });
+
+  it('should generate handle no card details', () => {
+    const card = createCard({ details: undefined });
+
+    expect(getTCGLink(card)).toEqual('#');
+  });
 });
 
 describe('CardMarket', () => {

--- a/tests/affiliate/links.test.ts
+++ b/tests/affiliate/links.test.ts
@@ -1,6 +1,7 @@
 import {
   getBulkManaPoolLink,
   getCardHoarderLink,
+  getCardKingdomLink,
   getCardMarketLink,
   getManaPoolLink,
   getTCGLink,
@@ -89,6 +90,25 @@ describe('Card Hoarder', () => {
 
     expect(getCardHoarderLink(card)).toEqual(
       `https://www.cardhoarder.com/cards?data%5Bsearch%5D=${encodedCardName}?affiliate_id=cubecobra&utm_source=cubecobra&utm_campaign=affiliate&utm_medium=card`,
+    );
+  });
+});
+
+describe('Card Kingdom', () => {
+  it('should generate a valid link for a card with a Card Kingdom', () => {
+    const card = createCard({
+      details: createCardDetails({
+        name: 'Oko, Thief of Crowns',
+        set_name: 'Throne of Eldraine',
+        collector_number: '197',
+      }),
+    });
+
+    const encodedSetName = 'throne-of-eldraine';
+    const encodedCardName = 'oko-thief-of-crowns';
+
+    expect(getCardKingdomLink(card)).toEqual(
+      `https://www.cardkingdom.com/mtg/${encodedSetName}/${encodedCardName}?partner=CubeCobra&utm_source=CubeCobra&utm_medium=affiliate&utm_campaign=CubeCobra`,
     );
   });
 });


### PR DESCRIPTION
I see nothing is using Card Hoarder yet but in quick sanity testing against their actual site I found that it is necessary to URI encode the card name for the search.

Eg https://www.cardhoarder.com/cards?cardname=Oko%2C%20Thief%20of%20Crowns&set_code=&format=&price_gte=&price_lte=&sort=release-date%3Anumber-asc&is_rentable_only=&is_buylisted_only=&in_stock_for_purchase=&in_stock_for_rent=&exclude_promos=&finish=&rarity=&page=1

