### PR TITLE
Allow custom back of card images to make the Transform button appear.

### DIFF
--- a/src/client/components/card/CardModal.tsx
+++ b/src/client/components/card/CardModal.tsx
@@ -131,8 +131,8 @@ const CardModal: React.FC<CardModalProps> = ({
 
   const updateField = useCallback(
     (field: keyof Card, value: any) => {
-      //Handle edge case of the back image being removed while looking at the back
-      if (field === 'imgBackUrl' && value.trim() === '' && !isFrontImage) {
+      //Handle edge case of the back image being removed while looking at the back, and there is no actual back image on the card details
+      if (field === 'imgBackUrl' && value.trim() === '' && !card?.details?.image_flip && !isFrontImage) {
         setIsFrontImage(true);
         setImageUsed(getCardFrontImage(card));
       }

--- a/src/client/components/card/CardModal.tsx
+++ b/src/client/components/card/CardModal.tsx
@@ -99,20 +99,16 @@ const CardModal: React.FC<CardModalProps> = ({
     }
   }, [card, versionDict]);
 
-  const updateField = useCallback(
-    (field: keyof Card, value: any) => {
-      editCard(card.index!, { ...card, [field]: value }, card.board!);
-    },
-    [card, editCard],
-  );
-
   const disabled = !canEdit || card.markedForDelete;
 
   const { showCustomImages } = useContext(DisplayContext);
 
-  const getCardFrontImage = function (card: Card) {
-    return (showCustomImages && cardImageUrl(card)) || card?.details?.image_normal;
-  };
+  const getCardFrontImage = useCallback(
+    (card: Card) => {
+      return (showCustomImages && cardImageUrl(card)) || card?.details?.image_normal;
+    },
+    [showCustomImages],
+  );
   const getCardBackImage = function (card: Card) {
     return (showCustomImages && cardImageBackUrl(card)) || card?.details?.image_flip;
   };
@@ -133,6 +129,18 @@ const CardModal: React.FC<CardModalProps> = ({
     setImageUsed(getCardBackImage(card));
   }
 
+  const updateField = useCallback(
+    (field: keyof Card, value: any) => {
+      //Handle edge case of the back image being removed while looking at the back
+      if (field === 'imgBackUrl' && value.trim() === '' && !isFrontImage) {
+        setIsFrontImage(true);
+        setImageUsed(getCardFrontImage(card));
+      }
+      editCard(card.index!, { ...card, [field]: value }, card.board!);
+    },
+    [card, editCard, getCardFrontImage, isFrontImage],
+  );
+
   return (
     <Modal lg isOpen={isOpen} setOpen={setOpen}>
       <ModalHeader setOpen={setOpen}>
@@ -151,7 +159,7 @@ const CardModal: React.FC<CardModalProps> = ({
                   fallbackSrc="/content/default_card.png"
                   alt={cardName(card)}
                 />
-                {card?.details?.image_flip && (
+                {getCardBackImage(card) && (
                   <Button
                     className="mt-1"
                     color="accent"


### PR DESCRIPTION
Requires the display setting of show custom images.

# Testing

## Before
If the card doesn't have a back image by nature of it being a DFC/transforming card, adding a custom back image doesn't allow transforming.
![old-adding-custom-back-image-on-single-faced-card-doesnt-transform](https://github.com/user-attachments/assets/f45fae49-2acb-48f2-af12-bc28ab48dddd)

## After

Still works with cards that already are double faced:
![custom-images-with-already-double-faced-card](https://github.com/user-attachments/assets/9792cf32-1275-4b39-b7b1-e06d94efd4f1)

Can add a custom back image to a single-faced card and then it can transform. And if you are looking at the custom back image then remove it, the UI reverts to the front face
![can-transform-when-custom-images-are-used](https://github.com/user-attachments/assets/d0522fbc-0029-4627-bcde-5ab18efe2dc4)

If the custom back image is removed and the card normally has a back image, it does not revert to the front face
![removing-custom-back-image-for-double-faced-stays-on-back](https://github.com/user-attachments/assets/e126aa80-86b3-4e74-b19e-af8d8c783812)

If "show custom images" is off, then cannot transform to custom back side:
![no-transform-if-hide-custom-images](https://github.com/user-attachments/assets/f46dd70d-908e-429e-a400-9e42c131cd46)

