### PR TITLE
Fix card name sorting on playtest data, fix invalid dates in date added sorting (v2)

### DIFF
--- a/src/client/analytics/AnalyticTable.tsx
+++ b/src/client/analytics/AnalyticTable.tsx
@@ -22,7 +22,7 @@ const sortWithTotal: (pool: Card[], sort: string) => SortWithTotalResult = (pool
     (cards as Card[]).reduce((acc, card) => acc + card.asfan!, 0),
   ]);
 
-const AnalyticTable: React.FC = ({}) => {
+const AnalyticTable: React.FC = () => {
   const { cube, changedCards } = useContext(CubeContext);
   const cards = changedCards.mainboard;
   const [column, setColumn] = useQueryParam('column', 'Color Identity');
@@ -38,6 +38,7 @@ const AnalyticTable: React.FC = ({}) => {
     try {
       return calculateAsfans(cube, cards, parseInt(draftFormat, 10));
     } catch (e) {
+      // eslint-disable-next-line no-console -- Debugging
       console.error('Invalid Draft Format', draftFormat, cube.formats[parseInt(draftFormat)], e);
       return {};
     }

--- a/src/client/analytics/Asfans.tsx
+++ b/src/client/analytics/Asfans.tsx
@@ -23,6 +23,7 @@ const Asfans: React.FC = () => {
     try {
       return calculateAsfans(cube, cards, parseInt(draftFormat));
     } catch (e) {
+      // eslint-disable-next-line no-console -- Debugging
       console.error('Invalid Draft Format', draftFormat, cube.formats[parseInt(draftFormat)], e);
       return {};
     }

--- a/src/client/analytics/Averages.tsx
+++ b/src/client/analytics/Averages.tsx
@@ -48,6 +48,7 @@ const Averages: React.FC<AveragesProps> = ({ characteristics }) => {
     try {
       return calculateAsfans(cube, cards, parseInt(draftFormat || '-1', 10));
     } catch (e) {
+      // eslint-disable-next-line no-console -- Debugging
       console.error(
         'Invalid Draft Format',
         draftFormat,
@@ -56,7 +57,7 @@ const Averages: React.FC<AveragesProps> = ({ characteristics }) => {
       );
       return {};
     }
-  }, [cards, draftFormat, useAsfans]);
+  }, [cube, cards, draftFormat, useAsfans]);
 
   const counts = useMemo(
     () =>

--- a/src/client/analytics/Chart.tsx
+++ b/src/client/analytics/Chart.tsx
@@ -24,7 +24,9 @@ import CubeContext from '../contexts/CubeContext';
 import { calculateAsfans } from '../drafting/createdraft';
 import useQueryParam from '../hooks/useQueryParam';
 
+// eslint-disable-next-line no-console -- Debugging
 console.log('ChartJS', ChartJS);
+// eslint-disable-next-line no-console -- Debugging
 console.log('BarElement', BarElement);
 
 // Register the necessary Chart.js components
@@ -108,6 +110,7 @@ const ChartComponent: React.FC<ChartComponentProps> = ({ characteristics }) => {
     try {
       return calculateAsfans(cube, cards, parseInt(draftFormat, 10));
     } catch (e) {
+      // eslint-disable-next-line no-console -- Debugging
       console.error('Invalid Draft Format', draftFormat, cube.formats[parseInt(draftFormat, 10)], e);
       return {};
     }

--- a/src/client/analytics/PlaytestData.tsx
+++ b/src/client/analytics/PlaytestData.tsx
@@ -6,7 +6,7 @@ import { fromEntries } from 'utils/Util';
 import Card, { DefaultElo } from '../../datatypes/Card';
 import { Flexbox } from '../components/base/Layout';
 import ErrorBoundary from '../components/ErrorBoundary';
-import { compareStrings, SortableTable } from '../components/SortableTable';
+import { SortableTable } from '../components/SortableTable';
 import withAutocard from '../components/WithAutocard';
 import CubeContext from '../contexts/CubeContext';
 
@@ -36,6 +36,10 @@ const renderCardLink = (card: Card) => (
 
 const renderPercent = (val: number) => {
   return <>{parseInt((val * 1000).toString(), 10) / 10}%</>;
+};
+
+const compareCardNames = (a: Card, b: Card): number => {
+  return (a?.details?.name_lower || '').localeCompare(b.details?.name_lower || '');
 };
 
 const PlaytestData: React.FC<PlaytestDataProps> = ({ cubeAnalytics }) => {
@@ -89,7 +93,7 @@ const PlaytestData: React.FC<PlaytestDataProps> = ({ cubeAnalytics }) => {
             { key: 'mainboards', title: 'Mainboard Count', sortable: true, heading: false },
           ]}
           data={data}
-          sortFns={{ label: compareStrings }}
+          sortFns={{ card: compareCardNames }}
         />
       </ErrorBoundary>
     </Flexbox>

--- a/src/client/utils/cardutil.ts
+++ b/src/client/utils/cardutil.ts
@@ -201,7 +201,26 @@ export const cardType = (card: Partial<Card>): string => card.type_line ?? card.
 
 export const cardRarity = (card: Card): string => card.rarity ?? card.details?.rarity ?? '';
 
-export const cardAddedTime = (card: Card): Date | null => (card.addedTmsp ? new Date(Number(card.addedTmsp)) : null);
+export const cardAddedTime = (card: Card): Date | null => {
+  if (!card.addedTmsp) {
+    return null;
+  }
+
+  //Stored as a date formatted string. This is what the backend does when adding cards via Text/Names
+  const fromString = Date.parse(card.addedTmsp);
+  if (!Number.isNaN(fromString)) {
+    return new Date(fromString);
+  }
+
+  //Stored as a string of a unix timestamp. This is what the UI does when adding cards
+  const n = Number(card.addedTmsp);
+  //addedTmsp is a unix timestamp number
+  if (!Number.isNaN(n)) {
+    return new Date(n);
+  }
+
+  return null;
+};
 
 export const cardImageUrl = (card: Card): string =>
   card.imgUrl ?? card.details?.image_normal ?? card.details?.image_small ?? '';


### PR DESCRIPTION
# Fixes
1. Card name sorting on the playtest data was using a sort function that didn't work for the fact the values of the column are Card objects and not scalar values
2. Fix invalid dates appearing in sorting because the addedTmsp can be stored as a unix timestamp string or as a parsable date string like `2025-01-19T18:56:15.683Z`

# Testing

## Before

Sorting names in playtest not doing anything:
![old-card-name-not-sorting-playtest-data](https://github.com/user-attachments/assets/ec5367bd-a4da-4391-9f74-d852cd102a99)

Examples of invalid dates for cards
![old-card-invalid-date-if-parsable-string](https://github.com/user-attachments/assets/7362d11a-fa42-4e8d-8ba1-fdc2418d5be8)
![old-card-invalid-dates](https://github.com/user-attachments/assets/85f661aa-69bf-43f1-8ff8-5359af323728)

## After
Sorting names in playtest working:
![new-card-name-sorting-playtest-data](https://github.com/user-attachments/assets/a872ac2e-624c-4ee2-92c0-76fb6dd48bfe)

Parsing the dates better so no Invalid dates
![new-card-date-parsing-better](https://github.com/user-attachments/assets/9646ea82-aeb2-4106-857b-64dfd1d49825)
![new-sort-date-added](https://github.com/user-attachments/assets/c33da43d-db89-4a94-9b28-1600ba442fdc)
