### PR TITLE
Fix not using distinct card names for searches due to incorrect number of arguments.

### DIFF
--- a/src/routes/tools_routes.js
+++ b/src/routes/tools_routes.js
@@ -85,6 +85,7 @@ router.get('/api/topcards', async (req, res) => {
       req.query.s,
       parseInt(req.query.p, 10),
       req.query.d,
+      'names',
       req?.user?.defaultPrinting,
     );
     res.status(200).send({
@@ -144,6 +145,7 @@ router.get('/topcards', async (req, res) => {
       req.query.s,
       parseInt(req.query.p, 10),
       req.query.d,
+      'names',
       req?.user?.defaultPrinting,
     );
 


### PR DESCRIPTION
Default arguments can be tricky especially when adding a new parameter. Thankfully this is something Typescript would statically see when distinct and printings have clearly defined types for the args.

# Testing 

## Before
In top cards, when filtering by name:
![old-multiple-cards-by-name](https://github.com/user-attachments/assets/b73f3b76-21bd-471a-b49b-e60b59dca527)

## After
In top cards without a filter, total # of cards smaller:
![new-top-cards-smaller-set](https://github.com/user-attachments/assets/9f23a058-e595-4bc7-bf4d-626c0d8b1277)

In top cards, when filtering by name:
![new-top-cards-distinct-names](https://github.com/user-attachments/assets/abc4bdb3-baa4-4e72-9850-a89808dd39a3)

Card search with default distinct by names
![new-search-cards-distinct-names](https://github.com/user-attachments/assets/68c99c78-7245-47f1-9c7b-db879280365c)

Card search with distinct by printings shows all
![new-search-cards-distinct-printings](https://github.com/user-attachments/assets/c078d779-9209-4bb5-82e3-c41d86523c2e)

