### PR TITLE
Add back stopping propagation of click events if the button isn't a submit type.

### DIFF
--- a/src/client/components/base/Button.tsx
+++ b/src/client/components/base/Button.tsx
@@ -71,6 +71,10 @@ const Button: React.FC<ButtonProps> = ({
     <button
       className={classes}
       onClick={(e) => {
+        if (type !== 'submit') {
+          e.preventDefault();
+        }
+
         if (onClick) {
           onClick(e);
         }


### PR DESCRIPTION
Put it into a full if for clarity, compared to the previous form which relied on JS && as a shortform for "if not, then do".

I removed the line in https://github.com/dekkerglen/CubeCobra/pull/2589 when fixing lint issues. VSCode reported `Expected an assignment or function call and instead saw an expression.` which lead me to believe it wasn't doing anything, but on second look it is acting because of the && shortcut.