### PR TITLE
User preference for card grid tightness

### DIFF
--- a/src/client/components/card/CardGrid.tsx
+++ b/src/client/components/card/CardGrid.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useContext } from 'react';
 
 import classNames from 'classnames';
 
 import Card from '../../../datatypes/Card';
+import { GridTightnessPreference } from '../../../datatypes/User';
+import UserContext from '../../contexts/UserContext';
 import { Col, NumCols, Row } from '../base/Layout';
 import FoilCardImage from '../FoilCardImage';
 import { CardImageProps } from './CardImage';
@@ -26,10 +28,20 @@ export interface CardGridProps {
 const CardGrid: React.FC<CardGridProps> = ({ 
   cards, cardProps, xs, sm, md, lg, xl, xxl, hrefFn, onClick, className, ratings, selectedIndex 
 }) => {
-  const maxRating = ratings ? Math.max(...(ratings.filter(r => r !== undefined))) : null;
-  
+  const maxRating = ratings ? Math.max(...ratings.filter((r) => r !== undefined)) : null;
+  const user = useContext(UserContext);
+
   return (
-    <Row xs={xs} sm={sm} md={md} lg={lg} xl={xl} xxl={xxl} className={className}>
+    <Row
+      xs={xs}
+      sm={sm}
+      md={md}
+      lg={lg}
+      xl={xl}
+      xxl={xxl}
+      className={className}
+      gutters={user?.gridTightness === GridTightnessPreference.TIGHT ? 0 : 2}
+    >
       {cards.map((card, cardIndex) => {
         const isHighestRated = ratings?.[cardIndex] === maxRating;
         const wasSelected = cardIndex === selectedIndex;

--- a/src/client/components/card/CardGrid.tsx
+++ b/src/client/components/card/CardGrid.tsx
@@ -25,8 +25,20 @@ export interface CardGridProps {
   selectedIndex?: number;
 }
 
-const CardGrid: React.FC<CardGridProps> = ({ 
-  cards, cardProps, xs, sm, md, lg, xl, xxl, hrefFn, onClick, className, ratings, selectedIndex 
+const CardGrid: React.FC<CardGridProps> = ({
+  cards,
+  cardProps,
+  xs,
+  sm,
+  md,
+  lg,
+  xl,
+  xxl,
+  hrefFn,
+  onClick,
+  className,
+  ratings,
+  selectedIndex,
 }) => {
   const maxRating = ratings ? Math.max(...ratings.filter((r) => r !== undefined)) : null;
   const user = useContext(UserContext);
@@ -46,25 +58,24 @@ const CardGrid: React.FC<CardGridProps> = ({
         const isHighestRated = ratings?.[cardIndex] === maxRating;
         const wasSelected = cardIndex === selectedIndex;
         const rating = ratings?.[cardIndex];
-        
+
         const getRatingStyle = () => {
-          if (isHighestRated && wasSelected) return "bg-[#087715]/95";
-          if (isHighestRated) return "bg-[#007BFF]/95";
-          if (wasSelected) return "bg-[#E6B800]/95";
-          return "bg-gray-700/80";
+          if (isHighestRated && wasSelected) return 'bg-[#087715]/95';
+          if (isHighestRated) return 'bg-[#007BFF]/95';
+          if (wasSelected) return 'bg-[#E6B800]/95';
+          return 'bg-gray-700/80';
         };
-        
+
         return (
           <Col key={cardIndex} xs={1} className="relative">
             <div className="relative">
-              <div className={classNames(
-                "relative",
-                {
-                  "ring-[5px] ring-[#007BFF] ring-offset-0 rounded-lg": isHighestRated && !wasSelected,
-                  "ring-[5px] ring-[#E6B800] ring-offset-0 rounded-lg": wasSelected && !isHighestRated,
-                  "ring-[5px] ring-[#087715] ring-offset-0 rounded-lg": isHighestRated && wasSelected,
-                }
-              )}>
+              <div
+                className={classNames('relative', {
+                  'ring-[5px] ring-[#007BFF] ring-offset-0 rounded-lg': isHighestRated && !wasSelected,
+                  'ring-[5px] ring-[#E6B800] ring-offset-0 rounded-lg': wasSelected && !isHighestRated,
+                  'ring-[5px] ring-[#087715] ring-offset-0 rounded-lg': isHighestRated && wasSelected,
+                })}
+              >
                 {hrefFn ? (
                   <a href={hrefFn(card)} className="hover:cursor-pointer">
                     <FoilCardImage card={card} autocard {...cardProps} />
@@ -74,18 +85,20 @@ const CardGrid: React.FC<CardGridProps> = ({
                     card={card}
                     autocard
                     onClick={() => onClick?.(card, cardIndex)}
-                    className={onClick ? 'cursor-pointer' : undefined}  // Removed hover:opacity-50
+                    className={onClick ? 'cursor-pointer' : undefined} // Removed hover:opacity-50
                     {...cardProps}
                   />
                 )}
                 {rating !== undefined && (
-                  <div className={classNames(
-                    "absolute bottom-2 left-1/2 transform -translate-x-1/2",
-                    "px-2 py-0.5 text-center min-w-[2.5rem]",
-                    "text-sm font-semibold text-white",
-                    "rounded-md shadow-sm backdrop-blur-[2px]",
-                    getRatingStyle()
-                  )}>
+                  <div
+                    className={classNames(
+                      'absolute bottom-2 left-1/2 transform -translate-x-1/2',
+                      'px-2 py-0.5 text-center min-w-[2.5rem]',
+                      'text-sm font-semibold text-white',
+                      'rounded-md shadow-sm backdrop-blur-[2px]',
+                      getRatingStyle(),
+                    )}
+                  >
                     {Math.round(rating * 100)}%
                   </div>
                 )}

--- a/src/client/components/card/CardSearch.tsx
+++ b/src/client/components/card/CardSearch.tsx
@@ -8,7 +8,7 @@ import { CardDetails } from '../../../datatypes/Card';
 import FilterContext from '../../contexts/FilterContext';
 import Banner from '../Banner';
 import Controls from '../base/Controls';
-import { Col, Flexbox,Row } from '../base/Layout';
+import { Col, Flexbox, Row } from '../base/Layout';
 import Link from '../base/Link';
 import Paginate from '../base/Pagination';
 import ResponsiveDiv from '../base/ResponsiveDiv';
@@ -40,6 +40,7 @@ const CardSearch: React.FC = () => {
 
     const response = await fetch(`/tool/api/searchcards/?${params.toString()}`);
     if (!response.ok) {
+      // eslint-disable-next-line no-console -- Debugging
       console.error(response);
     }
 
@@ -63,7 +64,7 @@ const CardSearch: React.FC = () => {
       setLoading(false);
       setCards([]);
     }
-  }, [page, direction, distinct, sort, filterInput]);
+  }, [page, direction, distinct, sort, filterInput, fetchData]);
 
   const updatePage = (index: number) => {
     setLoading(true);

--- a/src/client/components/cube/VisualSpoiler.tsx
+++ b/src/client/components/cube/VisualSpoiler.tsx
@@ -29,7 +29,7 @@ const VisualSpoiler: React.FC<VisualSpoilerProps> = ({ cards }) => {
         sortQuaternary || 'Alphabetical',
         cube.showUnsorted || false,
       ),
-    [cards, cube.showUnsorted, sortQuaternary, sortPrimary, sortSecondary],
+    [cards, sortPrimary, sortSecondary, sortTertiary, sortQuaternary, cube.showUnsorted],
   );
 
   return (

--- a/src/client/components/user/UserThemeForm.tsx
+++ b/src/client/components/user/UserThemeForm.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useMemo, useState } from 'react';
 
-import { PrintingPreference } from '../../../datatypes/Card';
+import { DefaultPrintingPreference, PrintingPreference } from '../../../datatypes/Card';
+import { DefaultGridTightnessPreference, GridTightnessPreference } from '../../../datatypes/User';
 import UserContext from '../../contexts/UserContext';
 import Button from '../base/Button';
 import Checkbox from '../base/Checkbox';
@@ -11,12 +12,13 @@ import CSRFForm from '../CSRFForm';
 const UserThemeForm: React.FC = () => {
   const user = useContext(UserContext);
   const [selectedTheme, setSelectedTheme] = useState(user?.theme || 'default');
-  const [defaultPrinting, setDefaultPrinting] = useState(user?.defaultPrinting || PrintingPreference.RECENT);
+  const [defaultPrinting, setDefaultPrinting] = useState(user?.defaultPrinting || DefaultPrintingPreference);
+  const [gridTightness, setGridTightness] = useState(user?.gridTightness || DefaultGridTightnessPreference);
   const [hideFeaturedCubes, setHideFeaturedCubes] = useState(user?.hideFeatured || false);
   const formRef = React.useRef<HTMLFormElement>(null);
   const formData = useMemo(
-    () => ({ theme: selectedTheme, hideFeatured: `${hideFeaturedCubes}`, defaultPrinting }),
-    [selectedTheme, hideFeaturedCubes, defaultPrinting],
+    () => ({ theme: selectedTheme, hideFeatured: `${hideFeaturedCubes}`, defaultPrinting, gridTightness }),
+    [selectedTheme, hideFeaturedCubes, defaultPrinting, gridTightness],
   );
 
   return (
@@ -39,6 +41,15 @@ const UserThemeForm: React.FC = () => {
           options={[
             { value: PrintingPreference.RECENT, label: 'Most Recent' },
             { value: PrintingPreference.FIRST, label: 'First' },
+          ]}
+        />
+        <Select
+          label="Default grid tightness"
+          value={formData.gridTightness}
+          setValue={(value) => setGridTightness(value as GridTightnessPreference)}
+          options={[
+            { value: GridTightnessPreference.LOOSE, label: 'Loose' },
+            { value: GridTightnessPreference.TIGHT, label: 'Tight (no space)' },
           ]}
         />
         <Checkbox label="Hide featured cubes" checked={hideFeaturedCubes} setChecked={setHideFeaturedCubes} />

--- a/src/datatypes/User.ts
+++ b/src/datatypes/User.ts
@@ -3,6 +3,12 @@ import Cube from './Cube';
 import Image from './Image';
 import { Notification } from './Notification';
 
+export enum GridTightnessPreference {
+  TIGHT = 'tight',
+  LOOSE = 'loose',
+}
+export const DefaultGridTightnessPreference = GridTightnessPreference.LOOSE;
+
 export default interface User {
   id: string;
   username: string;
@@ -22,4 +28,5 @@ export default interface User {
   patron?: string;
   notifications?: Notification[];
   defaultPrinting?: PrintingPreference;
+  gridTightness?: GridTightnessPreference;
 }

--- a/src/dynamo/models/user.js
+++ b/src/dynamo/models/user.js
@@ -1,4 +1,5 @@
 const { DefaultPrintingPreference } = require('../../datatypes/Card');
+const { DefaultGridTightnessPreference } = require('../../datatypes/User');
 const { getImageData } = require('../../util/imageutil');
 const createClient = require('../util');
 
@@ -70,6 +71,10 @@ const hydrate = (user) => {
   //Just nice to set the value instead of having undefined around
   if (!user.defaultPrinting) {
     user.defaultPrinting = DefaultPrintingPreference;
+  }
+  //Ensure a value is always set
+  if (!user.gridTightness) {
+    user.gridTightness = DefaultGridTightnessPreference;
   }
 
   return user;

--- a/src/routes/users_routes.js
+++ b/src/routes/users_routes.js
@@ -24,6 +24,7 @@ const uuid = require('uuid');
 import { DefaultPrintingPreference, PrintingPreference } from '../datatypes/Card';
 import { NoticeType } from '../datatypes/Notice';
 import { NotificationStatus } from '../datatypes/Notification';
+import { DefaultGridTightnessPreference, GridTightnessPreference } from '../datatypes/User';
 
 const router = express.Router();
 
@@ -356,6 +357,7 @@ router.post(
         token: uuid.v4(),
         dateCreated: new Date().valueOf(),
         defaultPrinting: DefaultPrintingPreference,
+        gridTightness: DefaultGridTightnessPreference,
       };
 
       const salt = await bcrypt.genSalt(10);
@@ -738,6 +740,10 @@ router.post('/changedisplay', ensureAuth, async (req, res) => {
       errors.push({ msg: 'Printing must be valid.' });
     }
 
+    if (![GridTightnessPreference.TIGHT, GridTightnessPreference.LOOSE].includes(req.body.gridTightness)) {
+      errors.push({ msg: 'Grid tightness must be valid.' });
+    }
+
     if (errors.length > 0) {
       req.flash('danger', 'Error updating display settings: ' + errors.map((error) => error.msg).join(', '));
       return redirect(req, res, '/user/account?nav=display');
@@ -746,6 +752,7 @@ router.post('/changedisplay', ensureAuth, async (req, res) => {
     user.theme = req.body.theme;
     user.hideFeatured = req.body.hideFeatured === 'on';
     user.defaultPrinting = req.body.defaultPrinting;
+    user.gridTightness = req.body.gridTightness;
 
     await User.update(user);
 

--- a/src/util/render.js
+++ b/src/util/render.js
@@ -45,6 +45,7 @@ const render = (req, res, page, reactProps = {}, options = {}) => {
         cubes,
         notifications: notifications.items,
         defaultPrinting: req.user.defaultPrinting,
+        gridTightness: req.user.gridTightness,
       };
     }
 


### PR DESCRIPTION
1. Defaults to loose as that is current behaviour
2. Tight means no space between card images

There are some places that use grid like visuals without CardGrid, such as recommendations when looking at card images. Those just use Row/Col components directly.

# Visual

Display preferences:
![display-preferences](https://github.com/user-attachments/assets/c5ecba6a-6fbf-4960-af32-2eaaf9532c16)

Loose grids (current behaviour):
![loose-grids](https://github.com/user-attachments/assets/a9c3ae40-445a-4cec-bd22-99ac4f1ecffd)

Tight grids:
![tight-grids](https://github.com/user-attachments/assets/d4d1a296-6ec9-4aad-a1e8-f75af24b7dd5)

Mobile tight grids:
![mobile-tight-grids](https://github.com/user-attachments/assets/56142d4d-423d-4b00-8fce-84b1e240b21c)
