### PR TITLE
Fix subtype sorting/grouping because the raw labels didn't handle both type_line and details.type

### DIFF
--- a/src/client/utils/Sort.ts
+++ b/src/client/utils/Sort.ts
@@ -328,7 +328,7 @@ function getEloBucket(elo: number): string {
   return `${bucketFloor}-${bucketFloor + 49}`;
 }
 
-function getLabelsRaw(cube: Card[] | null, sort: string, showOther: boolean): string[] {
+export function getLabelsRaw(cube: Card[] | null, sort: string, showOther: boolean): string[] {
   let ret: string[] = [];
 
   /* Start of sort Options */

--- a/src/client/utils/Sort.ts
+++ b/src/client/utils/Sort.ts
@@ -422,7 +422,7 @@ export function getLabelsRaw(cube: Card[] | null, sort: string, showOther: boole
   } else if (sort === 'Subtype') {
     const types = new Set<string>();
     for (const card of cube || []) {
-      const split = (card.type_line || '').split(/[-–—]/);
+      const split = cardType(card).split(/[-–—]/);
       if (split.length > 1) {
         const subtypes = split[1].trim().split(' ');
         const nonemptySubtypes = subtypes.filter((x) => x.trim());


### PR DESCRIPTION
# Problem
As reported in Discord, expected subtypes were not showing in Cube Analysis table or in sorting the cube table view.

# Solution
getRawLabels for Subtype sort only checked card.type_line, whereas getCardLabels uses cardType(card) which checks card.type_line and then card.details.type

# Other
Should Tribal be replaced in Supertypes by Kindred, or just add Kindred? The latter would be better for old cubes if their cards have type_line that contain Tribal still

# Testing

## Before

Sorting by Subtype when all the cards in the cube have type_line is as expected:
![old-cube-sorting-subtypes-when-all-cards-have-type-line](https://github.com/user-attachments/assets/57a36a88-8c9e-4baf-92af-5ed82dc781c9)

But if the cards don't have type_line (but do have card.details.type) nothing is grouped correctly (screenshot is when show other is off)
![old-cube-sorting-subtypes-when-no-cards-have-type-line](https://github.com/user-attachments/assets/0edd5777-a6ed-4f91-b215-2f8763c7c0b7)

If I add a new card and set its type line to something unique, the sorting at least hows those new subtypes:
![image](https://github.com/user-attachments/assets/1da3da4f-e4c7-4b9d-99ca-b73afda21323)

Analysis page with rows=Subtype when all the cards in the cube have type_line is as expected:
![old-analysis-subtypes-when-all-cards-have-type-line](https://github.com/user-attachments/assets/de44803a-9ce7-4b10-b06c-6d0bba25e7c5)

But if most cards are missing type_line, the analysis page have few rows. Here is
![old-analysis-subtypes-when-most-cards-dont-have-type-line](https://github.com/user-attachments/assets/8b1ae1e0-7bef-4786-9336-57a7a73c86db)

## After
I took a cube on my local where all cards have type_line (was imported via CSV) and exported the names. I temporarily turned off setting type_line in the code and imported the names into a new cube. This was more efficient than adding cards one by one with the UI; that form of addition does not set card.type_line or other overrides (it only sets addedTmsp, board, cardID, index, and status).

Cube sorting when cards don't have type_line
![new-cube-sorting-subtypes-when-no-cards-have-type-line](https://github.com/user-attachments/assets/98214c3e-5637-401d-9c85-c1182d895cb8)

Working the same as when cards have type_line
![new-cube-sorting-subtypes-when-all-cards-have-type-line](https://github.com/user-attachments/assets/cb1c8136-5aa4-45aa-8b9e-d9f97d441c13)

With the card I configured a unique type line, it appears alongside the other cards that don't have type_line
![new-cube-sorting-subtypes-with-type-line-vs-without](https://github.com/user-attachments/assets/f4466f2a-e820-413e-be61-d52597dbadf7)

The analysis rows works and has the types for the cards without type_line and the one I configured for
![new-analyis-with-sub-types](https://github.com/user-attachments/assets/b86b676d-db76-4198-9540-13b991a8d9f0)

