### PR TITLE
Reapply draftmancer deck picks breakdown fix

### DIFF
--- a/src/client/components/DecksPickBreakdown.tsx
+++ b/src/client/components/DecksPickBreakdown.tsx
@@ -167,8 +167,8 @@ const CubeBreakdown: React.FC<BreakdownProps> = ({ draft, seatNumber, pickNumber
   const onPickClick = (packIndex: number, pickIndex: number) => {
     let picks = 0;
     for (let i = 0; i < packIndex; i++) {
-      if (draft.InitialState?.[0]?.[i]?.cards?.length) {
-        picks += draft.InitialState[0][i].cards.length;
+      if (picksList[i]?.length) {
+        picks += picksList[i].length;
       }
     }
     setPickNumber((picks + pickIndex).toString());

--- a/src/client/components/DecksPickBreakdown.tsx
+++ b/src/client/components/DecksPickBreakdown.tsx
@@ -21,13 +21,17 @@ interface BreakdownProps {
   setPickNumber: (pickNumber: string) => void;
 }
 
-
 const CubeBreakdown: React.FC<BreakdownProps> = ({ draft, seatNumber, pickNumber, setPickNumber }) => {
   const [ratings, setRatings] = useState<number[]>([]);
   const [showRatings, setShowRatings] = useLocalStorage(`showDraftRatings-${draft.id}`, true);
 
   // Handle both CubeCobra and Draftmancer drafts
-  const { cardsInPack, pick = 0, pack = 0, picksList } = useMemo(() => {
+  const {
+    cardsInPack,
+    pick = 0,
+    pack = 0,
+    picksList,
+  } = useMemo(() => {
     // Draftmancer drafts
     if (draft.DraftmancerLog) {
       const log = draft.DraftmancerLog.players[seatNumber];
@@ -47,19 +51,19 @@ const CubeBreakdown: React.FC<BreakdownProps> = ({ draft, seatNumber, pickNumber
 
       for (let i = 0; i < log.length; i++) {
         subList.push({ cardIndex: log[i].pick });
-        
+
         // When we hit a pack boundary or the end
         if (i === log.length - 1 || (i + 1 < log.length && log[i].booster.length < log[i + 1].booster.length)) {
           draftPicksList.push([...subList]);
-          
+
           // If this pack contains our target pick
           if (totalPicks <= pickNum && totalPicks + subList.length > pickNum) {
             currentPick = pickNum - totalPicks + 1;
           }
-          
+
           totalPicks += subList.length;
           subList = [];
-          
+
           // Only increment pack if we haven't reached our target pick
           if (totalPicks <= pickNum) {
             currentPack += 1;
@@ -72,22 +76,22 @@ const CubeBreakdown: React.FC<BreakdownProps> = ({ draft, seatNumber, pickNumber
       }
 
       return {
-        cardsInPack: draftCardsInPack.map(index => ({ cardIndex: index })),
+        cardsInPack: draftCardsInPack.map((index) => ({ cardIndex: index })),
         pick: currentPick,
         pack: currentPack,
-        picksList: draftPicksList
+        picksList: draftPicksList,
       };
     }
-    
+
     // CubeCobra drafts
     const drafterState = getDrafterState(draft, seatNumber, parseInt(pickNumber));
     return {
-      cardsInPack: drafterState.cardsInPack.map(index => ({ cardIndex: index })),
+      cardsInPack: drafterState.cardsInPack.map((index) => ({ cardIndex: index })),
       pick: drafterState.pick ?? 0,
       pack: drafterState.pack ?? 0,
-      picksList: drafterState.picksList.map(list => 
-        list.map(item => ({ cardIndex: typeof item === 'number' ? item : item.cardIndex }))
-      )
+      picksList: drafterState.picksList.map((list) =>
+        list.map((item) => ({ cardIndex: typeof item === 'number' ? item : item.cardIndex })),
+      ),
     };
   }, [draft, seatNumber, pickNumber]);
 
@@ -95,7 +99,7 @@ const CubeBreakdown: React.FC<BreakdownProps> = ({ draft, seatNumber, pickNumber
   const currentPackPicks = picksList[pack] ?? [];
   const currentPickData = currentPackPicks[pick - 1];
   const actualPickIndex = cardsInPack.findIndex(
-    item => item.cardIndex === (currentPickData ? currentPickData.cardIndex : undefined)
+    (item) => item.cardIndex === (currentPickData ? currentPickData.cardIndex : undefined),
   );
 
   useEffect(() => {
@@ -119,9 +123,9 @@ const CubeBreakdown: React.FC<BreakdownProps> = ({ draft, seatNumber, pickNumber
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            pack: cardsInPack.map(item => draft.cards[item.cardIndex]?.details?.oracle_id).filter(Boolean),
-            picks: allPicks.map(idx => draft.cards[idx]?.details?.oracle_id).filter(Boolean)
-          })
+            pack: cardsInPack.map((item) => draft.cards[item.cardIndex]?.details?.oracle_id).filter(Boolean),
+            picks: allPicks.map((idx) => draft.cards[idx]?.details?.oracle_id).filter(Boolean),
+          }),
         });
 
         if (response.ok) {
@@ -129,7 +133,7 @@ const CubeBreakdown: React.FC<BreakdownProps> = ({ draft, seatNumber, pickNumber
           const newRatings = new Array(cardsInPack.length).fill(0);
           data.prediction.forEach((pred: { oracle: string; rating: number }) => {
             const cardIndex = cardsInPack.findIndex(
-              idx => draft.cards[idx.cardIndex].details?.oracle_id === pred.oracle
+              (idx) => draft.cards[idx.cardIndex].details?.oracle_id === pred.oracle,
             );
             if (cardIndex !== -1) {
               newRatings[cardIndex] = pred.rating;
@@ -205,14 +209,7 @@ const DecksPickBreakdown: React.FC<DecksPickBreakdownProps> = ({ draft, seatNumb
     return <Text>Sorry, we cannot display the pick breakdown for this draft.</Text>;
   }
 
-  return (
-    <CubeBreakdown 
-      pickNumber={pickNumber} 
-      seatNumber={seatNumber} 
-      draft={draft} 
-      setPickNumber={setPickNumber} 
-    />
-  );
+  return <CubeBreakdown pickNumber={pickNumber} seatNumber={seatNumber} draft={draft} setPickNumber={setPickNumber} />;
 };
 
 export default DecksPickBreakdown;


### PR DESCRIPTION
When validating the recent bug fixes in the most recent deployment I noticed that the deck picks for Draftmancer drafts did not get fixed. Found that my change was not fully incorporated into a change to show the draft bot predictions.

# Testing

## Before
Always showing the first pack contents and the bolding of the selected card is also on the first pack in the left nav
![old-deck-picks-draftmancer-always-first-pack](https://github.com/user-attachments/assets/f89293c6-0467-4682-9a17-8c2a038695bc)

## After
Back to correctly showing different packs / bolding the current pack card.
![new-deck-picks-draftmancer-draft](https://github.com/user-attachments/assets/9248fdca-ac6f-4dcb-b470-c0790e7cdfe4)
