### PR TITLE
Async load cube or user followers when the modal is opened, page results

### DIFF
--- a/src/client/components/cube/CubeOverviewCard.tsx
+++ b/src/client/components/cube/CubeOverviewCard.tsx
@@ -7,7 +7,6 @@ import ManaPoolBulkButton from 'components/purchase/ManaPoolBulkButton';
 import TCGPlayerBulkButton from 'components/purchase/TCGPlayerBulkButton';
 import { getCubeDescription, getCubeId } from 'utils/Util';
 
-import User from '../../../datatypes/User';
 import BaseUrlContext from '../../contexts/BaseUrlContext';
 import { CSRFContext } from '../../contexts/CSRFContext';
 import CubeContext from '../../contexts/CubeContext';
@@ -55,11 +54,11 @@ const PrivateCubeIcon: React.FC<PrivateCubeIconProps> = ({ visibility }) => {
 interface CubeOverviewCardProps {
   priceOwned: number;
   pricePurchase: number;
-  followers: User[];
+  followersCount: number;
   followed: boolean;
 }
 
-const CubeOverviewCard: React.FC<CubeOverviewCardProps> = ({ followed, priceOwned, pricePurchase, followers }) => {
+const CubeOverviewCard: React.FC<CubeOverviewCardProps> = ({ followed, priceOwned, pricePurchase, followersCount }) => {
   const { csrfFetch } = useContext(CSRFContext);
   const { cube } = useContext(CubeContext);
   const user = useContext(UserContext);
@@ -126,8 +125,8 @@ const CubeOverviewCard: React.FC<CubeOverviewCardProps> = ({ followed, priceOwne
                   <Text semibold md>
                     {getCubeDescription(cube)}
                   </Text>
-                  <FollowersModalLink href="#" modalprops={{ followers }}>
-                    {(cube.following || []).length} {(cube.following || []).length === 1 ? 'follower' : 'followers'}
+                  <FollowersModalLink href="#" modalprops={{ id: cube.id, type: 'cube' }}>
+                    {followersCount} {followersCount === 1 ? 'follower' : 'followers'}
                   </FollowersModalLink>
                 </Flexbox>
                 <Flexbox direction="row" justify="between">

--- a/src/client/components/modals/CreatePackageModal.tsx
+++ b/src/client/components/modals/CreatePackageModal.tsx
@@ -22,14 +22,18 @@ const CreatePackageModal: React.FC<CreatePackageModalProps> = ({ isOpen, setOpen
   const [cardName, setCardName] = useState<string>('');
   const [packageName, setPackageName] = useState<string>('');
   const [imageDict, setImageDict] = useState<{ [key: string]: { id: string } }>({});
+  const [fetched, setFetched] = useState(false);
 
   useEffect(() => {
-    fetch('/cube/api/imagedict')
-      .then((response) => response.json())
-      .then((json) => {
-        setImageDict(json.dict);
-      });
-  }, []);
+    if (isOpen && !fetched) {
+      fetch('/cube/api/imagedict')
+        .then((response) => response.json())
+        .then((json) => {
+          setImageDict(json.dict);
+          setFetched(true);
+        });
+    }
+  }, [isOpen, fetched]);
 
   const submitCard = () => {
     if (imageDict) {

--- a/src/client/components/modals/CubeOverviewModal.tsx
+++ b/src/client/components/modals/CubeOverviewModal.tsx
@@ -30,6 +30,7 @@ const CubeOverviewModal: React.FC<CubeOverviewModalProps> = ({ isOpen, setOpen, 
   const [state, setState] = useState<Cube>(JSON.parse(JSON.stringify(cube)));
   const [imagename, setImagename] = useState(cube.imageName);
   const [imageDict, setImageDict] = useState<Record<string, Image>>({});
+  const [fetched, setFetched] = useState(false);
   const formRef = React.createRef<HTMLFormElement>();
 
   const formData = useMemo(
@@ -44,9 +45,12 @@ const CubeOverviewModal: React.FC<CubeOverviewModalProps> = ({ isOpen, setOpen, 
       const response = await csrfFetch('/cube/api/imagedict');
       const json = await response.json();
       setImageDict(json.dict);
+      setFetched(true);
     };
-    getData();
-  }, [csrfFetch]);
+    if (isOpen && !fetched) {
+      getData();
+    }
+  }, [csrfFetch, fetched, isOpen]);
 
   const changeImage = useCallback(
     (image: string) => {

--- a/src/client/components/modals/CustomizeBasicsModal.tsx
+++ b/src/client/components/modals/CustomizeBasicsModal.tsx
@@ -3,7 +3,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import AutocompleteInput from 'components/base/AutocompleteInput';
 import Button from 'components/base/Button';
 import { Card } from 'components/base/Card';
-import { Col, Flexbox,Row } from 'components/base/Layout';
+import { Col, Flexbox, Row } from 'components/base/Layout';
 import { Modal, ModalBody, ModalFooter, ModalHeader } from 'components/base/Modal';
 import Text from 'components/base/Text';
 import LoadingButton from 'components/LoadingButton';
@@ -22,14 +22,18 @@ const CustomizeBasicsModal: React.FC<CustomizeBasicsModalProps> = ({ isOpen, set
   const [basics, setBasics] = useState<string[]>(cube.basics.slice());
   const [cardName, setCardName] = useState('');
   const [imageDict, setImageDict] = useState<Record<string, { id: string }>>({});
+  const [fetched, setFetched] = useState(false);
 
   useEffect(() => {
-    fetch('/cube/api/imagedict')
-      .then((response) => response.json())
-      .then((json) => {
-        setImageDict(json.dict);
-      });
-  }, []);
+    if (isOpen && !fetched) {
+      fetch('/cube/api/imagedict')
+        .then((response) => response.json())
+        .then((json) => {
+          setImageDict(json.dict);
+          setFetched(true);
+        });
+    }
+  }, [isOpen, fetched]);
 
   const submitCard = () => {
     if (imageDict) {

--- a/src/client/components/modals/FollowersModal.tsx
+++ b/src/client/components/modals/FollowersModal.tsx
@@ -1,34 +1,90 @@
-import React from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 
+import Button from 'components/base/Button';
 import { Col, Row } from 'components/base/Layout';
-import { Modal, ModalBody, ModalHeader } from 'components/base/Modal';
+import { Modal, ModalBody, ModalFooter, ModalHeader } from 'components/base/Modal';
 import Text from 'components/base/Text';
 import UserPreview from 'components/UserPreview';
 import User from 'datatypes/User';
 
+import { CSRFContext } from '../../contexts/CSRFContext';
+
 interface FollowersModalProps {
-  followers: User[];
+  id: string;
+  type: 'cube' | 'user';
   isOpen: boolean;
   setOpen: (open: boolean) => void;
 }
 
-const FollowersModal: React.FC<FollowersModalProps> = ({ followers, isOpen, setOpen }) => (
-  <Modal lg isOpen={isOpen} setOpen={setOpen}>
-    <ModalHeader setOpen={setOpen}>
-      <Text semibold lg>
-        Followers
-      </Text>
-    </ModalHeader>
-    <ModalBody>
-      <Row className="justify-content-center">
-        {followers.map((follower) => (
-          <Col key={follower.id} xs={6} sm={4} lg={3}>
-            <UserPreview user={follower} />
-          </Col>
-        ))}
-      </Row>
-    </ModalBody>
-  </Modal>
-);
+const PAGE_SIZE = 100;
+
+const FollowersModal: React.FC<FollowersModalProps> = ({ type, id, isOpen, setOpen }) => {
+  const { csrfFetch } = useContext(CSRFContext);
+  const [followers, setFollowers] = useState([] as User[]);
+  const [fetched, setFetched] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [hasMore, setHasMore] = useState(false);
+
+  useEffect(() => {
+    const run = async () => {
+      setLoading(true);
+      setFollowers([]);
+      const res = await csrfFetch(`/api/followers/${type}/${id}?skip=0&limit=${PAGE_SIZE}`, {
+        method: 'GET',
+      });
+
+      const json = await res.json();
+      setFollowers(json.followers);
+      setHasMore(json.hasMore);
+      setFetched(true);
+      setLoading(false);
+    };
+
+    //Only trigger if the modal is opened and if we haven't fetched yet
+    if (isOpen && !fetched) {
+      run();
+    }
+  }, [csrfFetch, type, id, isOpen, fetched]);
+
+  const loadMore = useCallback(async () => {
+    setLoading(true);
+    const skip = followers.length;
+    const res = await csrfFetch(`/api/followers/${type}/${id}?skip=${skip}&limit=${PAGE_SIZE}`, {
+      method: 'GET',
+    });
+
+    const json = await res.json();
+    setFollowers([...followers, ...json.followers]);
+    setHasMore(json.hasMore);
+    setLoading(false);
+  }, [csrfFetch, type, id, followers]);
+
+  return (
+    <Modal lg isOpen={isOpen} setOpen={setOpen}>
+      <ModalHeader setOpen={setOpen}>
+        <Text semibold lg>
+          Followers
+        </Text>
+      </ModalHeader>
+      <ModalBody>
+        <Row className="justify-content-center">
+          {followers.map((follower) => (
+            <Col key={follower.id} xs={6} sm={4} lg={3}>
+              <UserPreview user={follower} />
+            </Col>
+          ))}
+        </Row>
+        {loading && <div>Loading...</div>}
+        {hasMore && (
+          <ModalFooter>
+            <Button color="primary" block={true} type="button" onClick={loadMore}>
+              <div className={`centered`}>Load more</div>
+            </Button>
+          </ModalFooter>
+        )}
+      </ModalBody>
+    </Modal>
+  );
+};
 
 export default FollowersModal;

--- a/src/client/layouts/UserLayout.tsx
+++ b/src/client/layouts/UserLayout.tsx
@@ -17,7 +17,7 @@ import User from 'datatypes/User';
 
 interface UserLayoutProps {
   user: User;
-  followers: User[];
+  followersCount: number;
   following: boolean;
   activeLink: string;
   children?: React.ReactNode;
@@ -44,7 +44,7 @@ const ConfirmActionModalButton = withModal(Button, ConfirmActionModal);
 
 const UserLayout: React.FC<UserLayoutProps> = ({
   user,
-  followers,
+  followersCount,
   following,
   activeLink,
   children,
@@ -53,7 +53,7 @@ const UserLayout: React.FC<UserLayoutProps> = ({
   const activeUser = useContext(UserContext)!;
   const canEdit = activeUser && activeUser.id === user.id;
 
-  const numFollowers = followers.length;
+  const numFollowers = followersCount;
   const followersText = (
     <Text semibold sm>
       {numFollowers} {numFollowers === 1 ? 'follower' : 'followers'}
@@ -74,7 +74,7 @@ const UserLayout: React.FC<UserLayoutProps> = ({
               {user.username}
             </Text>
             {numFollowers > 0 ? (
-              <FollowersModalLink href="#" modalprops={{ followers }}>
+              <FollowersModalLink href="#" modalprops={{ id: user.id, type: 'user' }}>
                 {followersText}
               </FollowersModalLink>
             ) : (

--- a/src/client/pages/CubeOverviewPage.tsx
+++ b/src/client/pages/CubeOverviewPage.tsx
@@ -16,7 +16,6 @@ import withModal from 'components/WithModal';
 import UserContext from 'contexts/UserContext';
 import BlogPostType from 'datatypes/BlogPost';
 import Cube, { CubeCards } from 'datatypes/Cube';
-import User from 'datatypes/User';
 import useAlerts from 'hooks/UseAlerts';
 import CubeLayout from 'layouts/CubeLayout';
 import MainLayout from 'layouts/MainLayout';
@@ -33,7 +32,7 @@ interface CubeOverviewProps {
   cube: Cube;
   cards: CubeCards;
   followed: boolean;
-  followers: User[];
+  followersCount: number;
   loginCallback: () => void;
 }
 
@@ -44,7 +43,7 @@ const CubeOverview: React.FC<CubeOverviewProps> = ({
   pricePurchase,
   cube,
   followed,
-  followers,
+  followersCount,
 }) => {
   const user = useContext(UserContext);
   const { alerts, addAlert } = useAlerts();
@@ -89,7 +88,7 @@ const CubeOverview: React.FC<CubeOverviewProps> = ({
           <CubeOverviewCard
             priceOwned={priceOwned}
             pricePurchase={pricePurchase}
-            followers={followers}
+            followersCount={followersCount}
             followed={followed}
           />
           {post && <BlogPost key={post.id} post={post} />}

--- a/src/client/pages/UserBlogPage.tsx
+++ b/src/client/pages/UserBlogPage.tsx
@@ -14,7 +14,7 @@ import UserLayout from 'layouts/UserLayout';
 
 interface UserBlogPageProps {
   owner: User;
-  followers: User[];
+  followersCount: number;
   following: boolean;
   posts: BlogPostType[];
   loginCallback?: string;
@@ -24,7 +24,7 @@ interface UserBlogPageProps {
 const PAGE_SIZE = 10;
 
 const UserBlogPage: React.FC<UserBlogPageProps> = ({
-  followers,
+  followersCount,
   following,
   posts,
   owner,
@@ -64,7 +64,7 @@ const UserBlogPage: React.FC<UserBlogPageProps> = ({
 
       setLoading(false);
     }
-  }, [owner.id, currentLastKey, items, page]);
+  }, [csrfFetch, owner.id, currentLastKey, items, page]);
 
   const pager = (
     <Pagination
@@ -72,6 +72,7 @@ const UserBlogPage: React.FC<UserBlogPageProps> = ({
       active={page}
       hasMore={hasMore}
       onClick={async (newPage) => {
+        // eslint-disable-next-line no-console -- Debugging
         console.log(newPage, pageCount);
         if (newPage >= pageCount) {
           await fetchMoreData();
@@ -85,7 +86,7 @@ const UserBlogPage: React.FC<UserBlogPageProps> = ({
 
   return (
     <MainLayout loginCallback={loginCallback}>
-      <UserLayout user={owner} followers={followers} following={following} activeLink="blog">
+      <UserLayout user={owner} followersCount={followersCount} following={following} activeLink="blog">
         <DynamicFlash />
         {items.length > 0 ? (
           <Flexbox direction="col" gap="2" className="w-full my-3">

--- a/src/client/pages/UserCubePage.tsx
+++ b/src/client/pages/UserCubePage.tsx
@@ -17,17 +17,23 @@ import UserLayout from 'layouts/UserLayout';
 
 interface UserCubePageProps {
   owner: User;
-  followers: User[];
+  followersCount: number;
   following: boolean;
   cubes: Cube[];
   loginCallback: string;
 }
 
-const UserCubePage: React.FC<UserCubePageProps> = ({ owner, followers, following, cubes, loginCallback = '/' }) => {
+const UserCubePage: React.FC<UserCubePageProps> = ({
+  owner,
+  followersCount,
+  following,
+  cubes,
+  loginCallback = '/',
+}) => {
   const user = useContext(UserContext);
   return (
     <MainLayout loginCallback={loginCallback}>
-      <UserLayout user={owner} followers={followers} following={following} activeLink="view">
+      <UserLayout user={owner} followersCount={followersCount} following={following} activeLink="view">
         <DynamicFlash />
         <Flexbox direction="col" className="my-3" gap="2">
           <Card>

--- a/src/client/pages/UserDecksPage.tsx
+++ b/src/client/pages/UserDecksPage.tsx
@@ -15,7 +15,7 @@ import UserLayout from 'layouts/UserLayout';
 
 interface UserDecksPageProps {
   owner: User;
-  followers: User[];
+  followersCount: number;
   following: boolean;
   decks: Draft[];
   loginCallback?: string;
@@ -25,7 +25,7 @@ interface UserDecksPageProps {
 const PAGE_SIZE = 20;
 
 const UserDecksPage: React.FC<UserDecksPageProps> = ({
-  followers,
+  followersCount,
   following,
   decks,
   owner,
@@ -64,7 +64,7 @@ const UserDecksPage: React.FC<UserDecksPageProps> = ({
 
       setLoading(false);
     }
-  }, [owner.id, currentLastKey, items, page]);
+  }, [csrfFetch, currentLastKey, items, page]);
 
   const pager = (
     <Pagination
@@ -72,6 +72,7 @@ const UserDecksPage: React.FC<UserDecksPageProps> = ({
       active={page}
       hasMore={hasMore}
       onClick={async (newPage) => {
+        // eslint-disable-next-line no-console -- Debugging
         console.log(newPage, pageCount);
         if (newPage >= pageCount) {
           await fetchMoreData();
@@ -85,7 +86,7 @@ const UserDecksPage: React.FC<UserDecksPageProps> = ({
 
   return (
     <MainLayout loginCallback={loginCallback}>
-      <UserLayout user={owner} followers={followers} following={following} activeLink="decks">
+      <UserLayout user={owner} followersCount={followersCount} following={following} activeLink="decks">
         <DynamicFlash />
 
         <Card className="my-3">

--- a/src/datatypes/User.ts
+++ b/src/datatypes/User.ts
@@ -17,8 +17,8 @@ export default interface User {
   about?: string;
   hideTagColors?: boolean;
   followedCubes?: string[];
-  followedUsers?: string[];
-  following?: string[];
+  followedUsers?: string[]; //Who this user is following
+  following?: string[]; //Who is following this user
   image?: Image;
   imageName?: string;
   roles?: string[];

--- a/src/router/routes/api/followers.ts
+++ b/src/router/routes/api/followers.ts
@@ -37,12 +37,12 @@ export const getFollowers = async (req: Request, res: Response) => {
       //Cleanup after we are done with the cube
       delete res.locals.cube;
     } else {
-      res.status(400).send({ error: 'Unknow follower type' });
+      res.status(400).send({ error: 'Unknown follower type' });
       return;
     }
 
     const slice = followerIds.slice(skip, skip + limit);
-    const hasMore = followerIds.length >= skip + limit;
+    const hasMore = followerIds.length > skip + limit;
 
     const followers = await User.batchGet(slice);
     res.status(200).send({ followers: followers, hasMore });

--- a/src/router/routes/api/followers.ts
+++ b/src/router/routes/api/followers.ts
@@ -1,0 +1,60 @@
+import Cube from '../../../dynamo/models/cube';
+import User from '../../../dynamo/models/user';
+import { csrfProtection } from '../../../routes/middleware';
+import { NextFunction, Request, Response } from '../../../types/express';
+import { isCubeViewable } from '../../../util/cubefn';
+
+export const ensureCubeVisible = async (req: Request, res: Response, next: NextFunction) => {
+  const { id, type } = req.params;
+
+  if (type === 'cube') {
+    const cube = await Cube.getById(id);
+    if (!isCubeViewable(cube, req.user)) {
+      res.status(404).send({ error: 'Cube not found' });
+      return;
+    } else {
+      //Pass the cube through to the handler so it doesn't have to be loaded again
+      res.locals.cube = cube;
+    }
+  }
+
+  next();
+};
+
+export const getFollowers = async (req: Request, res: Response) => {
+  try {
+    const { id, type } = req.params;
+
+    const limit = parseInt((req.query?.limit || '100') as string, 10);
+    const skip = parseInt((req.query?.skip || '0') as string, 10);
+
+    let followerIds = [];
+    if (type === 'user') {
+      const user = await User.getById(id);
+      followerIds = user?.following || [];
+    } else if (type === 'cube') {
+      followerIds = res.locals.cube?.following || [];
+      //Cleanup after we are done with the cube
+      delete res.locals.cube;
+    } else {
+      res.status(400).send({ error: 'Unknow follower type' });
+      return;
+    }
+
+    const slice = followerIds.slice(skip, skip + limit);
+    const hasMore = followerIds.length >= skip + limit;
+
+    const followers = await User.batchGet(slice);
+    res.status(200).send({ followers: followers, hasMore });
+  } catch {
+    res.status(500).send({ error: 'Error' });
+  }
+};
+
+export const routes = [
+  {
+    method: 'get',
+    path: '/:type/:id',
+    handler: [csrfProtection, ensureCubeVisible, getFollowers],
+  },
+];

--- a/src/routes/cube/index.js
+++ b/src/routes/cube/index.js
@@ -554,7 +554,7 @@ router.get('/overview/:id', async (req, res) => {
 
     const blogs = await Blog.getByCube(cube.id, 1);
 
-    const followers = await User.batchGet(cube.following);
+    const followersCount = cube.following.length;
 
     // calculate cube prices
     const nameToCards = {};
@@ -608,7 +608,7 @@ router.get('/overview/:id', async (req, res) => {
         cards,
         post: blogs && blogs.items.length > 0 ? blogs.items[0] : null,
         followed: req.user && cube.following && cube.following.some((id) => req.user.id === id),
-        followers,
+        followersCount,
         priceOwned: !cube.PrivatePrices ? totalPriceOwned : null,
         pricePurchase: !cube.PrivatePrices ? totalPricePurchase : null,
       },

--- a/src/routes/users_routes.js
+++ b/src/routes/users_routes.js
@@ -464,14 +464,12 @@ router.get('/view/:id', async (req, res) => {
 
     const cubes = (await Cube.getByOwner(user.id)).items.filter((cube) => isCubeListed(cube, req.user));
 
-    const followers = await User.batchGet(user.following || []);
-
     const following = req.user && user.following && user.following.some((id) => id === req.user.id);
 
     return render(req, res, 'UserCubePage', {
       owner: user,
       cubes,
-      followers,
+      followersCount: (user.following || []).length,
       following,
     });
   } catch (err) {
@@ -491,11 +489,9 @@ router.get('/decks/:userid', async (req, res) => {
       return redirect(req, res, '/404');
     }
 
-    const followers = await User.batchGet(user.following || []);
-
     return render(req, res, 'UserDecksPage', {
       owner: user,
-      followers,
+      followersCount: (user.following || []).length,
       following: req.user && (req.user.followedUsers || []).some((id) => id === user.id),
       decks: decks.items,
       lastKey: decks.lastEvaluatedKey,
@@ -546,7 +542,6 @@ router.get('/blog/:userid', async (req, res) => {
     }
 
     const posts = await Blog.getByOwner(req.params.userid, 10);
-    const followers = await User.batchGet(user.following || []);
 
     return render(
       req,
@@ -556,7 +551,7 @@ router.get('/blog/:userid', async (req, res) => {
         owner: user,
         posts: posts.items,
         lastKey: posts.lastKey,
-        followers,
+        followersCount: (user.following || []).length,
         following: req.user && (req.user.followedUsers || []).some((id) => id === user.id),
       },
       {

--- a/tests/followers.api.test.ts
+++ b/tests/followers.api.test.ts
@@ -1,0 +1,141 @@
+import Cube from '../src/dynamo/models/cube';
+import User from '../src/dynamo/models/user';
+import { ensureCubeVisible, getFollowers } from '../src/router/routes/api/followers';
+import CubeFn from '../src/util/cubefn';
+import { createCube, createUser } from './test-utils/data';
+import { expectRegisteredRoutes } from './test-utils/route';
+import { call, middleware } from './test-utils/transport';
+
+jest.mock('../src/dynamo/models/user');
+jest.mock('../src/dynamo/models/cube');
+jest.mock('../src/util/cubefn');
+
+describe('Followers API', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should get followers for a user', async () => {
+    const mockUser = createUser({ following: ['user1', 'user2'] });
+    (User.getById as jest.Mock).mockResolvedValue(mockUser);
+    const users = [createUser({ id: 'user1' }), createUser({ id: 'user2' })];
+    (User.batchGet as jest.Mock).mockResolvedValue(users);
+
+    const res = await call(getFollowers)
+      .withParams({ id: '123', type: 'user' })
+      .withQuery({ limit: '2', skip: '0' })
+      .send();
+
+    expect(res.status).toEqual(200);
+    expect(res.body).toEqual({
+      followers: users,
+      hasMore: false,
+    });
+  });
+
+  it('should get followers for a cube', async () => {
+    const mockCube = createCube({ following: ['user1', 'user2', 'user3'] });
+    (Cube.getById as jest.Mock).mockResolvedValue(mockCube);
+    const users = [createUser({ id: 'user1' }), createUser({ id: 'user2' })];
+    (User.batchGet as jest.Mock).mockResolvedValue(users);
+
+    const res = await call(getFollowers)
+      .withParams({ id: '123', type: 'cube' })
+      .withResponseLocals({
+        cube: mockCube,
+      })
+      .withQuery({ limit: '2', skip: '0' })
+      .send();
+
+    expect(res.status).toEqual(200);
+    expect(res.body).toEqual({
+      followers: users,
+      hasMore: true,
+    });
+  });
+
+  it('should return 400 for unknown follower type', async () => {
+    const res = await call(getFollowers).withParams({ id: '123', type: 'unknown' }).send();
+
+    expect(res.status).toEqual(400);
+    expect(res.body).toEqual({ error: 'Unknown follower type' });
+  });
+
+  it('should handle errors', async () => {
+    (User.getById as jest.Mock).mockRejectedValue(new Error('Failed to get user'));
+
+    const res = await call(getFollowers).withParams({ id: '123', type: 'user' }).send();
+
+    expect(res.status).toEqual(500);
+    expect(res.body).toEqual({ error: 'Error' });
+  });
+
+  it('should handle more followers than the limit', async () => {
+    const mockUser = createUser({ following: ['user1', 'user2', 'user3', 'user4'] });
+    (User.getById as jest.Mock).mockResolvedValue(mockUser);
+    const usersSetOne = [createUser({ id: 'user1' }), createUser({ id: 'user2' })];
+    const usersSetTwo = [createUser({ id: 'user3' }), createUser({ id: 'user4' })];
+    (User.batchGet as jest.Mock).mockResolvedValueOnce(usersSetOne);
+    (User.batchGet as jest.Mock).mockResolvedValueOnce(usersSetTwo);
+
+    const res = await call(getFollowers)
+      .withParams({ id: '123', type: 'user' })
+      .withQuery({ limit: '2', skip: '0' })
+      .send();
+
+    expect(res.status).toEqual(200);
+    expect(res.body).toEqual({
+      followers: usersSetOne,
+      hasMore: true,
+    });
+
+    const pageTwo = await call(getFollowers)
+      .withParams({ id: '123', type: 'user' })
+      .withQuery({ limit: '2', skip: '2' })
+      .send();
+
+    expect(pageTwo.status).toEqual(200);
+    expect(pageTwo.body).toEqual({
+      followers: usersSetTwo,
+      hasMore: false,
+    });
+  });
+});
+
+describe('Ensure Cube Visible Middleware', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call next if cube is viewable', async () => {
+    const mockCube = { id: '123', viewable: true };
+    (Cube.getById as jest.Mock).mockResolvedValue(mockCube);
+    (CubeFn.isCubeViewable as jest.Mock).mockReturnValue(true);
+
+    const res = await middleware(ensureCubeVisible).withParams({ id: '123', type: 'cube' }).as(createUser()).send();
+
+    expect(res.nextCalled).toBeTruthy();
+    expect(res.rawResponse.locals.cube).toEqual(mockCube);
+  });
+
+  it('should return 404 if cube is not viewable', async () => {
+    (Cube.getById as jest.Mock).mockResolvedValue(null);
+    (CubeFn.isCubeViewable as jest.Mock).mockReturnValue(false);
+
+    const res = await middleware(ensureCubeVisible).withParams({ id: '123', type: 'cube' }).as(createUser()).send();
+
+    expect(res.status).toEqual(404);
+    expect(res.body).toEqual({ error: 'Cube not found' });
+  });
+});
+
+describe('Followers Routes', () => {
+  it('should register its own routes', async () => {
+    expectRegisteredRoutes([
+      {
+        path: '/api/followers/:type/:id',
+        method: 'get',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
# Problem
As identified by endpoint duration logging there are outliers where a huge number of followers slows the backend down, having to fetch all the users from dynamo and send them in the response. Most noticeable is in the Modo Vintage cube which has over 3000 followers.

# Solution
As proposed by Dekkaru, load the results asynchronously on the frontend and do so using paging. That reduces the size of the initial page response/duration and keeps each fetch for the new page small.

I choose a page size of 100 as that is in line with other paging. For Modo Vintage Cube that would require 30+ clicks to see all the users, but then again I can't really see why anyone would do that.

## Other improvements
Updated imagedict loads that exist in modals to only do so when the modal is opened and if it hasn't been fetched yet. We discussed changing the caching headers for this more so that the server has to do less work, but this should make a dent in the amount of traffic already

# Testing
I created 50+ fake users by inserting directly into dynamodb, then added those users as followers to a cube and user. Scale wise nowhere close to Modo Vintage cube, but alongside reducing the page size to 10 while testing it allowed me to validate the paging.

## Before

On my local the response size for the Cube overview is 11,039,624 bytes when it contains the followers. The average response duration across 6 samples was 1,378 ms; it is not a super interesting number. The production logs will be a much better indication of the performance improvement.

Both packages and Cube overview loaded the imagedict right away, even though its only needed in the various modals. Perhaps it would make sense to have a ImageDictContext in the future? (I am still a context newbie with react)
![old-packages-loads-imagedict-right-away](https://github.com/user-attachments/assets/82bd34b4-7529-4a48-8316-0041ff17ce0c)
![old-overview-loads-imagedict-twice-right-away](https://github.com/user-attachments/assets/0872385d-c821-4fde-bddb-9bb2f49a3f4e)

## After

On my local the response size for the Cube overview is 10,999,615 bytes when it only has followers count. The average response duration across 6 samples was 972 ms; again it is not very interesting.

Paged loading of followers in the modal:
![new-paged-loading-of-followers2](https://github.com/user-attachments/assets/34e261e9-8484-40ef-84d3-fb5413591f95)

The network requests for the paged loading:
![new-paged-loading-of-followers-network](https://github.com/user-attachments/assets/f9fb79ff-e952-4367-92cb-2b9e56e64d13)

**Fetching the image dict occurs after modals are opened.**

On cube overview load no fetches:
![new-fetching-imagedict-in-modals-occurs-on-open](https://github.com/user-attachments/assets/4802be70-4a23-4d93-8381-7a453b9d82eb)
Opening customize basics does a fetch:
![new-fetching-imagedict-in-modals-occurs-on-open2](https://github.com/user-attachments/assets/e848b4d7-506f-4ee7-b6a6-c88964536699)
Opening edit overview does its own fetch:
![new-fetching-imagedict-in-modals-occurs-on-open3](https://github.com/user-attachments/assets/5cbb3ad7-7fd8-4ca0-9eed-eca5f3ab52a6)

