### PR TITLE
Fix drafts failing when the basic lands are not literal lands.

### DIFF
--- a/src/util/draftbots.js
+++ b/src/util/draftbots.js
@@ -119,12 +119,18 @@ const calculateBasics = (mainboard, basics) => {
   const basicsNeeded = 40 - mainboard.length;
 
   const basicLands = basics.filter((card) => card.type.includes('Land'));
+  //Cube basics don't have to be actual land cards (could be land art cards or just regular cards).
+  //We need lands though in order to calculate pip sources and if none are found we bail, and the bot gets no basics added
+  if (basicLands.length === 0) {
+    return [];
+  }
 
   for (let i = 0; i < basicsNeeded; i++) {
     const pips = pipsPerSource([...mainboard, ...result]);
 
     let bestBasic = 0;
     let score = basicLands[0].color_identity.map((color) => pips[color]).reduce((a, b) => a + b, 0);
+    //Cube's are not restricted to having 1 of each basic land. Could have multiple of a basic land type or none of a type
     for (let j = 1; j < basicLands.length; j++) {
       const newScore = basicLands[j].color_identity.map((color) => pips[color]).reduce((a, b) => a + b, 0);
       if (newScore > score) {


### PR DESCRIPTION
The code was already handling no basics at all when filling out a bot's draft. But it wasn't handling if the cube's basics aren't actually lands, such that there were no basic lands for calculations.

# Testing

## Before
1. Configured my cube with art cards for basics
2. Do draft
3. Draft finish endpoint fails

## After
1. Configured my cube with art cards for basics
2. Do draft
3. Draft finish endpoint completes
4. Save deck
5. Look at bot decks, see no basics
6. Edit your draft
7. Try "Build for me"
8. See changes, but no basics

1. Switch to a cube with actual basics
2. Do draft
3. Draft finish endpoint completes
4. Save deck
5. Look at bot decks, see basic lands
6. Edit your draft
7. Try "Build for me"
8. See changes, with basics

# Concerns
The autocomplete for the cube basics is pretty awkward now, as searching for "island" or any other basic land shows 10 art cards. To get an actual basic you have to type "island [" or similar, and then further filter by set code. Doesn't feel like the best UX.