### PR TITLE
Correct (reduce) bottom margin on headers that aren't H1.

### DIFF
--- a/src/client/components/Markdown.tsx
+++ b/src/client/components/Markdown.tsx
@@ -199,7 +199,7 @@ interface RenderH2Props {
 const renderH2: React.FC<RenderH2Props> = (node) => {
   const id = generateHeadingId(node.children);
   return (
-    <Text id={id} xxxl semibold className="mb-4">
+    <Text id={id} xxxl semibold className="mb-2">
       {node.children}
     </Text>
   );
@@ -212,7 +212,7 @@ interface RenderH3Props {
 const renderH3: React.FC<RenderH3Props> = (node) => {
   const id = generateHeadingId(node.children);
   return (
-    <Text id={id} xxl semibold className="mb-4">
+    <Text id={id} xxl semibold className="mb-2">
       {node.children}
     </Text>
   );
@@ -225,7 +225,7 @@ interface RenderH4Props {
 const renderH4: React.FC<RenderH4Props> = (node) => {
   const id = generateHeadingId(node.children);
   return (
-    <Text id={id} xl semibold className="mb-4">
+    <Text id={id} xl semibold className="mb-2">
       {node.children}
     </Text>
   );
@@ -238,7 +238,7 @@ interface RenderH5Props {
 const renderH5: React.FC<RenderH5Props> = (node) => {
   const id = generateHeadingId(node.children);
   return (
-    <Text id={id} lg semibold className="mb-4">
+    <Text id={id} lg semibold className="mb-2">
       {node.children}
     </Text>
   );
@@ -251,7 +251,7 @@ interface RenderH6Props {
 const renderH6: React.FC<RenderH6Props> = (node) => {
   const id = generateHeadingId(node.children);
   return (
-    <Text id={id} md semibold className="mb-4">
+    <Text id={id} md semibold className="mb-2">
       {node.children}
     </Text>
   );


### PR DESCRIPTION
Copy/paste error in https://github.com/dekkerglen/CubeCobra/pull/2498 when fixing the header linking, used the H1 bottom margin for all by accident.

# Testing

## Before
![old-header-bottom-margin](https://github.com/user-attachments/assets/c1cec9c7-0a33-4228-904e-103dbe24b2f6)

## After
Less margin (half as much) on the headers that aren't H1
![new-header-bottom-margin](https://github.com/user-attachments/assets/18afe383-a7ae-44e8-9e9d-cf8b7e5ba9c4)
