### PR TITLE
Fix Draftmancer pick breakdown

### DIFF
--- a/src/client/components/DecksPickBreakdown.tsx
+++ b/src/client/components/DecksPickBreakdown.tsx
@@ -131,9 +131,7 @@ const DraftmancerBreakdown: React.FC<BreakdownProps> = ({ draft, seatNumber, pic
                 onClick={(index) => {
                   let picks = 0;
                   for (let i = 0; i < listindex; i++) {
-                    if (draft.InitialState !== undefined) {
-                      picks += draft.InitialState[0][i].cards.length;
-                    }
+                    picks += picksList[listindex].length;
                   }
                   setPickNumber((picks + index).toString());
                 }}

--- a/src/client/components/DecksPickBreakdown.tsx
+++ b/src/client/components/DecksPickBreakdown.tsx
@@ -85,10 +85,15 @@ const DraftmancerBreakdown: React.FC<BreakdownProps> = ({ draft, seatNumber, pic
     const picksList = [];
     let subList = [];
     let cardsInPack: number[] = [];
-    let pick: number = 0;
+    //The pick number within the pack, for the overall pick matching pickNumber
+    let pick: number = 1;
+    //Track the pick number within the pack as we traverse the overall picks, since Draftmancer doesn't segment into packs unlike CubeCobra
+    let currentPackPick: number = 0;
+    //The pack currently within
     let pack = 1;
 
     for (let i = 0; i < log.length; i++) {
+      currentPackPick += 1;
       subList.push(log[i].pick);
       // if this is the last pack, or the next item is a new pack
       if (i === log.length - 1 || log[i].booster.length < log[i + 1].booster.length) {
@@ -97,12 +102,13 @@ const DraftmancerBreakdown: React.FC<BreakdownProps> = ({ draft, seatNumber, pic
 
         if (i < parseInt(pickNumber)) {
           pack += 1;
+          currentPackPick = 0;
         }
       }
 
       if (i === parseInt(pickNumber)) {
         cardsInPack = log[i].booster;
-        pick = log[i].pick;
+        pick = currentPackPick;
       }
     }
 
@@ -131,7 +137,7 @@ const DraftmancerBreakdown: React.FC<BreakdownProps> = ({ draft, seatNumber, pic
                 onClick={(index) => {
                   let picks = 0;
                   for (let i = 0; i < listindex; i++) {
-                    picks += picksList[listindex].length;
+                    picks += picksList[i].length;
                   }
                   setPickNumber((picks + index).toString());
                 }}
@@ -140,7 +146,7 @@ const DraftmancerBreakdown: React.FC<BreakdownProps> = ({ draft, seatNumber, pic
         </Flexbox>
       </Col>
       <Col xs={6} sm={8} lg={9} xl={10}>
-        <Text semibold lg>{`Pack ${(pack || 0) + 1}: Pick ${pick}`}</Text>
+        <Text semibold lg>{`Pack ${pack || 0}: Pick ${pick}`}</Text>
         <CardGrid
           xs={2}
           sm={3}


### PR DESCRIPTION
# Problems
1. Clicking on picks from packs > 1 on the left nav still shows the contents of the first pack
2. The pack/pick numbers were not accurate

# Testing

I tested a Draftmancer draft locally in two ways:
1. Exported from the reactProps the Draftmancer state from https://cubecobra.com/cube/deck/35d3237d-23dc-470c-9035-abd19f7a6cc2?view=picks&seat=1 (original bug report) and forced by local to use that in the reactProps. Had to use against a cube with an equivalent number of cards
2. Imported a Draftmancer draft into the api/draftmancer/publish endpoint. "Wacky" draft example provided by Dekkaru

## Before

As you click through the picks once you get to pack 2 you see the same cards as in pack 1 and the same pick #. Also you can see the pack/pick numbers are all over the place.
![old-draftmancer-draft-picks-recycles-first-pack](https://github.com/user-attachments/assets/494ce94c-4e4b-44a7-aa0c-d54197697310)

## After

Now each pack shows the correct cards
![new-draftmancer-draft-picks-through-packs](https://github.com/user-attachments/assets/e96ddca6-6c7a-472d-a227-60aa605439dc)

And the pick/pack number are accurate
![new-draftmancer-draft-picks-wacky-draft-correct-pack_pick-numbers](https://github.com/user-attachments/assets/713df08b-de37-4217-94e6-41340ed3fde5)
