### PR TITLE
Pass cube's printing preference to the add/cuts endpoints, to bypass get from dynamo.

### DIFF
--- a/src/client/analytics/Suggestions.tsx
+++ b/src/client/analytics/Suggestions.tsx
@@ -45,6 +45,7 @@ const Suggestions: React.FC = () => {
           skip: 0,
           limit: PAGE_SIZE,
           filterText: filterInput,
+          printingPreference: cube.defaultPrinting,
         }),
         headers: {
           'Content-Type': 'application/json',
@@ -57,7 +58,7 @@ const Suggestions: React.FC = () => {
       setAddsLoading(false);
     };
     run();
-  }, [csrfFetch, cube.id, filterInput]);
+  }, [csrfFetch, cube, filterInput]);
 
   useEffect(() => {
     const run = async () => {
@@ -70,6 +71,7 @@ const Suggestions: React.FC = () => {
           skip: 0,
           limit: PAGE_SIZE,
           filterText: filterInput,
+          printingPreference: cube.defaultPrinting,
         }),
         headers: {
           'Content-Type': 'application/json',
@@ -81,7 +83,7 @@ const Suggestions: React.FC = () => {
       setCutsLoading(false);
     };
     run();
-  }, [csrfFetch, cube.id, filterInput]);
+  }, [csrfFetch, cube, filterInput]);
 
   const loadMoreAdds = useCallback(async () => {
     setAddsLoading(true);
@@ -92,6 +94,7 @@ const Suggestions: React.FC = () => {
         skip: addCards.length,
         limit: PAGE_SIZE,
         filterText: filterInput,
+        printingPreference: cube.defaultPrinting,
       }),
       headers: {
         'Content-Type': 'application/json',
@@ -101,7 +104,7 @@ const Suggestions: React.FC = () => {
     const json = await res.json();
     setAddCards([...addCards, ...json.adds]);
     setAddsLoading(false);
-  }, [addCards, csrfFetch, cube.id, filterInput]);
+  }, [addCards, csrfFetch, cube, filterInput]);
 
   const cardsToUse = maybeOnly ? addsInMaybe : addCards;
   const reversedCuts = [...cutCards].reverse();

--- a/src/routes/cube/api.js
+++ b/src/routes/cube/api.js
@@ -793,7 +793,7 @@ router.post('/calculatebasics', async (req, res) => {
 
 router.post('/adds', async (req, res) => {
   let { skip, limit } = req.body;
-  const { cubeID, filterText } = req.body;
+  const { cubeID, filterText, printingPreference } = req.body;
 
   limit = parseInt(limit, 10);
   skip = parseInt(skip, 10);
@@ -804,8 +804,6 @@ router.post('/adds', async (req, res) => {
 
   let slice;
   let { length } = adds;
-
-  const cube = await Cube.getById(cubeID);
 
   if (filterText && filterText.length > 0) {
     const { err, filter } = makeFilter(`${filterText}`);
@@ -818,7 +816,7 @@ router.post('/adds', async (req, res) => {
       });
     }
 
-    const eligible = getAllMostReasonable(filter, cube.defaultPrinting);
+    const eligible = getAllMostReasonable(filter, printingPreference);
     length = eligible.length;
 
     const oracleToEligible = Object.fromEntries(eligible.map((card) => [card.oracle_id, true]));
@@ -830,7 +828,7 @@ router.post('/adds', async (req, res) => {
 
   return res.status(200).send({
     adds: slice.map((item) => {
-      const card = getReasonableCardByOracleWithPrintingPreference(item.oracle, cube.defaultPrinting);
+      const card = getReasonableCardByOracleWithPrintingPreference(item.oracle, printingPreference);
       return {
         details: card,
         cardID: card.scryfall_id,
@@ -841,14 +839,13 @@ router.post('/adds', async (req, res) => {
 });
 
 router.post('/cuts', async (req, res) => {
-  const { cubeID, filterText } = req.body;
+  const { cubeID, filterText, printingPreference } = req.body;
 
   const cards = await Cube.getCards(cubeID);
 
   const { cuts } = recommend(cards.mainboard.map((card) => card.details.oracle_id));
 
   let slice = cuts;
-  const cube = await Cube.getById(cubeID);
 
   if (filterText && filterText.length > 0) {
     const { err, filter } = makeFilter(`${filterText}`);
@@ -860,7 +857,7 @@ router.post('/cuts', async (req, res) => {
       });
     }
 
-    const eligible = getAllMostReasonable(filter, cube.defaultPrinting);
+    const eligible = getAllMostReasonable(filter, printingPreference);
 
     const oracleToEligible = Object.fromEntries(eligible.map((card) => [card.oracle_id, true]));
 
@@ -869,7 +866,7 @@ router.post('/cuts', async (req, res) => {
 
   return res.status(200).send({
     cuts: slice.map((item) => {
-      const card = getReasonableCardByOracleWithPrintingPreference(item.oracle, cube.defaultPrinting);
+      const card = getReasonableCardByOracleWithPrintingPreference(item.oracle, printingPreference);
       return {
         details: card,
         cardID: card.scryfall_id,


### PR DESCRIPTION
At least locally the lookup could take seconds and that is with no network latency pretty much!

Pairing this up with https://github.com/dekkerglen/CubeCobra/pull/2633 for improvements to the recommendations performance. I dunno how much this will help in production; on my local in master branch the timing of Cube.getById(cubeID) is very inconsistent, bouncing between less than 100ms and 5+ seconds. At this point I'm guessing that is due to localstack, but either way its a pretty simple change to pass the printing preference in.