### PR TITLE
Sorting (grouping) price with etched cards

### DIFF
--- a/src/client/utils/Sort.ts
+++ b/src/client/utils/Sort.ts
@@ -712,7 +712,7 @@ export function cardGetLabels(card: Card, sort: string, showOther = false): stri
   } else if (sort === 'Creature/Non-Creature') {
     ret = cardType(card).toLowerCase().includes('creature') ? ['Creature'] : ['Non-Creature'];
   } else if (sort === 'Price USD' || sort === 'Price') {
-    const price = card.details?.prices.usd ?? card.details?.prices.usd_foil;
+    const price = card.details?.prices.usd ?? card.details?.prices.usd_foil ?? card.details?.prices.usd_etched;
     if (price) {
       ret = [getPriceBucket(price, '$')];
     } else {


### PR DESCRIPTION
# Problem
Etched cards, specifically those which are true etched only variants, do not have USD price and so in the sorting/grouping code for "Price USD" it determined "No price available".

A card who's finish is modified to etched retains the price information of the original card, which includes USD and/or USD foil but not etched price.

# Solution
As the "Price USD" code already falls back to checking the foil USD price if USD price is unavailable, it seems logical to also fallback to checking USD etched price.

As well the 4th category sort for "Price" uses cardPrice() which checks the card finish to get the price, but also falls back to other USD price variants if necessary. So this makes "Price USD" align closer to that, apart from not taking the finish into account explicitly.

## Concerns
* USD Foil price sorting doesn't have fallbacks, so will also group things into "No price available"
* CubeCobra doesn't track EUR foil or Etched pricing (though it is available on Scryfall) so inconsistent with USD prices

# Testing
Created unit tests. I wanted to actually test sortDeep and validate that the prices resulted in the correct groupings, but I could not get typescript to like the DeepSorted type such that I could extract the label / cards in order to assert on them.

# Before
Etched cards grouped as "No Price Available"
![old-etched-cards-without-pricing-group](https://github.com/user-attachments/assets/24b1d4d0-1c61-4cdc-993d-8089af42c8d1)

# After
Etched cards all grouped into price buckets. I used a different secondary sort here so that it is easy to see the Etched cards in their finish grouping.
![new-etched-cards-in-pricing-groups](https://github.com/user-attachments/assets/11682684-fc19-44dd-917a-8e1af05188ca)
