### PR TITLE
Use user or cube printing preference in more places cards are shown (ML stuff)

### DIFF
--- a/src/datatypes/Card.ts
+++ b/src/datatypes/Card.ts
@@ -171,7 +171,7 @@ export enum PrintingPreference {
   RECENT = 'recent',
   FIRST = 'first',
 }
-export const DefaultPrintingPreference = PrintingPreference.RECENT;
+export const DefaultPrintingPreference = PrintingPreference.FIRST;
 
 export default interface Card {
   index?: number;

--- a/src/routes/cube/api.js
+++ b/src/routes/cube/api.js
@@ -10,7 +10,7 @@ import carddb, {
   getAllMostReasonable,
   getIdsFromName,
   getMostReasonable,
-  getReasonableCardByOracle,
+  getReasonableCardByOracleWithPrintingPreference,
 } from '../../util/carddb';
 const { ensureAuth, jsonValidationErrors } = require('../middleware');
 const util = require('../../util/util');
@@ -805,6 +805,8 @@ router.post('/adds', async (req, res) => {
   let slice;
   let { length } = adds;
 
+  const cube = await Cube.getById(cubeID);
+
   if (filterText && filterText.length > 0) {
     const { err, filter } = makeFilter(`${filterText}`);
 
@@ -815,8 +817,6 @@ router.post('/adds', async (req, res) => {
         hasMoreAdds: false,
       });
     }
-
-    const cube = await Cube.getById(cubeID);
 
     const eligible = getAllMostReasonable(filter, cube.defaultPrinting);
     length = eligible.length;
@@ -830,7 +830,7 @@ router.post('/adds', async (req, res) => {
 
   return res.status(200).send({
     adds: slice.map((item) => {
-      const card = getReasonableCardByOracle(item.oracle);
+      const card = getReasonableCardByOracleWithPrintingPreference(item.oracle, cube.defaultPrinting);
       return {
         details: card,
         cardID: card.scryfall_id,
@@ -848,6 +848,7 @@ router.post('/cuts', async (req, res) => {
   const { cuts } = recommend(cards.mainboard.map((card) => card.details.oracle_id));
 
   let slice = cuts;
+  const cube = await Cube.getById(cubeID);
 
   if (filterText && filterText.length > 0) {
     const { err, filter } = makeFilter(`${filterText}`);
@@ -859,8 +860,6 @@ router.post('/cuts', async (req, res) => {
       });
     }
 
-    const cube = await Cube.getById(cubeID);
-
     const eligible = getAllMostReasonable(filter, cube.defaultPrinting);
 
     const oracleToEligible = Object.fromEntries(eligible.map((card) => [card.oracle_id, true]));
@@ -870,7 +869,7 @@ router.post('/cuts', async (req, res) => {
 
   return res.status(200).send({
     cuts: slice.map((item) => {
-      const card = getReasonableCardByOracle(item.oracle);
+      const card = getReasonableCardByOracleWithPrintingPreference(item.oracle, cube.defaultPrinting);
       return {
         details: card,
         cardID: card.scryfall_id,

--- a/src/routes/tools_routes.js
+++ b/src/routes/tools_routes.js
@@ -169,12 +169,13 @@ router.get('/topcards', async (req, res) => {
 router.get('/card/:id', async (req, res) => {
   try {
     let { id } = req.params;
+    const printingPreference = req?.user?.defaultPrinting;
 
     // if id is a cardname, redirect to the default version for that card
     const possibleName = cardutil.decodeName(id);
     const ids = getIdsFromName(possibleName);
     if (ids) {
-      id = getMostReasonable(possibleName, req?.user?.defaultPrinting).scryfall_id;
+      id = getMostReasonable(possibleName, printingPreference).scryfall_id;
     }
 
     // if id is a foreign id, redirect to english version
@@ -185,7 +186,7 @@ router.get('/card/:id', async (req, res) => {
 
     // if id is an oracle id, redirect to most reasonable scryfall
     if (carddb.oracleToId[id]) {
-      id = getMostReasonableById(carddb.oracleToId[id][0], req?.user?.defaultPrinting).scryfall_id;
+      id = getMostReasonableById(carddb.oracleToId[id][0], printingPreference).scryfall_id;
     }
 
     // if id is not a scryfall ID, error
@@ -202,8 +203,8 @@ router.get('/card/:id', async (req, res) => {
       history.items.push({});
     }
 
-    const related = getRelatedCards(card.oracle_id);
-    const mlSubstitution = getOracleForMl(card.oracle_id);
+    const related = getRelatedCards(card.oracle_id, printingPreference);
+    const mlSubstitution = getOracleForMl(card.oracle_id, printingPreference);
 
     const baseUrl = util.getBaseUrl();
     return render(

--- a/src/util/carddb.ts
+++ b/src/util/carddb.ts
@@ -191,6 +191,14 @@ export function getReasonableCardByOracle(oracleId: string): CardDetails {
   return getFirstReasonable(ids);
 }
 
+export function getReasonableCardByOracleWithPrintingPreference(
+  oracleId: string,
+  printingPreference: PrintingPreference,
+): CardDetails {
+  const ids = catalog.oracleToId[oracleId];
+  return getMostReasonableByPrintingPreference(ids, printingPreference)!;
+}
+
 export function isOracleBasic(oracleId: string): boolean {
   return cardFromId(catalog.oracleToId[oracleId][0]).type.includes('Basic');
 }

--- a/src/util/carddb.ts
+++ b/src/util/carddb.ts
@@ -111,13 +111,21 @@ export function getMostReasonable(
   printing: PrintingPreference = PrintingPreference.RECENT,
   filter?: FilterFunction,
 ): CardDetails | null {
-  let ids = getIdsFromName(cardName);
+  const ids = getIdsFromName(cardName);
   if (ids === undefined || ids.length === 0) {
     // Try getting it by ID in case this is an ID.
 
     return getMostReasonableById(cardName, printing);
   }
 
+  return getMostReasonableByPrintingPreference(ids, printing, filter);
+}
+
+export function getMostReasonableByPrintingPreference(
+  ids: string[],
+  printingPreference: PrintingPreference = PrintingPreference.RECENT,
+  filter?: FilterFunction,
+): CardDetails | null {
   if (filter) {
     ids = ids
       .map((id) => detailsToCard(cardFromId(id)))
@@ -147,7 +155,7 @@ export function getMostReasonable(
   ids = cards.map((card) => card.details.scryfall_id);
 
   // Ids have been sorted from oldest to newest. So reverse if we want the newest printing.
-  if (printing === PrintingPreference.RECENT) {
+  if (printingPreference === PrintingPreference.RECENT) {
     ids = [...ids];
     ids.reverse();
   }
@@ -191,7 +199,20 @@ const indexToReasonable = (index: number): CardDetails => {
   return getFirstReasonable(catalog.oracleToId[catalog.indexToOracle[index]]);
 };
 
-export function getRelatedCards(oracleId: string): Record<string, Record<string, CardDetails[]>> {
+const indexToReasonableWithPrintingPreference = (
+  index: number,
+  printingPreference: PrintingPreference,
+): CardDetails => {
+  const ids = catalog.oracleToId[catalog.indexToOracle[index]];
+  //Use ! to tell Typescript we expect to always get a card here, because we are going through
+  //the catalog that CubeCobra built. Thus expect consistency
+  return getMostReasonableByPrintingPreference(ids, printingPreference)!;
+};
+
+export function getRelatedCards(
+  oracleId: string,
+  printingPreference: PrintingPreference,
+): Record<string, Record<string, CardDetails[]>> {
   const related = catalog.metadatadict[oracleId];
 
   if (!related) {
@@ -217,37 +238,45 @@ export function getRelatedCards(oracleId: string): Record<string, Record<string,
     };
   }
 
+  const mapper = (oracleIndex: number) => {
+    return indexToReasonableWithPrintingPreference(oracleIndex, printingPreference);
+  };
+
   return {
     cubedWith: {
-      top: related.cubedWith.top.map(indexToReasonable),
-      creatures: related.cubedWith.creatures.map(indexToReasonable),
-      spells: related.cubedWith.spells.map(indexToReasonable),
-      other: related.cubedWith.other.map(indexToReasonable),
+      top: related.cubedWith.top.map(mapper),
+      creatures: related.cubedWith.creatures.map(mapper),
+      spells: related.cubedWith.spells.map(mapper),
+      other: related.cubedWith.other.map(mapper),
     },
     draftedWith: {
-      top: related.draftedWith.top.map(indexToReasonable),
-      creatures: related.draftedWith.creatures.map(indexToReasonable),
-      spells: related.draftedWith.spells.map(indexToReasonable),
-      other: related.draftedWith.other.map(indexToReasonable),
+      top: related.draftedWith.top.map(mapper),
+      creatures: related.draftedWith.creatures.map(mapper),
+      spells: related.draftedWith.spells.map(mapper),
+      other: related.draftedWith.other.map(mapper),
     },
     synergistic: {
-      top: related.synergistic.top.map(indexToReasonable),
-      creatures: related.synergistic.creatures.map(indexToReasonable),
-      spells: related.synergistic.spells.map(indexToReasonable),
-      other: related.synergistic.other.map(indexToReasonable),
+      top: related.synergistic.top.map(mapper),
+      creatures: related.synergistic.creatures.map(mapper),
+      spells: related.synergistic.spells.map(mapper),
+      other: related.synergistic.other.map(mapper),
     },
   };
 }
 
 // if the oracle id is not in the training data, we will use the similar card in the metadata dict
-export function getOracleForMl(oracleId: string): string {
+export function getOracleForMl(oracleId: string, printingPreference: PrintingPreference | null): string {
   const related = catalog.metadatadict[oracleId];
 
   if (!related || related.mostSimilar === undefined) {
     return oracleId;
   }
 
-  return indexToReasonable(related.mostSimilar).oracle_id;
+  if (printingPreference) {
+    return indexToReasonableWithPrintingPreference(related.mostSimilar, printingPreference).oracle_id;
+  } else {
+    return indexToReasonable(related.mostSimilar).oracle_id;
+  }
 }
 
 export function getAllMostReasonable(


### PR DESCRIPTION
# Changes
1. Related cards on the tool/card page now will use the user's printing preference (eg drafted with, cubed with, synergy)
2. Analysis page adds/cuts will now use the cube's printing preference
3. Change the default printing preference to first per Dekkaru's ask. This applies to new users and user's that haven't yet saved their preference

**If you can think of other places cards are shown based on name or oracle (and thus we can choose any printing) let me know and I can investigate**

# Testing

## Before
On tool/card page showing related:
![old-first-printing-preference-not-conformed-in-cubed-with](https://github.com/user-attachments/assets/53cdc07a-5e65-4062-8b9d-ef36823712e7)
![old-first-printing-preferenc-not-conformed-in-related](https://github.com/user-attachments/assets/6f34e1f8-69a2-4f85-8787-44ce4d1c30b4)

In add/cuts recommender:
![old-recommender-neither-first-or-most-recent-printing](https://github.com/user-attachments/assets/b9ed7ea3-801b-4e3e-ae60-f1bb12587e7a)
The Lunarch veteran is not a promo but it does have special frame effects. However update_cards.ts doesn't look for those effects, only extendedart and showcase. But either way it isn't the first or most recent printing
![old-recommends-can-include-promos-that-arent-reasonable](https://github.com/user-attachments/assets/71ed4061-3d2c-487e-a988-530239c8fbcd)

## After

### First printing
Related cards:
![new-first-printing-preference-for-related](https://github.com/user-attachments/assets/7247f733-68eb-4cc5-862a-09eb2e31f5f2)
![new-first-printing-prefernced-for-related-cubed-with](https://github.com/user-attachments/assets/db60ad46-2a69-4f73-8c5c-14b275dcb628)
![new-first-printing-prefernced-for-related-synergy](https://github.com/user-attachments/assets/0616feb7-775c-4acd-bf24-d645874ea10a)

Add/cuts
![new-first-printing-recommended-adds](https://github.com/user-attachments/assets/2cd26813-9d48-41d8-8fe3-440b36132123)
![new-first-printing-recommended-cuts](https://github.com/user-attachments/assets/8daf4a18-f9bc-4d10-84b8-f0e435f0692d)

### Most recent printing
Related cards:
![new-most-recent-printing-prefernced-for-related](https://github.com/user-attachments/assets/e7edd362-428b-4089-aed7-fe5c902d712e)
![new-most-recent-printing-prefernced-for-related-cubed-with](https://github.com/user-attachments/assets/177811e9-7ece-4b35-890c-45fcd1470d6a)
![new-most-recent-printing-prefernced-for-related-synergy](https://github.com/user-attachments/assets/eea1b592-dcbe-44a7-aab5-b618dfd440cf)

Add/cuts
![new-most-recent-printing-recommended-adds](https://github.com/user-attachments/assets/d800b070-f124-42d5-917c-9ce8e70681c6)
![new-most-recent-printing-recommended-cuts](https://github.com/user-attachments/assets/66977582-2cb9-4142-abf4-cbd52c3d3f31)



