### PR TITLE
Fix for packages saved with card objects instead of card ids

### DIFF
--- a/src/dynamo/models/package.ts
+++ b/src/dynamo/models/package.ts
@@ -143,13 +143,17 @@ const packages = {
 
     let cardIds: string[] = [];
     if (document.cards) {
-      cardIds = document.cards.map((card) => {
-        if (typeof card !== 'string' && card.scryfall_id) {
-          return card.scryfall_id;
-        } else {
-          return card as string;
-        }
-      });
+      cardIds = document.cards
+        .map((card) => {
+          if (typeof card !== 'string' && card.scryfall_id) {
+            return card.scryfall_id;
+          } else if (typeof card === 'string') {
+            return card as string;
+          } else {
+            return undefined;
+          }
+        })
+        .filter((cardId) => cardId !== undefined);
     }
 
     await client.put({

--- a/src/dynamo/models/package.ts
+++ b/src/dynamo/models/package.ts
@@ -68,7 +68,13 @@ const hydrate = async (pack?: UnhydratedCardPackage): Promise<CardPackage | unde
 
   const owner = await User.getById(pack.owner);
   const cards = pack.cards.map((c) => {
-    return cardFromId(c);
+    // @ts-expect-error -- Temporary solution for cards accidently saved to dynamo instead of card ids
+    if (typeof c !== 'string' && c.scryfall_id) {
+      // @ts-expect-error -- Temporary solution
+      return cardFromId(c.scryfall_id);
+    } else {
+      return cardFromId(c);
+    }
   });
 
   return createHydratedPackage(pack, owner, cards);
@@ -80,7 +86,13 @@ const batchHydrate = async (packs: UnhydratedCardPackage[]): Promise<CardPackage
   return packs.map((pack) => {
     const owner = owners.find((owner) => owner.id === pack.owner);
     const cards = pack.cards.map((c) => {
-      return cardFromId(c);
+      // @ts-expect-error -- Temporary solution for cards accidently saved to dynamo instead of card ids
+      if (typeof c !== 'string' && c.scryfall_id) {
+        // @ts-expect-error -- Temporary solution
+        return cardFromId(c.scryfall_id);
+      } else {
+        return cardFromId(c);
+      }
     });
 
     //Technically it is possible to not find an owner but let's assume our data is correct


### PR DESCRIPTION
No real idea how that might have occurred. My guess from the old code is https://github.com/dekkerglen/CubeCobra/blob/6a9504f98874f8bcbc72d2224539b7ff770f6f38/src/dynamo/models/package.js#L122 that objects somehow crept through. If it was because the card was an object but didn't have a scryfall_id, well then this change won't help.

If this doesn't fix it, not sure what the root cause is. If it does fix the packages on load, then I plan to vote on each to save and fix the data in dynamo =)

# Testing
First I validated everything is working in master. Successfully created packages and did actions like voting. The former has card ids as strings, and the latter has cards as objects from hydraton.

## Before
1. Modified the put code so that the map did nothing (input == output)
2. Created a package
3. It works with cards as strings
4. Voted on the package
5. Now cards stored as objects
6. Now the cards in the package all displayed as not found (using placeholder card)

Visually
![old-broken-card-package-with-cardids-as-objects](https://github.com/user-attachments/assets/c781fa38-8884-48e1-acfb-43baeb637210)
Data in dynamo:
![old-broken-cardids-stored-in-dynamo](https://github.com/user-attachments/assets/cd57748d-5a93-45f1-bd7e-0c8b44ee1986)

## After
1. Reverted the put change so the scryfall_id is pulled off objects, and otherwise strings are strings
2. Now the package loads with real cards
3. Voted on the package
4. The mapping correctly results in an array of strings saved for card ids

Packages fixed on loading by handling objects and using their scryfall_id
![new-fix-incorrect-cardids-on-load](https://github.com/user-attachments/assets/b50fa142-8b29-4e05-9e8e-ab9562156781)

See in debugger how on the document (put input) the cards are objects, but the mapped cardIds are an array of strings
![new-cardids-fixed-on-save](https://github.com/user-attachments/assets/5095437a-9ca0-42c8-b0c3-208a18b785fb)

And see in dynamo fixed to array of strings
![new-cardids-fixed-on-save2](https://github.com/user-attachments/assets/1e292244-78dd-421d-beca-4272265c1a4d)
