### PR TITLE
Follow up to #2549, pull the promo_type from Scryfall onto Cards.

### DIFF
--- a/scripts/clean_followers.js
+++ b/scripts/clean_followers.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const Cube = require('../src/dynamo/models/cube');
-const { initializeCardDb } = require('../src/util/carddb');
+const { initializeCardDb } = require('../src/util/cardCatalog');
 
 (async () => {
   try {

--- a/scripts/rebuild_cube.js
+++ b/scripts/rebuild_cube.js
@@ -1,6 +1,6 @@
 const cubeId = '63ddcf7a75838178427ea858';
 
-const { initializeCardDb } = require('../src/util/carddb');
+const { initializeCardDb } = require('../src/util/cardCatalog');
 
 const ChangeLog = require('../src/dynamo/models/changelog');
 const Cube = require('../src/dynamo/models/cube');

--- a/src/app.js
+++ b/src/app.js
@@ -15,7 +15,7 @@ const rateLimit = require('express-rate-limit');
 const DynamoDBStore = require('dynamodb-store');
 const cloudwatch = require('./util/cloudwatch');
 const { updateCardbase } = require('./util/updatecards');
-const carddb = require('./util/carddb');
+const cardCatalog = require('./util/cardCatalog');
 const { render } = require('./util/render');
 const flash = require('connect-flash');
 
@@ -45,7 +45,6 @@ app.use((req, res, next) => {
 
   next();
 });
-
 
 // do this before https redirect
 app.post('/healthcheck', (req, res) => {
@@ -234,7 +233,6 @@ if (process.env.DOWNTIME_ACTIVE === 'true') {
   );
 }
 
-
 app.use((req, res, next) => {
   if (req.user && req.user.roles.includes('Banned')) {
     req.session.destroy(() => {
@@ -295,7 +293,7 @@ schedule.scheduleJob('0 10 * * *', async () => {
 });
 
 // Start server after carddb is initialized.
-carddb.initializeCardDb().then(async () => {
+cardCatalog.initializeCardDb().then(async () => {
   http.createServer(app).listen(process.env.PORT || 5000, '127.0.0.1');
   // eslint-disable-next-line no-console
   console.info(`Server started on port ${process.env.PORT || 5000}...`);

--- a/src/jobs/apply_scryfall_migrations.js
+++ b/src/jobs/apply_scryfall_migrations.js
@@ -1,5 +1,5 @@
 const fetch = require('node-fetch');
-const { initializeCardDb } = require('../util/carddb');
+const { initializeCardDb } = require('../util/cardCatalog');
 const Cube = require('../dynamo/models/cube');
 const _ = require('lodash');
 

--- a/src/jobs/export_cubes.ts
+++ b/src/jobs/export_cubes.ts
@@ -8,7 +8,8 @@ import Card from 'datatypes/Card';
 import { cardOracleId } from 'utils/cardutil';
 
 import type CubeType from '../datatypes/Cube';
-import { getAllOracleIds, initializeCardDb } from '../util/carddb';
+import { initializeCardDb } from '../util/cardCatalog';
+import { getAllOracleIds } from '../util/carddb';
 
 const Cube = require('../dynamo/models/cube');
 

--- a/src/jobs/export_decks.ts
+++ b/src/jobs/export_decks.ts
@@ -7,7 +7,7 @@ import 'module-alias/register';
 
 import type DraftType from '../datatypes/Draft';
 import Draft from '../dynamo/models/draft';
-import { initializeCardDb } from '../util/carddb';
+import { initializeCardDb } from '../util/cardCatalog';
 import { getDrafterState } from '../util/draftutil';
 
 const draftCardIndexToOracle = (cardIndex: string | number, draftCards: { [x: string]: any }) => {

--- a/src/jobs/export_simple_card_dict.ts
+++ b/src/jobs/export_simple_card_dict.ts
@@ -4,7 +4,8 @@ import fs from 'fs';
 
 import 'module-alias/register';
 
-import { getAllOracleIds, getMostReasonableById, getVersionsByOracleId, initializeCardDb } from '../util/carddb';
+import { initializeCardDb } from '../util/cardCatalog';
+import { getAllOracleIds, getMostReasonableById, getVersionsByOracleId } from '../util/carddb';
 
 (async () => {
   await initializeCardDb();

--- a/src/jobs/repair_hashes.js
+++ b/src/jobs/repair_hashes.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const Cube = require('../dynamo/models/cube');
 const CubeHash = require('../dynamo/models/cubeHash');
-const { initializeCardDb } = require('../util/carddb');
+const { initializeCardDb } = require('../util/cardCatalog');
 
 (async () => {
   try {

--- a/src/jobs/update_cards.ts
+++ b/src/jobs/update_cards.ts
@@ -19,7 +19,8 @@ import { CardDetails, ColorCategory, DefaultElo } from 'datatypes/Card';
 import { ManaSymbol } from 'datatypes/Mana';
 
 import * as cardutil from '../client/utils/cardutil';
-import { CardMetadata, fileToAttribute, reasonableCard } from '../util/carddb';
+import { CardMetadata, fileToAttribute } from '../util/cardCatalog';
+import { reasonableCard } from '../util/carddb';
 import * as util from '../util/util';
 
 interface ScryfallCard {

--- a/src/jobs/update_cards.ts
+++ b/src/jobs/update_cards.ts
@@ -33,6 +33,7 @@ interface ScryfallCard {
   reprint: boolean;
   border_color: string;
   promo: boolean;
+  promo_types: string[];
   digital: boolean;
   finishes: string[];
   prices: {
@@ -527,6 +528,7 @@ function convertCard(
     ck: ckPrice,
     mp: mpPrice,
   };
+  newcard.promo_types = card.promo_types || undefined;
 
   newcard.digital = card.digital;
   newcard.isToken = card.layout === 'token';

--- a/src/jobs/update_cube_history.ts
+++ b/src/jobs/update_cube_history.ts
@@ -13,7 +13,8 @@ import type ChangeLogType from 'datatypes/ChangeLog';
 import { Period, UnhydratedCardHistory } from '../datatypes/History';
 import CardHistory from '../dynamo/models/cardhistory';
 import ChangeLog from '../dynamo/models/changelog';
-import { cardFromId, initializeCardDb } from '../util/carddb';
+import { initializeCardDb } from '../util/cardCatalog';
+import { cardFromId } from '../util/carddb';
 import { getCubeTypes } from '../util/cubefn';
 
 type CubeDict = Record<string, string[]>;

--- a/src/jobs/update_draft_history.ts
+++ b/src/jobs/update_draft_history.ts
@@ -12,7 +12,7 @@ import type { CardAnalytic } from '../datatypes/CubeAnalytic';
 import type DraftType from '../datatypes/Draft';
 import CubeAnalytic from '../dynamo/models/cubeAnalytic';
 import Draft from '../dynamo/models/draft';
-import { initializeCardDb } from '../util/carddb';
+import { initializeCardDb } from '../util/cardCatalog';
 import { getDrafterState } from '../util/draftutil';
 
 // global listeners for promise rejections

--- a/src/jobs/update_metadata_dict.ts
+++ b/src/jobs/update_metadata_dict.ts
@@ -4,7 +4,8 @@ require('dotenv').config();
 
 const fs = require('fs');
 const { DefaultElo } = require('../datatypes/Card');
-import carddb, { cardFromId, CardMetadata, initializeCardDb, Related } from '../util/carddb';
+import { CardMetadata, initializeCardDb, Related } from '../util/cardCatalog';
+import carddb, { cardFromId } from '../util/carddb';
 const { encode, oracleInData } = require('../util/ml');
 const correlationLimit = 36;
 // import { HierarchicalNSW } from 'hnswlib-node';

--- a/src/util/cardCatalog.ts
+++ b/src/util/cardCatalog.ts
@@ -1,0 +1,107 @@
+import json from 'big-json';
+import fs from 'fs';
+
+type OracleIdIndex = number;
+
+export interface Related {
+  top: OracleIdIndex[];
+  creatures: OracleIdIndex[];
+  spells: OracleIdIndex[];
+  other: OracleIdIndex[];
+}
+export interface CardMetadata {
+  cubedWith: Related;
+  draftedWith: Related;
+  synergistic: Related;
+  elo: number;
+  popularity: number;
+  cubes: number;
+  picks: number;
+  mostSimilar: OracleIdIndex;
+}
+
+interface Catalog {
+  cardtree: Record<string, any>;
+  imagedict: Record<string, any>;
+  cardimages: Record<string, any>;
+  cardnames: string[];
+  full_names: string[];
+  nameToId: Record<string, string[]>;
+  oracleToId: Record<string, string[]>;
+  english: Record<string, string>;
+  _carddict: Record<string, any>;
+  indexToOracle: string[];
+  metadatadict: Record<string, CardMetadata>;
+  printedCardList: any[];
+}
+
+const catalog: Catalog = {
+  cardtree: {},
+  imagedict: {},
+  cardimages: {},
+  cardnames: [],
+  full_names: [],
+  nameToId: {},
+  oracleToId: {},
+  english: {},
+  _carddict: {},
+  indexToOracle: [],
+  metadatadict: {},
+  printedCardList: [], // for card filters
+};
+
+export const fileToAttribute: Record<string, keyof Catalog> = {
+  'carddict.json': '_carddict',
+  'cardtree.json': 'cardtree',
+  'names.json': 'cardnames',
+  'nameToId.json': 'nameToId',
+  'oracleToId.json': 'oracleToId',
+  'full_names.json': 'full_names',
+  'imagedict.json': 'imagedict',
+  'cardimages.json': 'cardimages',
+  'english.json': 'english',
+  'indexToOracle.json': 'indexToOracle',
+  'metadatadict.json': 'metadatadict',
+};
+
+async function loadJSONFile(filename: string, attribute: keyof Catalog) {
+  return new Promise<void>((resolve, reject) => {
+    try {
+      const readStream = fs.createReadStream(filename);
+      const parseStream = json.createParseStream();
+
+      parseStream.on('data', (parsed) => {
+        catalog[attribute] = parsed;
+      });
+
+      readStream.pipe(parseStream);
+
+      readStream.on('end', () => {
+        // eslint-disable-next-line no-console
+        console.info(`Loaded ${filename} into ${attribute}`);
+        resolve();
+      });
+    } catch (e) {
+      reject(e);
+    }
+  });
+}
+
+export async function loadAllFiles() {
+  await Promise.all(
+    Object.entries(fileToAttribute).map(([filename, attribute]) => loadJSONFile(`private/${filename}`, attribute)),
+  );
+}
+
+export async function initializeCardDb() {
+  // eslint-disable-next-line no-console
+  console.info('Loading carddb...');
+  await loadAllFiles();
+
+  catalog.printedCardList = Object.values(catalog._carddict).filter((card) => !card.digital && !card.isToken);
+
+  // eslint-disable-next-line no-console
+  console.info('Finished loading carddb.');
+}
+
+export default catalog;

--- a/src/util/cardCatalog.ts
+++ b/src/util/cardCatalog.ts
@@ -20,7 +20,7 @@ export interface CardMetadata {
   mostSimilar: OracleIdIndex;
 }
 
-interface Catalog {
+export interface Catalog {
   cardtree: Record<string, any>;
   imagedict: Record<string, any>;
   cardimages: Record<string, any>;

--- a/src/util/carddb.ts
+++ b/src/util/carddb.ts
@@ -1,73 +1,8 @@
-import json from 'big-json';
-import fs from 'fs';
-
 import { filterCardsDetails, FilterFunction } from '../client/filtering/FilterCards';
 import { detailsToCard } from '../client/utils/cardutil';
 import { SortFunctions } from '../client/utils/Sort';
 import { CardDetails, PrintingPreference } from '../datatypes/Card';
-
-type OracleIdIndex = number;
-
-export interface Related {
-  top: OracleIdIndex[];
-  creatures: OracleIdIndex[];
-  spells: OracleIdIndex[];
-  other: OracleIdIndex[];
-}
-export interface CardMetadata {
-  cubedWith: Related;
-  draftedWith: Related;
-  synergistic: Related;
-  elo: number;
-  popularity: number;
-  cubes: number;
-  picks: number;
-  mostSimilar: OracleIdIndex;
-}
-
-interface Catalog {
-  cardtree: Record<string, any>;
-  imagedict: Record<string, any>;
-  cardimages: Record<string, any>;
-  cardnames: string[];
-  full_names: string[];
-  nameToId: Record<string, string[]>;
-  oracleToId: Record<string, string[]>;
-  english: Record<string, string>;
-  _carddict: Record<string, any>;
-  indexToOracle: string[];
-  metadatadict: Record<string, CardMetadata>;
-  printedCardList: any[];
-}
-
-const catalog: Catalog = {
-  cardtree: {},
-  imagedict: {},
-  cardimages: {},
-  cardnames: [],
-  full_names: [],
-  nameToId: {},
-  oracleToId: {},
-  english: {},
-  _carddict: {},
-  indexToOracle: [],
-  metadatadict: {},
-  printedCardList: [], // for card filters
-};
-
-export const fileToAttribute: Record<string, keyof Catalog> = {
-  'carddict.json': '_carddict',
-  'cardtree.json': 'cardtree',
-  'names.json': 'cardnames',
-  'nameToId.json': 'nameToId',
-  'oracleToId.json': 'oracleToId',
-  'full_names.json': 'full_names',
-  'imagedict.json': 'imagedict',
-  'cardimages.json': 'cardimages',
-  'english.json': 'english',
-  'indexToOracle.json': 'indexToOracle',
-  'metadatadict.json': 'metadatadict',
-};
+import catalog from './cardCatalog';
 
 // eslint-disable-next-line camelcase
 export function getPlaceholderCard(scryfall_id: string): CardDetails {
@@ -127,46 +62,6 @@ export function cardFromId(id: string): CardDetails {
   }
 
   return details;
-}
-
-async function loadJSONFile(filename: string, attribute: keyof Catalog) {
-  return new Promise<void>((resolve, reject) => {
-    try {
-      const readStream = fs.createReadStream(filename);
-      const parseStream = json.createParseStream();
-
-      parseStream.on('data', (parsed) => {
-        catalog[attribute] = parsed;
-      });
-
-      readStream.pipe(parseStream);
-
-      readStream.on('end', () => {
-        // eslint-disable-next-line no-console
-        console.info(`Loaded ${filename} into ${attribute}`);
-        resolve();
-      });
-    } catch (e) {
-      reject(e);
-    }
-  });
-}
-
-export async function loadAllFiles() {
-  await Promise.all(
-    Object.entries(fileToAttribute).map(([filename, attribute]) => loadJSONFile(`private/${filename}`, attribute)),
-  );
-}
-
-export async function initializeCardDb() {
-  // eslint-disable-next-line no-console
-  console.info('Loading carddb...');
-  await loadAllFiles();
-
-  catalog.printedCardList = Object.values(catalog._carddict).filter((card) => !card.digital && !card.isToken);
-
-  // eslint-disable-next-line no-console
-  console.info('Finished loading carddb.');
 }
 
 export function reasonableCard(card: CardDetails): boolean {

--- a/src/util/updatecards.js
+++ b/src/util/updatecards.js
@@ -1,7 +1,7 @@
 require('dotenv').config();
 const fs = require('fs');
 const AWS = require('aws-sdk');
-const { fileToAttribute, loadAllFiles } = require('./carddb');
+const { fileToAttribute, loadAllFiles } = require('./cardCatalog');
 
 const downloadFromS3 = async (basePath = 'private') => {
   const s3 = new AWS.S3({

--- a/tests/cards/carddb.test.ts
+++ b/tests/cards/carddb.test.ts
@@ -25,7 +25,7 @@ jest.mock('../../src/util/cardCatalog', () => {
 });
 
 import { FilterFunction } from '../../src/client/filtering/FilterCards';
-import Card, { CardDetails } from '../../src/datatypes/Card';
+import Card, { CardDetails, PrintingPreference } from '../../src/datatypes/Card';
 import { getMostReasonable, reasonableCard } from '../../src/util/carddb';
 import { createCard, createCardDetails } from '../test-utils/data';
 
@@ -146,7 +146,7 @@ describe('getMostReasonable', () => {
     });
 
     fillCatalogWithCards([cardOne]);
-    expect(getMostReasonable('Unknown name', 'recent')).toBeNull();
+    expect(getMostReasonable('Unknown name', PrintingPreference.RECENT)).toBeNull();
   });
 
   it('Match found by name, one possible card', async () => {
@@ -155,7 +155,7 @@ describe('getMostReasonable', () => {
     });
 
     fillCatalogWithCards([cardOne]);
-    expect(getMostReasonable('Card 1', 'recent')).toEqual(cardOne.details);
+    expect(getMostReasonable('Card 1', PrintingPreference.RECENT)).toEqual(cardOne.details);
   });
 
   it('Unreasonable match found by name, but still returned as only card', async () => {
@@ -169,7 +169,7 @@ describe('getMostReasonable', () => {
     });
 
     fillCatalogWithCards([cardOne]);
-    expect(getMostReasonable('Nexus of Fate', 'recent')).toEqual(cardOne.details);
+    expect(getMostReasonable('Nexus of Fate', PrintingPreference.RECENT)).toEqual(cardOne.details);
   });
 
   it('Many unreasonable match found by name, first card by printing returned', async () => {
@@ -193,7 +193,7 @@ describe('getMostReasonable', () => {
     });
 
     fillCatalogWithCards([cardOne, cardTwo]);
-    expect(getMostReasonable('Nexus of Fate', 'first')).toEqual(cardTwo.details);
+    expect(getMostReasonable('Nexus of Fate', PrintingPreference.FIRST)).toEqual(cardTwo.details);
   });
 
   it('Lookup by oracle id', async () => {
@@ -219,7 +219,7 @@ describe('getMostReasonable', () => {
     });
 
     fillCatalogWithCards([cardOne, cardTwo]);
-    expect(getMostReasonable('abcd-efgh', 'first')).toEqual(cardTwo.details);
+    expect(getMostReasonable('abcd-efgh', PrintingPreference.FIRST)).toEqual(cardTwo.details);
   });
 
   it('Lookup by full card name, only considers that exact set/collector number', async () => {
@@ -249,7 +249,7 @@ describe('getMostReasonable', () => {
     });
 
     fillCatalogWithCards([cardOne, cardTwo]);
-    expect(getMostReasonable('Goblin Warleader [CMD-10]', 'recent')).toEqual(cardTwo.details);
+    expect(getMostReasonable('Goblin Warleader [CMD-10]', PrintingPreference.RECENT)).toEqual(cardTwo.details);
   });
 
   it('Matches found by name, sorting by released at primarily', async () => {
@@ -273,8 +273,8 @@ describe('getMostReasonable', () => {
     });
 
     fillCatalogWithCards([cardOne, cardTwo]);
-    expect(getMostReasonable('Giant Spider', 'recent')).toEqual(cardOne.details);
-    expect(getMostReasonable('Giant Spider', 'first')).toEqual(cardTwo.details);
+    expect(getMostReasonable('Giant Spider', PrintingPreference.RECENT)).toEqual(cardOne.details);
+    expect(getMostReasonable('Giant Spider', PrintingPreference.FIRST)).toEqual(cardTwo.details);
   });
 
   it('Matches found by name, collector sorting secondary after released', async () => {
@@ -308,8 +308,8 @@ describe('getMostReasonable', () => {
     });
 
     fillCatalogWithCards([cardOne, cardTwo, cardThree]);
-    expect(getMostReasonable('Giant Spider', 'recent')).toEqual(cardThree.details);
-    expect(getMostReasonable('Giant Spider', 'first')).toEqual(cardTwo.details);
+    expect(getMostReasonable('Giant Spider', PrintingPreference.RECENT)).toEqual(cardThree.details);
+    expect(getMostReasonable('Giant Spider', PrintingPreference.FIRST)).toEqual(cardTwo.details);
   });
 
   it('Matches found by name, filters to none', async () => {
@@ -349,7 +349,7 @@ describe('getMostReasonable', () => {
     filter.fieldsUsed = ['name'];
 
     fillCatalogWithCards([cardOne, cardTwo, cardThree]);
-    expect(getMostReasonable('Giant Spider', 'recent', filter)).toBeNull();
+    expect(getMostReasonable('Giant Spider', PrintingPreference.RECENT, filter)).toBeNull();
   });
 
   it('Matches found by name and filtering', async () => {
@@ -392,6 +392,6 @@ describe('getMostReasonable', () => {
     filter.fieldsUsed = ['set'];
 
     fillCatalogWithCards([cardOne, cardTwo, cardThree]);
-    expect(getMostReasonable('Giant Spider', 'first', filter)).toEqual(cardOne.details);
+    expect(getMostReasonable('Giant Spider', PrintingPreference.FIRST, filter)).toEqual(cardOne.details);
   });
 });

--- a/tests/cards/carddb.test.ts
+++ b/tests/cards/carddb.test.ts
@@ -1,21 +1,48 @@
-import { CardDetails } from '../../src/datatypes/Card';
-import { reasonableCard } from '../../src/util/carddb';
-import { createCardDetails } from '../test-utils/data';
+/* eslint-disable no-prototype-builtins */
+
+import { Catalog } from '../../src/util/cardCatalog';
+
+const mockCardCatalog: Catalog = {
+  cardtree: {},
+  imagedict: {},
+  cardimages: {},
+  cardnames: [],
+  full_names: [],
+  nameToId: {},
+  oracleToId: {},
+  english: {},
+  _carddict: {},
+  indexToOracle: [],
+  metadatadict: {},
+  printedCardList: [], // for card filters
+};
+
+jest.mock('../../src/util/cardCatalog', () => {
+  return {
+    __esModule: true,
+    default: mockCardCatalog,
+  };
+});
+
+import { FilterFunction } from '../../src/client/filtering/FilterCards';
+import Card, { CardDetails } from '../../src/datatypes/Card';
+import { getMostReasonable, reasonableCard } from '../../src/util/carddb';
+import { createCard, createCardDetails } from '../test-utils/data';
+
+const overridesForNormalDetails: Partial<CardDetails> = {
+  isExtra: false,
+  promo: false,
+  digital: false,
+  isToken: false,
+  border_color: 'black',
+  promo_types: undefined,
+  language: 'en',
+  tcgplayer_id: '12345',
+  collector_number: '270',
+  layout: 'normal',
+};
 
 describe('reasonableCard', () => {
-  const overridesForNormalDetails: Partial<CardDetails> = {
-    isExtra: false,
-    promo: false,
-    digital: false,
-    isToken: false,
-    border_color: 'black',
-    promo_types: undefined,
-    language: 'en',
-    tcgplayer_id: '12345',
-    collector_number: '270',
-    layout: 'normal',
-  };
-
   it('Regular details are reasonable', async () => {
     const details = createCardDetails(overridesForNormalDetails);
 
@@ -80,5 +107,291 @@ describe('reasonableCard', () => {
     const details = createCardDetails({ ...overridesForNormalDetails, layout: 'art_series' });
 
     expect(reasonableCard(details)).toBeFalsy();
+  });
+});
+
+describe('getMostReasonable', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const fillCatalogWithCards = (cards: Card[]) => {
+    //Reset
+    mockCardCatalog._carddict = {};
+    mockCardCatalog.nameToId = {};
+    mockCardCatalog.oracleToId = {};
+
+    cards.forEach((card) => {
+      const cardId = card.details?.scryfall_id || '';
+      const name = card?.details?.name_lower || '';
+      const oracleId = card?.details?.oracle_id || '';
+
+      mockCardCatalog._carddict[cardId] = card.details;
+
+      if (!mockCardCatalog.nameToId.hasOwnProperty(name)) {
+        mockCardCatalog.nameToId[name] = [];
+      }
+      mockCardCatalog.nameToId[name].push(cardId);
+
+      if (!mockCardCatalog.oracleToId.hasOwnProperty(oracleId)) {
+        mockCardCatalog.oracleToId[oracleId] = [];
+      }
+      mockCardCatalog.oracleToId[oracleId].push(cardId);
+    });
+  };
+
+  it('No match found by name', async () => {
+    const cardOne = createCard({
+      details: createCardDetails({ ...overridesForNormalDetails, name: 'Card 1', name_lower: 'card 1' }),
+    });
+
+    fillCatalogWithCards([cardOne]);
+    expect(getMostReasonable('Unknown name', 'recent')).toBeNull();
+  });
+
+  it('Match found by name, one possible card', async () => {
+    const cardOne = createCard({
+      details: createCardDetails({ ...overridesForNormalDetails, name: 'Card 1', name_lower: 'card 1' }),
+    });
+
+    fillCatalogWithCards([cardOne]);
+    expect(getMostReasonable('Card 1', 'recent')).toEqual(cardOne.details);
+  });
+
+  it('Unreasonable match found by name, but still returned as only card', async () => {
+    const cardOne = createCard({
+      details: createCardDetails({
+        ...overridesForNormalDetails,
+        name: 'Nexus of Fate',
+        name_lower: 'nexus of fate',
+        promo: true,
+      }),
+    });
+
+    fillCatalogWithCards([cardOne]);
+    expect(getMostReasonable('Nexus of Fate', 'recent')).toEqual(cardOne.details);
+  });
+
+  it('Many unreasonable match found by name, first card by printing returned', async () => {
+    const cardOne = createCard({
+      details: createCardDetails({
+        ...overridesForNormalDetails,
+        name: 'Nexus of Fate',
+        name_lower: 'nexus of fate',
+        promo: true,
+        collector_number: '653',
+      }),
+    });
+    const cardTwo = createCard({
+      details: createCardDetails({
+        ...overridesForNormalDetails,
+        name: 'Nexus of Fate',
+        name_lower: 'nexus of fate',
+        promo: true,
+        collector_number: '67',
+      }),
+    });
+
+    fillCatalogWithCards([cardOne, cardTwo]);
+    expect(getMostReasonable('Nexus of Fate', 'first')).toEqual(cardTwo.details);
+  });
+
+  it('Lookup by oracle id', async () => {
+    const cardOne = createCard({
+      details: createCardDetails({
+        ...overridesForNormalDetails,
+        name: 'Goblin Warleader',
+        name_lower: 'goblin warleader',
+        collector_number: '10',
+        released_at: '2022/04/17',
+        oracle_id: 'abcd-efgh',
+      }),
+    });
+    const cardTwo = createCard({
+      details: createCardDetails({
+        ...overridesForNormalDetails,
+        name: 'Goblin Warleader',
+        name_lower: 'goblin warleader',
+        collector_number: '10',
+        released_at: '1995/01/31',
+        oracle_id: '1234-5678',
+      }),
+    });
+
+    fillCatalogWithCards([cardOne, cardTwo]);
+    expect(getMostReasonable('abcd-efgh', 'first')).toEqual(cardTwo.details);
+  });
+
+  it('Lookup by full card name, only considers that exact set/collector number', async () => {
+    const cardOne = createCard({
+      details: createCardDetails({
+        ...overridesForNormalDetails,
+        name: 'Goblin Warleader',
+        name_lower: 'goblin warleader',
+        collector_number: '13',
+        released_at: '2022/04/17',
+        oracle_id: 'abcd-efgh',
+        set: 'AFR',
+        full_name: 'Goblin Warleader [ARF-13]',
+      }),
+    });
+    const cardTwo = createCard({
+      details: createCardDetails({
+        ...overridesForNormalDetails,
+        name: 'Goblin Warleader',
+        name_lower: 'goblin warleader',
+        collector_number: '10',
+        released_at: '1995/01/31',
+        oracle_id: '1234-5678',
+        set: 'CMD',
+        full_name: 'Goblin Warleader [CMD-10]',
+      }),
+    });
+
+    fillCatalogWithCards([cardOne, cardTwo]);
+    expect(getMostReasonable('Goblin Warleader [CMD-10]', 'recent')).toEqual(cardTwo.details);
+  });
+
+  it('Matches found by name, sorting by released at primarily', async () => {
+    const cardOne = createCard({
+      details: createCardDetails({
+        ...overridesForNormalDetails,
+        name: 'Giant Spider',
+        name_lower: 'giant spider',
+        collector_number: '10',
+        released_at: '2022/04/17',
+      }),
+    });
+    const cardTwo = createCard({
+      details: createCardDetails({
+        ...overridesForNormalDetails,
+        name: 'Giant Spider',
+        name_lower: 'giant spider',
+        collector_number: '10',
+        released_at: '1995/01/31',
+      }),
+    });
+
+    fillCatalogWithCards([cardOne, cardTwo]);
+    expect(getMostReasonable('Giant Spider', 'recent')).toEqual(cardOne.details);
+    expect(getMostReasonable('Giant Spider', 'first')).toEqual(cardTwo.details);
+  });
+
+  it('Matches found by name, collector sorting secondary after released', async () => {
+    const cardOne = createCard({
+      details: createCardDetails({
+        ...overridesForNormalDetails,
+        name: 'Giant Spider',
+        name_lower: 'giant spider',
+        collector_number: '232',
+        released_at: '2022/04/17',
+      }),
+    });
+    const cardTwo = createCard({
+      details: createCardDetails({
+        ...overridesForNormalDetails,
+        name: 'Giant Spider',
+        name_lower: 'giant spider',
+        collector_number: '17',
+        released_at: '2022/04/17',
+      }),
+    });
+
+    const cardThree = createCard({
+      details: createCardDetails({
+        ...overridesForNormalDetails,
+        name: 'Giant Spider',
+        name_lower: 'giant spider',
+        collector_number: '477',
+        released_at: '2022/04/17',
+      }),
+    });
+
+    fillCatalogWithCards([cardOne, cardTwo, cardThree]);
+    expect(getMostReasonable('Giant Spider', 'recent')).toEqual(cardThree.details);
+    expect(getMostReasonable('Giant Spider', 'first')).toEqual(cardTwo.details);
+  });
+
+  it('Matches found by name, filters to none', async () => {
+    const cardOne = createCard({
+      details: createCardDetails({
+        ...overridesForNormalDetails,
+        name: 'Giant Spider',
+        name_lower: 'giant spider',
+        collector_number: '232',
+        released_at: '2022/04/17',
+      }),
+    });
+    const cardTwo = createCard({
+      details: createCardDetails({
+        ...overridesForNormalDetails,
+        name: 'Giant Spider',
+        name_lower: 'giant spider',
+        collector_number: '17',
+        released_at: '2022/04/17',
+      }),
+    });
+
+    const cardThree = createCard({
+      details: createCardDetails({
+        ...overridesForNormalDetails,
+        name: 'Giant Spider',
+        name_lower: 'giant spider',
+        collector_number: '477',
+        released_at: '2022/04/17',
+      }),
+    });
+
+    const filter: FilterFunction = (): boolean => {
+      return false;
+    };
+    filter.stringify = 'blah';
+    filter.fieldsUsed = ['name'];
+
+    fillCatalogWithCards([cardOne, cardTwo, cardThree]);
+    expect(getMostReasonable('Giant Spider', 'recent', filter)).toBeNull();
+  });
+
+  it('Matches found by name and filtering', async () => {
+    const cardOne = createCard({
+      details: createCardDetails({
+        ...overridesForNormalDetails,
+        name: 'Giant Spider',
+        name_lower: 'giant spider',
+        collector_number: '232',
+        released_at: '2022/04/17',
+        set: 'DMR',
+      }),
+    });
+    const cardTwo = createCard({
+      details: createCardDetails({
+        ...overridesForNormalDetails,
+        name: 'Giant Spider',
+        name_lower: 'giant spider',
+        collector_number: '17',
+        released_at: '2022/04/17',
+        set: 'LEA',
+      }),
+    });
+
+    const cardThree = createCard({
+      details: createCardDetails({
+        ...overridesForNormalDetails,
+        name: 'Giant Spider',
+        name_lower: 'giant spider',
+        collector_number: '477',
+        released_at: '2022/04/17',
+        set: 'DMR',
+      }),
+    });
+
+    const filter: FilterFunction = (card): boolean => {
+      return card.details?.set.includes('DMR') || false;
+    };
+    filter.stringify = 'blah';
+    filter.fieldsUsed = ['set'];
+
+    fillCatalogWithCards([cardOne, cardTwo, cardThree]);
+    expect(getMostReasonable('Giant Spider', 'first', filter)).toEqual(cardOne.details);
   });
 });

--- a/tests/cards/carddb.test.ts
+++ b/tests/cards/carddb.test.ts
@@ -1,0 +1,84 @@
+import { CardDetails } from '../../src/datatypes/Card';
+import { reasonableCard } from '../../src/util/carddb';
+import { createCardDetails } from '../test-utils/data';
+
+describe('reasonableCard', () => {
+  const overridesForNormalDetails: Partial<CardDetails> = {
+    isExtra: false,
+    promo: false,
+    digital: false,
+    isToken: false,
+    border_color: 'black',
+    promo_types: undefined,
+    language: 'en',
+    tcgplayer_id: '12345',
+    collector_number: '270',
+    layout: 'normal',
+  };
+
+  it('Regular details are reasonable', async () => {
+    const details = createCardDetails(overridesForNormalDetails);
+
+    expect(reasonableCard(details)).toBeTruthy();
+  });
+
+  it('Extras are not reasonable', async () => {
+    const details = createCardDetails({ ...overridesForNormalDetails, isExtra: true });
+
+    expect(reasonableCard(details)).toBeFalsy();
+  });
+
+  it('Promos are not reasonable', async () => {
+    const details = createCardDetails({ ...overridesForNormalDetails, promo: true });
+
+    expect(reasonableCard(details)).toBeFalsy();
+  });
+
+  it('Digital cards are not reasonable', async () => {
+    const details = createCardDetails({ ...overridesForNormalDetails, digital: true });
+
+    expect(reasonableCard(details)).toBeFalsy();
+  });
+
+  it('Tokens are not reasonable', async () => {
+    const details = createCardDetails({ ...overridesForNormalDetails, isToken: true });
+
+    expect(reasonableCard(details)).toBeFalsy();
+  });
+
+  it('Gold borders are not reasonable', async () => {
+    const details = createCardDetails({ ...overridesForNormalDetails, border_color: 'gold' });
+
+    expect(reasonableCard(details)).toBeFalsy();
+  });
+
+  it('Promo variants are not reasonable', async () => {
+    const details = createCardDetails({ ...overridesForNormalDetails, promo_types: ['boosterfun'] });
+
+    expect(reasonableCard(details)).toBeFalsy();
+  });
+
+  it('Non-english cards are not reasonable', async () => {
+    const details = createCardDetails({ ...overridesForNormalDetails, language: 'fr' });
+
+    expect(reasonableCard(details)).toBeFalsy();
+  });
+
+  it('Must have TGC player ID to be reasonable', async () => {
+    const details = createCardDetails({ ...overridesForNormalDetails, tcgplayer_id: undefined });
+
+    expect(reasonableCard(details)).toBeFalsy();
+  });
+
+  it('Must not be a promo based on collector number to be reasonable', async () => {
+    const details = createCardDetails({ ...overridesForNormalDetails, collector_number: '177★' });
+
+    expect(reasonableCard(details)).toBeFalsy();
+  });
+
+  it('Must not be an art series card to be reasonable', async () => {
+    const details = createCardDetails({ ...overridesForNormalDetails, layout: 'art_series' });
+
+    expect(reasonableCard(details)).toBeFalsy();
+  });
+});

--- a/tests/test-utils/data.ts
+++ b/tests/test-utils/data.ts
@@ -46,6 +46,7 @@ export const createCardDetails = (overrides?: Partial<CardDetails>): CardDetails
   collector_number: '123',
   released_at: '',
   promo: false,
+  promo_types: undefined,
   reprint: false,
   digital: false,
   full_name: generateRandomString(LETTERS, 10, 25),


### PR DESCRIPTION
This supports promo_type being used to filter variants during "reasonable cards" search, eliminating things like alternate frames, booster fun, etc.

cc @DankTrainTom 

Works with https://github.com/dekkerglen/CubeCobra/pull/2549

With https://github.com/dekkerglen/CubeCobra/pull/2616 that gives User's the choice of most recent or first printing, we could add more allowed values such that someone can want to see promos or at least alternative frames. For example Eldraine adventure cards have the scrollwork frame are tracked as promos because they have "showcase" frame_effects, but I could see someone wanting to use that printing yet exclude literal promos. The best example I can come up with is Brazen Borrower, whose showcase frame is https://scryfall.com/card/eld/281/brazen-borrower-petty-theft but then has later promos like https://scryfall.com/card/spg/30/brazen-borrower-petty-theft (special guest) or secret lairs. But of course that is a topic for another day, just adding as context.

## Edit
Added unit tests for reasonableCard and getMostReasonable. The latter required me to extract the catalog loading from carddb.ts to a separate file, in order to be able to mock the catalog with Jest. Tthough https://jestjs.io/docs/mock-functions#mocking-partials worked to mock the catalog as imported to the test, it did not allow changing the catalog as it existed within the carddb file.

For additional regression testing I re-ran the update cards function and re-tested the card search, using debugging to validate the catalog as imported into carddb has contents even if coming from cardCatalog and async filled in.

# Testing

## Before
Most recent printing includes Tamiyo promo (https://scryfall.com/card/mh3/443/tamiyo-inquisitive-student-tamiyo-seasoned-scholar) which is not considered a literal promo (card.promo === false) but does have promo_types (bundle and boosterfun)
![old-tamiyo-most-recent-includes-promo-type](https://github.com/user-attachments/assets/857f58de-15ab-467b-9734-9d58f643898d)

## After
Those promo like variants are filtered and then the original printing is returned:
![new-tamiyo-most-recent-filters-promos](https://github.com/user-attachments/assets/9313abe1-a439-412a-a824-8a38ee1a35de)
