### PR TITLE
Allow card search with apostrophe

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -44,7 +44,7 @@ jobs:
         uses: tj-actions/eslint-changed-files@v25
         with:
           config_path: 'eslint.config.mjs'
-          extra_args: '--max-warnings=0'
+          extra_args: '--max-warnings=0 --no-warn-ignored'
           reporter: github-pr-review
 
       - name: Run Prettier on changed files

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,7 +8,7 @@ import tseslint from 'typescript-eslint';
 
 export default [
   {
-    ignores: ['dist/**/*', '.git/**/*', 'node_modules/**/*', 'src/generated/**/*', 'jobs/archived/*.js'],
+    ignores: ['dist/**/*', '.git/**/*', 'node_modules/**/*', 'src/client/generated/**/*', 'jobs/archived/*.js'],
   },
   js.configs.recommended,
   ...tseslint.configs.recommended,

--- a/nearley/values.ne
+++ b/nearley/values.ne
@@ -167,7 +167,7 @@ noQuoteStringValue ->
     | "and"i [^ \t\n"'\\=<>:] 
     | "o"i [^rR \t\n"'\\=<>:]
     | "or"i [^ \t\n"'\\=<>:]
-    ) [^ \t\n"'\\=<>:]:* {% ([startChars, chars]) => startChars.concat(chars).join('').toLowerCase() %}
+    ) [^ \t\n"\\=<>:]:* {% ([startChars, chars]) => startChars.concat(chars).join('').toLowerCase() %}
 # "
 
 manaCostOpValue -> equalityOperator manaCostValue {% ([op, value]) => manaCostOperation(op, value) %}

--- a/src/client/filtering/FilterCards.ts
+++ b/src/client/filtering/FilterCards.ts
@@ -30,7 +30,9 @@ export function defaultFilter(): FilterFunction {
   return result as FilterFunction;
 }
 
-export function makeFilter(filterText: string): { err: any; filter: FilterFunction | null } {
+export type FilterResult = { err: any; filter: FilterFunction | null };
+
+export function makeFilter(filterText: string): FilterResult {
   if (!filterText || filterText.trim() === '') {
     return {
       err: false,

--- a/src/client/generated/filtering/cardFilters.js
+++ b/src/client/generated/filtering/cardFilters.js
@@ -1365,7 +1365,7 @@ var grammar = {
     {"name": "noQuoteStringValue$subexpression$2$subexpression$5", "symbols": [/[oO]/, /[rR]/], "postprocess": function(d) {return d.join(""); }},
     {"name": "noQuoteStringValue$subexpression$2", "symbols": ["noQuoteStringValue$subexpression$2$subexpression$5", /[^ \t\n"'\\=<>:]/]},
     {"name": "noQuoteStringValue$ebnf$1", "symbols": []},
-    {"name": "noQuoteStringValue$ebnf$1", "symbols": ["noQuoteStringValue$ebnf$1", /[^ \t\n"'\\=<>:]/], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
+    {"name": "noQuoteStringValue$ebnf$1", "symbols": ["noQuoteStringValue$ebnf$1", /[^ \t\n"\\=<>:]/], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
     {"name": "noQuoteStringValue", "symbols": ["noQuoteStringValue$subexpression$2", "noQuoteStringValue$ebnf$1"], "postprocess": ([startChars, chars]) => startChars.concat(chars).join('').toLowerCase()},
     {"name": "manaCostOpValue", "symbols": ["equalityOperator", "manaCostValue"], "postprocess": ([op, value]) => manaCostOperation(op, value)},
     {"name": "manaCostValue$ebnf$1", "symbols": ["manaSymbol"]},

--- a/tests/cards/filtering.test.ts
+++ b/tests/cards/filtering.test.ts
@@ -97,6 +97,10 @@ describe('Filter syntax', () => {
     expect(result.err).toBeTruthy();
     const result2 = makeFilter(`name:'${name}'`);
     expect(result2.err).toBeTruthy();
+
+    //But it does work if the quote is escaped
+    assertValidNameFilter(makeFilter(`'Urza\\'s Bauble'`));
+    assertValidNameFilter(makeFilter(`n:'Urza\\'s Bauble'`));
   });
 
   it('Partial working names with double quotes', async () => {
@@ -110,6 +114,10 @@ describe('Filter syntax', () => {
     expect(result.err).toBeTruthy();
     const result2 = makeFilter(`name:"${name}"`);
     expect(result2.err).toBeTruthy();
+
+    //But it does work if the quote is escaped
+    assertValidNameFilter(makeFilter(`"Kongming, \\"Sleeping Dragon\\""`));
+    assertValidNameFilter(makeFilter(`n:'Urza\\'s Bauble'`));
   });
 
   const failingNamesWithInterestingCharacters = ['Hazmat Suit (Used)'];

--- a/tests/cards/filtering.test.ts
+++ b/tests/cards/filtering.test.ts
@@ -120,7 +120,9 @@ describe('Filter syntax', () => {
     assertValidNameFilter(makeFilter(`n:'Urza\\'s Bauble'`));
   });
 
-  const failingNamesWithInterestingCharacters = ['Hazmat Suit (Used)'];
+  const failingNamesWithInterestingCharacters = [
+    'Hazmat Suit (Used)', //The brackets get interpreted as another clause and we only want a single filter
+  ];
 
   it.each(failingNamesWithInterestingCharacters)('Failing names with interesting characters (%s)', async (name) => {
     const result = makeFilter(name);

--- a/tests/cards/filtering.test.ts
+++ b/tests/cards/filtering.test.ts
@@ -77,13 +77,14 @@ describe('Filter syntax', () => {
     'The Ultimate Nightmare of Wizards of the Coast® Customer Service',
     'Ratonhnhaké꞉ton',
     'Kongming, "Sleeping Dragon"',
+    "Urza's Bauble",
   ];
 
   it.each(workingNamesWithInterestingCharacters)('Working names with interesting characters (%s)', async (name) => {
     assertValidNameFilter(makeFilter(name));
   });
 
-  const failingNamesWithInterestingCharacters = ["Urza's Bauble", 'Hazmat Suit (Used)'];
+  const failingNamesWithInterestingCharacters = ['Hazmat Suit (Used)'];
 
   it.each(failingNamesWithInterestingCharacters)('Failing names with interesting characters (%s)', async (name) => {
     const result = makeFilter(name);

--- a/tests/cards/filtering.test.ts
+++ b/tests/cards/filtering.test.ts
@@ -1,0 +1,92 @@
+import { FilterResult, makeFilter } from '../../src/client/filtering/FilterCards';
+
+describe('Filter syntax', () => {
+  const assertValidNameFilter = (result: FilterResult) => {
+    expect(result.err).toBeFalsy();
+    expect(result.filter).toBeInstanceOf(Function);
+    expect(result.filter?.fieldsUsed).toEqual(['name_lower']);
+  };
+
+  it('Empty filter is no filtering', async () => {
+    const result = makeFilter('');
+    expect(result.err).toBeFalsy();
+    expect(result.filter).toBeNull();
+
+    const result2 = makeFilter('     ');
+    expect(result2.err).toBeFalsy();
+    expect(result2.filter).toBeNull();
+  });
+
+  it('Default filter is card name', async () => {
+    assertValidNameFilter(makeFilter('Urza'));
+    assertValidNameFilter(makeFilter('"Armageddon"'));
+    assertValidNameFilter(makeFilter("'Goblin Welder'"));
+  });
+
+  it('Negative name filter', async () => {
+    assertValidNameFilter(makeFilter('-mox'));
+    assertValidNameFilter(makeFilter('-"Diamond"'));
+    assertValidNameFilter(makeFilter("-'Dockside Chef'"));
+  });
+
+  it('Explicit name filter', async () => {
+    assertValidNameFilter(makeFilter('name:Blood'));
+    assertValidNameFilter(makeFilter('name:"Caustic Bro"'));
+    assertValidNameFilter(makeFilter("name:'The Meathook Mass'"));
+  });
+
+  it('Short explicit name filter', async () => {
+    assertValidNameFilter(makeFilter('n:Master of Death'));
+    assertValidNameFilter(makeFilter('n:"Abrupt Decay"'));
+    assertValidNameFilter(makeFilter("n:'March of Otherworldly Light'"));
+  });
+
+  it('Exact name filter', async () => {
+    assertValidNameFilter(makeFilter('name=Bloodghast'));
+    assertValidNameFilter(makeFilter('name="Caustic Bronco"'));
+    assertValidNameFilter(makeFilter("name='The Meathook Massacre'"));
+  });
+
+  it('Not exact name filter', async () => {
+    assertValidNameFilter(makeFilter('name!=Bloodghast'));
+    assertValidNameFilter(makeFilter('name!="Caustic Bronco"'));
+    assertValidNameFilter(makeFilter("name!='The Meathook Massacre'"));
+
+    assertValidNameFilter(makeFilter('name<>Bloodghast'));
+    assertValidNameFilter(makeFilter('name<>"Caustic Bronco"'));
+    assertValidNameFilter(makeFilter("name<>'The Meathook Massacre'"));
+  });
+
+  it('Combination name filters', async () => {
+    assertValidNameFilter(makeFilter('Dragon or angel'));
+    assertValidNameFilter(makeFilter('dragon AND orb'));
+    assertValidNameFilter(makeFilter('-Dragon AND rage'));
+    assertValidNameFilter(makeFilter('-Dragon or rage'));
+  });
+
+  const workingNamesWithInterestingCharacters = [
+    'Chatterfang, Squirrel',
+    'Oni-Cult Anvil',
+    'Busted!',
+    '+2 mace',
+    'Mr. Orfeo, the Boulder',
+    'Borrowing 100,000 Arrows',
+    'TL;DR',
+    'Question Elemental?',
+    '_____ Goblin',
+    'The Ultimate Nightmare of Wizards of the Coast® Customer Service',
+    'Ratonhnhaké꞉ton',
+    'Kongming, "Sleeping Dragon"',
+  ];
+
+  it.each(workingNamesWithInterestingCharacters)('Working names with interesting characters (%s)', async (name) => {
+    assertValidNameFilter(makeFilter(name));
+  });
+
+  const failingNamesWithInterestingCharacters = ["Urza's Bauble", 'Hazmat Suit (Used)'];
+
+  it.each(failingNamesWithInterestingCharacters)('Failing names with interesting characters (%s)', async (name) => {
+    const result = makeFilter(name);
+    expect(result.err).toBeTruthy();
+  });
+});

--- a/tests/cards/filtering.test.ts
+++ b/tests/cards/filtering.test.ts
@@ -76,12 +76,40 @@ describe('Filter syntax', () => {
     '_____ Goblin',
     'The Ultimate Nightmare of Wizards of the Coast® Customer Service',
     'Ratonhnhaké꞉ton',
-    'Kongming, "Sleeping Dragon"',
-    "Urza's Bauble",
   ];
 
   it.each(workingNamesWithInterestingCharacters)('Working names with interesting characters (%s)', async (name) => {
     assertValidNameFilter(makeFilter(name));
+    assertValidNameFilter(makeFilter(`'${name}'`));
+    assertValidNameFilter(makeFilter(`"${name}"`));
+    assertValidNameFilter(makeFilter(`name:'${name}'`));
+    assertValidNameFilter(makeFilter(`name:"${name}"`));
+  });
+
+  it('Partial working names with single quotes', async () => {
+    const name = "Urza's Bauble";
+    assertValidNameFilter(makeFilter(name));
+    assertValidNameFilter(makeFilter(`"${name}"`));
+    assertValidNameFilter(makeFilter(`name:"${name}"`));
+
+    //Cannot single-quote surround a name containing a single quote
+    const result = makeFilter(`'${name}'`);
+    expect(result.err).toBeTruthy();
+    const result2 = makeFilter(`name:'${name}'`);
+    expect(result2.err).toBeTruthy();
+  });
+
+  it('Partial working names with double quotes', async () => {
+    const name = 'Kongming, "Sleeping Dragon"';
+    assertValidNameFilter(makeFilter(name));
+    assertValidNameFilter(makeFilter(`'${name}'`));
+    assertValidNameFilter(makeFilter(`name:'${name}'`));
+
+    //Cannot double-quote surround a name containing a double quote
+    const result = makeFilter(`"${name}"`);
+    expect(result.err).toBeTruthy();
+    const result2 = makeFilter(`name:"${name}"`);
+    expect(result2.err).toBeTruthy();
   });
 
   const failingNamesWithInterestingCharacters = ['Hazmat Suit (Used)'];


### PR DESCRIPTION
This allows name searching, without needing quotes, for names like:

* Jace, Vryn's Prodigy

* Urza's Bauble

For the details of the grammar I referenced https://github.com/dekkerglen/CubeCobra/pull/1647. From that it looks pretty safe to me to remove the apostrophe from the last part of noQuoteStringValue which is trying to match all the remaining text in the token, after and/or are past. Unlike my previous PR https://github.com/dekkerglen/CubeCobra/pull/2580 it is NOT possible to remove the colon from the exclusions, as that would result in ambiguity with `<filter>:...` filters.

**Without a ton more testing I cannot guarantee that this didn't break other filters.** The changed noQuoteStringValue is used in other filters though they are not likely to contain anything with a single quote.

# Testing
## Before
Searching using double or single quoted

Searching in cube:

![image](https://github.com/user-attachments/assets/726758cb-586f-4da2-a391-12ff4702ad8f)
![image](https://github.com/user-attachments/assets/78ff8ff3-82c7-41d7-8de1-e03dbb7045fe)
![image](https://github.com/user-attachments/assets/79a8addc-4826-4e23-9468-f4eaf538b387)

Card search
![image](https://github.com/user-attachments/assets/b98b75df-bdf4-47da-bad7-b7b4b7912d1e)

## After
Now searching for cards with apostrophe works without quotes.

![image](https://github.com/user-attachments/assets/258d8429-1c89-45bb-9037-9954f0099969)
![image](https://github.com/user-attachments/assets/0a0b846f-401f-4648-b985-c2dfa30ec110)
![image](https://github.com/user-attachments/assets/46fadd7a-8309-4542-868c-45686f2fa743)

![image](https://github.com/user-attachments/assets/2dada279-5f12-4c19-8fbe-23a933ae7a13)
![image](https://github.com/user-attachments/assets/149c0368-2469-456e-8812-49b284c6a643)


### How I gathered unique characters for testing
I gathered all the unique characters in card names using:

```
jq '.[]' cubecobra/private/names.json -r | awk '{for(i=1;i<=NF;i++)if(!a[$i]++)print $i}' FS=""  | sort
```
Then using scryfall I grabbed one or two cards whose name contains non-alphabetic characters giving me the names used in the test file.