### PR TITLE
Change tag filter to be partial matching instead of exact

### DIFF
--- a/src/client/filtering/FuncOperations.js
+++ b/src/client/filtering/FuncOperations.js
@@ -283,6 +283,7 @@ export const setCountOperation = (op, value) => {
 export const setElementOperation = (op, value) => {
   switch (op.toString()) {
     case ':':
+      return (fieldValue) => fieldValue?.some((elem) => elem?.toLowerCase().includes(value));
     case '=':
       return (fieldValue) => fieldValue?.some((elem) => elem?.toLowerCase() === value);
     case '<>':

--- a/src/client/filtering/FuncOperations.js
+++ b/src/client/filtering/FuncOperations.js
@@ -183,6 +183,7 @@ const canCastWith = (mana, cost) => {
   cost = [...cost]
     .filter((symbol) => symbol[0] === 'x' || symbol[0] === 'y' || symbol[0] === 'z')
     .map((symbol) => {
+      // eslint-disable-next-line no-console -- Debugging
       console.debug(symbol);
       if (symbol.length === 1) {
         const intValue = parseInt(symbol[0], 10);
@@ -210,6 +211,7 @@ const canCastWith = (mana, cost) => {
         intValue = 1;
       }
     }
+    // eslint-disable-next-line no-console -- Debugging
     console.debug(intValue);
     if (Number.isInteger(intValue)) {
       const remove = [];

--- a/src/client/pages/FiltersPage.tsx
+++ b/src/client/pages/FiltersPage.tsx
@@ -446,7 +446,7 @@ const FiltersPage: React.FC<FiltersPageProps> = ({ loginCallback }) => (
                 rows={[
                   {
                     query: <code>tag:Signed</code>,
-                    description: 'All cards in a cube who have a tag named Signed, case insensitive.',
+                    description: 'All cards in a cube who have a tag which contains Signed, case insensitive.',
                   },
                   {
                     query: <code>tags=0</code>,

--- a/src/client/pages/FiltersPage.tsx
+++ b/src/client/pages/FiltersPage.tsx
@@ -492,7 +492,8 @@ const FiltersPage: React.FC<FiltersPageProps> = ({ loginCallback }) => (
             <Accordion title="Legality">
               <p>
                 You can use <code>leg:</code>, <code>legal:</code>, or <code>legality:</code> to filter cards by
-                legality.
+                legality. Also <code>banned:</code>, <code>ban:</code>, or <code>restricted:</code> to check inversely.
+                The format name can also be double-quoted.
               </p>
               <Text semibold>Examples:</Text>
               <Table
@@ -504,6 +505,15 @@ const FiltersPage: React.FC<FiltersPageProps> = ({ loginCallback }) => (
                   {
                     query: <code>-leg:Standard</code>,
                     description: 'All cards that are not legal in Standard.',
+                  },
+                  {
+                    query: <code>banned:Modern</code>,
+                    description: 'All cards that are banned in Modern.',
+                  },
+                  {
+                    query: <code>restricted:"Vintage"</code>,
+                    description:
+                      'All cards that are restricted in Vintage (the only format with restrictions currently).',
                   },
                 ]}
               />

--- a/tests/cards/filterOperations.test.ts
+++ b/tests/cards/filterOperations.test.ts
@@ -7,27 +7,39 @@ describe('setElementOperation', () => {
     expect(result).toThrow('Unrecognized operator');
   });
 
-  it('Equality operators', async () => {
-    const result = () => setElementOperation('+=', 'Tag');
-    expect(result).toThrow(Error);
-    expect(result).toThrow('Unrecognized operator');
-  });
-
-  it.each([':', '='])('Equality operator matching (%s)', async (op) => {
+  it('Equality operator matching', async () => {
     //Predicate values are lowercased by the nearley grammar
-    const filterer = setElementOperation(op, 'fetch');
+    const filterer = setElementOperation('=', 'fetch');
 
     //The filter function for tags lowercases the inputs
     const tags = ['brazen', 'Fetch', 'Kindred'];
     expect(filterer(tags)).toBeTruthy();
   });
 
-  it.each([':', '='])('Equality operator NOT matching (%s)', async (op) => {
+  it('Equality operator NOT matching', async () => {
     //Predicate values are lowercased by the nearley grammar
-    const filterer = setElementOperation(op, 'travel');
+    const filterer = setElementOperation('=', 'travel');
 
     //The filter function for tags lowercases the inputs
     const tags = ['brazen', 'Fetch', 'Kindred'];
+    expect(filterer(tags)).toBeFalsy();
+  });
+
+  it('Contains operator matching', async () => {
+    //Predicate values are lowercased by the nearley grammar
+    const filterer = setElementOperation(':', 'fetch');
+
+    //The filter function for tags lowercases the inputs
+    const tags = ['brazen', 'Fetch Land', 'Kindred'];
+    expect(filterer(tags)).toBeTruthy();
+  });
+
+  it('Contains operator NOT matching', async () => {
+    //Predicate values are lowercased by the nearley grammar
+    const filterer = setElementOperation(':', 'rap');
+
+    //The filter function for tags lowercases the inputs
+    const tags = ['brazen', 'Fetch Land', 'Kindred'];
     expect(filterer(tags)).toBeFalsy();
   });
 

--- a/tests/cards/filterOperations.test.ts
+++ b/tests/cards/filterOperations.test.ts
@@ -1,0 +1,51 @@
+import { setElementOperation } from '../../src/client/filtering/FuncOperations';
+
+describe('setElementOperation', () => {
+  it('Invalid operator', async () => {
+    const result = () => setElementOperation('+=', 'Tag');
+    expect(result).toThrow(Error);
+    expect(result).toThrow('Unrecognized operator');
+  });
+
+  it('Equality operators', async () => {
+    const result = () => setElementOperation('+=', 'Tag');
+    expect(result).toThrow(Error);
+    expect(result).toThrow('Unrecognized operator');
+  });
+
+  it.each([':', '='])('Equality operator matching (%s)', async (op) => {
+    //Predicate values are lowercased by the nearley grammar
+    const filterer = setElementOperation(op, 'fetch');
+
+    //The filter function for tags lowercases the inputs
+    const tags = ['brazen', 'Fetch', 'Kindred'];
+    expect(filterer(tags)).toBeTruthy();
+  });
+
+  it.each([':', '='])('Equality operator NOT matching (%s)', async (op) => {
+    //Predicate values are lowercased by the nearley grammar
+    const filterer = setElementOperation(op, 'travel');
+
+    //The filter function for tags lowercases the inputs
+    const tags = ['brazen', 'Fetch', 'Kindred'];
+    expect(filterer(tags)).toBeFalsy();
+  });
+
+  it.each(['!=', '<>'])('Inequality operator matching (%s)', async (op) => {
+    //Predicate values are lowercased by the nearley grammar
+    const filterer = setElementOperation(op, 'fetch');
+
+    //The filter function for tags lowercases the inputs
+    const tags = ['brazen', 'Fetch', 'Kindred'];
+    expect(filterer(tags)).toBeFalsy();
+  });
+
+  it.each(['!=', '<>'])('Inequality operator NOT matching (%s)', async (op) => {
+    //Predicate values are lowercased by the nearley grammar
+    const filterer = setElementOperation(op, 'transit');
+
+    //The filter function for tags lowercases the inputs
+    const tags = ['brazen', 'Fetch', 'Kindred'];
+    expect(filterer(tags)).toBeTruthy();
+  });
+});

--- a/tests/cards/filtering.test.ts
+++ b/tests/cards/filtering.test.ts
@@ -153,3 +153,46 @@ describe('Tag filter syntax', () => {
     assertValidTagFilter(makeFilter('tag<=1'));
   });
 });
+
+const formatFilters = ['legality', 'legal', 'leg', 'banned', 'ban', 'restricted'];
+
+describe.each(formatFilters)('Format filter (%s)', (filterName) => {
+  const assertLegalityFilter = (result: FilterResult) => {
+    expect(result.err).toBeFalsy();
+    expect(result.filter).toBeInstanceOf(Function);
+    //All format type filters use the card's legality information
+    expect(result.filter?.fieldsUsed).toEqual(['legality']);
+  };
+
+  const availableFormats = [
+    'Standard',
+    'Pioneer',
+    'Modern',
+    'Legacy',
+    'Vintage',
+    'Brawl',
+    'Historic',
+    'Pauper',
+    'Penny',
+    'Commander',
+  ];
+
+  it.each(availableFormats)(`${filterName} filtering (%s)`, async (formatName) => {
+    assertLegalityFilter(makeFilter(`${filterName}:${formatName}`));
+    assertLegalityFilter(makeFilter(`${filterName}:"${formatName}"`));
+  });
+
+  it(`${filterName} filtering other operators`, async () => {
+    assertLegalityFilter(makeFilter(`${filterName}=Legacy`));
+    assertLegalityFilter(makeFilter(`${filterName}<>Standard`));
+    assertLegalityFilter(makeFilter(`${filterName}!="Modern"`));
+    assertLegalityFilter(makeFilter(`${filterName}!="Commander"`));
+  });
+
+  it(`${filterName} filtering unknown formats`, async () => {
+    expect(makeFilter(`${filterName}:TinyLeaders`).err).toBeTruthy();
+    expect(makeFilter(`${filterName}:Lega`).err).toBeTruthy();
+    expect(makeFilter(`${filterName}:EDH`).err).toBeTruthy();
+    expect(makeFilter(`${filterName}:"Oathbreaker"`).err).toBeTruthy();
+  });
+});

--- a/tests/cards/filtering.test.ts
+++ b/tests/cards/filtering.test.ts
@@ -1,6 +1,6 @@
 import { FilterResult, makeFilter } from '../../src/client/filtering/FilterCards';
 
-describe('Filter syntax', () => {
+describe('Name filter syntax', () => {
   const assertValidNameFilter = (result: FilterResult) => {
     expect(result.err).toBeFalsy();
     expect(result.filter).toBeInstanceOf(Function);
@@ -127,5 +127,29 @@ describe('Filter syntax', () => {
   it.each(failingNamesWithInterestingCharacters)('Failing names with interesting characters (%s)', async (name) => {
     const result = makeFilter(name);
     expect(result.err).toBeTruthy();
+  });
+});
+
+describe('Tag filter syntax', () => {
+  const assertValidTagFilter = (result: FilterResult) => {
+    expect(result.err).toBeFalsy();
+    expect(result.filter).toBeInstanceOf(Function);
+    expect(result.filter?.fieldsUsed).toEqual(['tags']);
+  };
+
+  it('Tag contents filter operations', async () => {
+    assertValidTagFilter(makeFilter('tag:fetch'));
+    assertValidTagFilter(makeFilter('tags:fetch'));
+  });
+
+  it('Tag count filter operations', async () => {
+    //All filters based on the number of tags
+    assertValidTagFilter(makeFilter('tag=3'));
+    assertValidTagFilter(makeFilter('tag!=3'));
+    assertValidTagFilter(makeFilter('tag<>3'));
+    assertValidTagFilter(makeFilter('tag>0'));
+    assertValidTagFilter(makeFilter('tag>=0'));
+    assertValidTagFilter(makeFilter('tag<2'));
+    assertValidTagFilter(makeFilter('tag<=1'));
   });
 });


### PR DESCRIPTION
# Problem
The tag filter with a string value is doing exact matching, which is less useful that a partial match and if you compare it to name filtering the `:` operation is for partial not exact matching.

Because the tag filter supports both strings (the tag value matches the string) and numbers (the count of tags) it is not really possible to support both `=` and `:` for strings, as that would cause ambiguity in the parser given that all numbers are a subset of a string.

# Solution
Update setElementOperation so that the `:` operator does partial matching of the set element value.

Though setElementOperation is also used in the various legality filters (legality, banned, restricted and variants), the change for `:` to partial match doesn't affect it because the grammar defines all the possible formats as full strings. Thus even though setElementOperation will be doing a partial match, its equivalent to an exact match given that only the exact format strings are allowed.

# Testing

## Before
It can match tags that are a single word (no spaces) without quotes:
![old-tag-string-exact-match-single-word](https://github.com/user-attachments/assets/d684e744-d876-4c4a-af53-f073512178f8)

But if the tag has a space, double quotes are required (otherwise the filter used is tag:word AND name contains word2)
![old-tag-string-quoted-exact-match-necessary-for-spaces](https://github.com/user-attachments/assets/372e0b62-0461-44d8-93fe-5dd346831321)

And per the above examples, Tag filter string only does exact matching so "Spell" doesn't match the tags with "Spells matter"
![old-tag-string-only-exact-match](https://github.com/user-attachments/assets/91191d64-7647-4438-8d8c-50fdbd7f70a1)

## After
Now tag does partial match:
![new-tag-string-partial-matching](https://github.com/user-attachments/assets/f0da8cdc-b54e-4e0c-a3b5-38f434463d8a)

Even with quotes for multiple words:
![new-tag-string-partial-matching-with-qoutes](https://github.com/user-attachments/assets/6f148935-d0ac-48be-8b9f-9388e646aea0)

Numeric matching still works:
![new-tag-numeric-matching-still-works2](https://github.com/user-attachments/assets/6608e281-0b36-4b37-9a6a-9d3224d4aee1)
![new-tag-numeric-matching-still-works](https://github.com/user-attachments/assets/4ef04e66-bf19-464d-bc4a-4d7d0fe91825)

