### PR TITLE
Webpack split vendor and common dependencies into their own files

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "webpack-dev-server": "NODE_OPTIONS=--max_old_space-size=18192 npx webpack serve --config webpack.dev.mjs",
     "nearley": "sh nearley/helper.sh",
     "ci-build": "npm run nearley && tsc -b && NODE_OPTIONS=--max_old_space_size=16384 node_modules/.bin/webpack --mode production --config webpack.prod.mjs",
-    "devstart": "npm run nearley --watch & npm run nodemon & npm run webpack-dev-server & npm run tailwind:watch & npx tailwindcss -i ./src/client/css/stylesheet.css -o ./public/css/stylesheet.css --watch=always",
+    "devstart": "npm run nearley --watch & npm run nodemon & npm run webpack-dev-server & npx tailwindcss -i ./src/client/css/stylesheet.css -o ./public/css/stylesheet.css --watch=always",
     "setup": "npm run nearley && npm run webpack --progress && node --max-old-space-size=8192 force_update.js",
     "cards": "node --max-old-space-size=8192 force_update.js",
     "download-model": "node --max-old-space-size=8192 src/jobs/download_model.js",

--- a/src/app.js
+++ b/src/app.js
@@ -294,7 +294,9 @@ schedule.scheduleJob('0 10 * * *', async () => {
 
 // Start server after carddb is initialized.
 cardCatalog.initializeCardDb().then(async () => {
-  http.createServer(app).listen(process.env.PORT || 5000, '127.0.0.1');
+  http.createServer(app).listen(process.env.PORT || 5000, process.env.LISTEN_ON || '127.0.0.1');
   // eslint-disable-next-line no-console
-  console.info(`Server started on port ${process.env.PORT || 5000}...`);
+  console.info(
+    `Server started on port ${process.env.PORT || 5000}, listening on ${process.env.LISTEN_ON || '127.0.0.1'}...`,
+  );
 });

--- a/src/util/render.js
+++ b/src/util/render.js
@@ -27,6 +27,15 @@ const redirect = (req, res, to) => {
   }
 };
 
+const getBundlesForPage = (page) => {
+  //Webpack-dev-server doesn't do splitting, so only need to include the page bundle which gets compiled on the fly
+  if (process.env?.NODE_ENV !== 'development') {
+    return [`/js/vendors.bundle.js`, `/js/commons.bundle.js`, `/js/${page}.bundle.js`];
+  } else {
+    return [`/js/${page}.bundle.js`];
+  }
+};
+
 const render = (req, res, page, reactProps = {}, options = {}) => {
   getCubes(req, async (cubes) => {
     if (req.user) {
@@ -71,7 +80,7 @@ const render = (req, res, page, reactProps = {}, options = {}) => {
       res.render('main', {
         reactHTML: null, // TODO renable ReactDOMServer.renderToString(React.createElement(page, reactProps)),
         reactProps: serialize(reactProps),
-        page,
+        bundles: getBundlesForPage(page),
         metadata: options.metadata,
         title: options.title ? `${options.title} - Cube Cobra` : 'Cube Cobra',
         patron: req.user && (req.user.roles || []).includes('Patron'),

--- a/views/main.pug
+++ b/views/main.pug
@@ -45,4 +45,5 @@ html(lang='en' class=theme)
  
 		script(type='text/javascript').
 			window.reactProps = !{reactProps};
-		script(src='/js/'+page+'.bundle.js')
+		each src in bundles
+			script(src=src)

--- a/webpack.prod.mjs
+++ b/webpack.prod.mjs
@@ -21,7 +21,7 @@ const config = {
       minimize: true,
       debug: false,
     }),
-    new webpack.IgnorePlugin({ resourceRegExp: /^(\.\/locale)|(moment)$/ }),
+    new webpack.IgnorePlugin({ resourceRegExp: /^(\.\/locale)|(moment)$/ })
   ],
   optimization: {
     minimize: true,
@@ -30,11 +30,26 @@ const config = {
         parallel: true,
       }),
     ],
-    usedExports: true,
+    sideEffects: true,
+    splitChunks: {
+      chunks: 'all',
+      cacheGroups: {
+        commons: {
+          name: 'commons',
+          chunks: 'initial',
+          minChunks: 2,
+        },
+        vendors: {
+          test: /[\\/]node_modules[\\/]/,
+          name: 'vendors',
+          chunks: 'all',
+        },
+      },
+    },
   },
   infrastructureLogging: {
     level: 'verbose',
- }
+  }
 };
 
 const clientConfig = merge(commonClientConfig, config, {});


### PR DESCRIPTION
# Problem
The bundles for each page are very large and have duplicate content within them, which you can see in the screenshot below which was made by https://www.npmjs.com/package/webpack-bundle-analyzer.

![webpack-bundles-current](https://github.com/user-attachments/assets/ec2c0fd0-3440-4a38-89a2-96a5575c8c80)


# Solution
Webpack has a number of ways to split bundles to improving caching and reduce duplication. I've implemented a pretty standard pattern I've used at past jobs in which all node modules are put into a vendors file, then all common CubeCobra JS is put into a commons file. Then each bundle for a page only contains a small subset of 'unique' code for that page.

## Packaging

Can see in this screenshot how the vendors bundles contains all the node stuff (of which a majority is part of the markdown component), commons contains frequently used CubeCobra stuff like filtering and most components, then page bundles contain components that have no reuse.
![webpack-vendor-and-common](https://github.com/user-attachments/assets/88382baf-1048-485f-806c-6e99f759f9c1)

Also the size of the bundles in this screenshot are not comparable to the size in the previous one; from sizes on disk the old page bundles averaged 3MB vs the vendors bundle from this branch is 3.65MB. In total the size of the JS files in dist/ from master branch is 185MB vs this branch which is 5.6MB! The commons bundle is 0.68MB.

So each user is going to be downloading a lot less bytes which means less NAT gateway egress cost. The gzip compression on the files served by express seems to shrink the size in transit to anywhere from 33% to 10% of the original size (eg Vendor bundle of 3.65MB is 1.1MB over the wire).

## Build speed

Also this makes the build much faster because Terser plugin does not have to compress the same vendor/common stuff for each page. The numbers are:

| Branch | npm run build time | npm run ci-build time | npm run ci-build time in Github actions |
|--------|--------|--------|--------|
| Master | ~15m | ~12m | 9m |
| This branch | 2m20s | 2m | 1m30s |

This could also be faster as I believe webpack is double building the pages. The server config in webpack.common.mjs builds pages and puts them in dist/pages, whereas the client config builds the same as bundles and puts within dist/. The latter is what express is serving up from my view.

## Granular caching
In this new scheme with vendor and commons split out, it should additionally reduce the amount of bytes a user has to download when they go to a new page or after a release. Unless we've added/upgraded packages that are used client side, the vendor bundle will not change after a release so users won't have to download it again. They will likely have to download commons again, but may only have to download a few page bundles instead of all.

## Potential cost savings for network egress
Assuming some numbers such as:
* Gzip compression results in bundle transfer over the wire being 33% of the disk size
* Users on average look at 5 pages (Cube Analysis, Cube List, Cube Overview, Dashboard, Login)
* 500 users use the app between releases

With current master branch:
* Total disk size of those page bundles is ~17MB
* Gzip reduces that to 5.6MB over the wire
* Times 500 users is 2800MB or 2.8GB
* At $0.045 per GB in us-east-2 that is $0.126 (which admittedly doesn't sound like much)
* If there was a release per week, then times that by 4 (2.8GB x 4)

With splitting:
* Total disk size of those page bundles plus commons is 0.8MB, and vendors is 3.65MB
* Gzip reduces that to 0.26MB and 1.2MB over the wire (sum 1.46MB)
* Times 500 users is 730MB or 0.73GB
* At $0.045 per GB in us-east-2 that is $0.03285
* If there was a release per week, then likely only the pages+commons changes, so only adds 4 times 0.73 x 4  = 2.9MB

# Testing
Functionality wise I did a simple regression across the site. Went to every page, 

## Before
Running in developer mode locally. Can see on 3 different pages dowloading 3-4 MBs of bundles each time (when nothing in cache)
![old-developer-mode-single-bundle](https://github.com/user-attachments/assets/ec5b5ffb-f916-45cc-bd3a-79e51b46e5f5)
![old-developer-mode-single-bundle2](https://github.com/user-attachments/assets/389924d6-3e0a-4ee6-95f8-3445ae990b4c)
![old-developer-mode-single-bundle3](https://github.com/user-attachments/assets/18fe4245-4a46-4a8e-8093-8b7e250b9b11)

## After
In developer mode locally there is no difference, since webpack-dev-server is bundling on the fly. It does not take module splitting into account.
![new-developer-single-bundle-webpack-server](https://github.com/user-attachments/assets/c33d1cfb-de12-4890-977a-762560b7a70d)

But if you were to run locally in production mode (run webpack instead of webpack-dev-server, direct requests straight to express, use dev tools to pretend we are AWS load balancer to bypass HTTPS redirect), then on first page hit we get the vendors and commons, but on the next page the only download has to be the small page bundle.
![new-production-mode-multiple-webpack-bundles](https://github.com/user-attachments/assets/c0c73137-96bc-43b3-ad74-641c78bd1f40)
![new-production-mode-multiple-webpack-bundles2](https://github.com/user-attachments/assets/218fc70d-351a-4258-b5b9-307786664872)

