### PR TITLE
Keep cube overview changes around in local storage so that validation errors don't lose your work

### DIFF
--- a/src/client/components/CSRFForm.tsx
+++ b/src/client/components/CSRFForm.tsx
@@ -24,4 +24,6 @@ const CSRFForm = forwardRef<HTMLFormElement, CSRFFormProps>(({ children, method,
   );
 });
 
+CSRFForm.displayName = 'CSRFForm';
+
 export default CSRFForm;

--- a/src/client/components/modals/CubeOverviewModal.tsx
+++ b/src/client/components/modals/CubeOverviewModal.tsx
@@ -5,6 +5,7 @@ import { getCubeDescription } from 'utils/Util';
 import Cube from '../../../datatypes/Cube';
 import Image from '../../../datatypes/Image';
 import { CSRFContext } from '../../contexts/CSRFContext';
+import useLocalStorage from '../../hooks/useLocalStorage';
 import AutocompleteInput from '../base/AutocompleteInput';
 import Button from '../base/Button';
 import { Card, CardHeader } from '../base/Card';
@@ -27,8 +28,8 @@ interface CubeOverviewModalProps {
 
 const CubeOverviewModal: React.FC<CubeOverviewModalProps> = ({ isOpen, setOpen, cube }) => {
   const { csrfFetch } = useContext(CSRFContext);
-  const [state, setState] = useState<Cube>(JSON.parse(JSON.stringify(cube)));
-  const [imagename, setImagename] = useState(cube.imageName);
+  const [state, setState] = useLocalStorage<Cube>(`${cube.id}-overview-state`, JSON.parse(JSON.stringify(cube)));
+  const [imagename, setImagename] = useLocalStorage(`${cube.id}-overview-imagename`, cube.imageName);
   const [imageDict, setImageDict] = useState<Record<string, Image>>({});
   const formRef = React.createRef<HTMLFormElement>();
 
@@ -55,7 +56,7 @@ const CubeOverviewModal: React.FC<CubeOverviewModalProps> = ({ isOpen, setOpen, 
         setState({ ...state, imageName: image, image: imageDict[image.toLowerCase()] });
       }
     },
-    [imageDict, setState, state],
+    [imageDict, setImagename, setState, state],
   );
 
   return (

--- a/src/client/components/modals/CubeOverviewModal.tsx
+++ b/src/client/components/modals/CubeOverviewModal.tsx
@@ -49,6 +49,14 @@ const CubeOverviewModal: React.FC<CubeOverviewModalProps> = ({ isOpen, setOpen, 
     getData();
   }, [csrfFetch]);
 
+  useEffect(() => {
+    /* The card count is used by getCubeDescription and unlike the rest of the cube state in this modal,
+     * the count can be changed by other pages. Thus override it to be sure its accurate compared to any local storage
+     */
+    setState({ ...state, cardCount: cube.cardCount });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- We only want this to trigger once, on load
+  }, []);
+
   const changeImage = useCallback(
     (image: string) => {
       setImagename(image);


### PR DESCRIPTION
# Solution
As Dekkaru described using local storage makes sense and it's a pattern used in many places.

Because the overview save is a full page reload, there is no good way to clear local storage on success like Dekkaru suggested. That meant I had to handle a minor discrepancy with the card count used in the modal, by taking that from the cube passed into the modal component.

Alternatively, but more work, would have been to convert the endpoint to an API with a JSON response though at that point local storage probably isn't needed (though would be nice in case you accidentally refresh the page).

I noticed via chrome dev tools that there is a lot of local storage items staying around even when likely never usable again, such as individual blog post title/body. Since browser's don't implement a least recently used strategy for local storage, eventually we might fill it up and then nothing new can be saved.

# Testing

## Before
The discord report was with an empty cube, I tested with banned words filter. Can see that after trying to save, all my changes were lost
![old-cube-overview-modal-forgets-changed-on-validation-error](https://github.com/user-attachments/assets/13795cf2-3aa2-4fb9-9450-fc9cc4bc1276)

## After
Now the changes are saved in local storage and used the next time.
![new-cube-overview-modal-keeps-changes-around-even-on-validation-error](https://github.com/user-attachments/assets/c1fa7180-1f98-41a0-a9ee-9901c4b3ec9f)


