### PR TITLE
feat: allow disabling autocapitalize and others on text inputs

### DIFF
--- a/src/client/components/base/Input.tsx
+++ b/src/client/components/base/Input.tsx
@@ -37,6 +37,9 @@ const Input: React.FC<InputProps> = ({
   value,
   disabled = false,
   onEnter,
+  autoCapitalize = 'sentences',
+  autoCorrect = 'on',
+  spellCheck = true,
 }) => {
   return (
     <div className="block w-full">
@@ -83,6 +86,9 @@ const Input: React.FC<InputProps> = ({
         onChange={disabled ? undefined : onChange}
         value={value}
         disabled={disabled}
+        autoCapitalize={autoCapitalize}
+        autoCorrect={autoCorrect}
+        spellCheck={spellCheck}
       />
     </div>
   );

--- a/src/client/components/cube/CompareCollapse.tsx
+++ b/src/client/components/cube/CompareCollapse.tsx
@@ -23,7 +23,15 @@ const CompareCollapse: React.FC<CompareCollapseProps> = ({ isOpen }) => {
   return (
     <Collapse isOpen={isOpen}>
       <Flexbox direction="row" gap="2" className="mt-2">
-        <Input type="text" placeholder="Comparison Cube ID" value={compareID} onChange={handleChange} />
+        <Input
+          type="text"
+          placeholder="Comparison Cube ID"
+          value={compareID}
+          onChange={handleChange}
+          autoCapitalize="none"
+          autoComplete="off"
+          spellCheck={false}
+        />
         <Button type="link" color="primary" href={targetUrl} block>
           Compare cubes
         </Button>


### PR DESCRIPTION
Adding a few props to `Input` to allow disabling `autocapitalize`, `autocorrect` and `spellcheck` then using it in the cube id input when comparing cubes.

## Current behaviour
https://github.com/user-attachments/assets/e28576d1-fbcb-43f7-9962-bfe0d93ce865

## With autocapitalize disabled
https://github.com/user-attachments/assets/5d030fec-6a03-4a3e-acdf-080498578b00

Feel free to close this if it's not something you want to have. I'm guessing there are other inputs that could use this but this is a first step.