### PR TITLE
Add form validation to the create cube modal, leveraging built-in browser input/form validation.

### DIFF
--- a/src/client/components/base/Input.tsx
+++ b/src/client/components/base/Input.tsx
@@ -21,6 +21,7 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onEnter?: () => void;
   disabled?: boolean;
+  otherInputProps?: React.InputHTMLAttributes<HTMLInputElement>;
 }
 
 const Input: React.FC<InputProps> = ({
@@ -40,6 +41,7 @@ const Input: React.FC<InputProps> = ({
   autoCapitalize = 'sentences',
   autoCorrect = 'on',
   spellCheck = true,
+  otherInputProps = {},
 }) => {
   return (
     <div className="block w-full">
@@ -56,6 +58,7 @@ const Input: React.FC<InputProps> = ({
         )}
       </Flexbox>
       <input
+        {...otherInputProps}
         className={classNames(
           'block w-full h-full px-3 py-2 border border-border bg-bg rounded-md shadow-sm placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-opacity-50 focus:border-focus-ring sm:text-sm transition duration-200 ease-in-out',
           {

--- a/src/client/components/forms/ChallengeInput.tsx
+++ b/src/client/components/forms/ChallengeInput.tsx
@@ -41,6 +41,9 @@ const ChallengeInput: React.FC<ChallengeInputProps> = ({ name, question, answer,
       label={`Security Question: ${question}`}
       value={answer}
       onChange={(e) => setAnswer(e.target.value)}
+      otherInputProps={{
+        required: true,
+      }}
     />
   );
 };

--- a/src/client/components/modals/CreateCubeModal.tsx
+++ b/src/client/components/modals/CreateCubeModal.tsx
@@ -1,9 +1,10 @@
-import React, { useContext, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useMemo, useRef, useState } from 'react';
 
 import ReCAPTCHA from 'react-google-recaptcha';
 
 import CaptchaContext from '../../contexts/CaptchaContext';
 import UserContext from '../../contexts/UserContext';
+import Alert, { UncontrolledAlertProps } from '../base/Alert';
 import Button from '../base/Button';
 import Input from '../base/Input';
 import { Flexbox } from '../base/Layout';
@@ -21,16 +22,60 @@ const CreateCubeModal: React.FC<Props> = ({ isOpen, setOpen }) => {
   const user = useContext(UserContext);
   const captchaSiteKey = useContext(CaptchaContext);
   const [loading, setLoading] = useState(false);
-  const formRef = React.createRef<HTMLFormElement>();
+  //useRef creates a reference that persists between renders, necessary for it to have a value within setTimeout
+  const formRef = useRef<HTMLFormElement>(null);
   const [name, setName] = useState('');
+  const [isNameValid, setNameValid] = useState(true);
   const [captcha, setCaptcha] = useState('');
   const [answer, setAnswer] = useState('');
   const challenge = useMemo(() => generateChallenge(), []);
+  const [alerts, setAlerts] = useState<UncontrolledAlertProps[]>([]);
 
   const formData = useMemo(
     () => ({ name, captcha, question: challenge.question, answer }),
     [name, captcha, challenge, answer],
   );
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      setAlerts([]); // Clear alerts first
+
+      // Add a small delay to ensure the UI updates before showing new alerts
+      setTimeout(() => {
+        // Check form validity
+        if (formRef.current?.checkValidity()) {
+          if (captcha) {
+            setLoading(true);
+            formRef.current?.submit();
+          } else {
+            setAlerts([{ color: 'danger', message: 'Please complete the CAPTCHA' }]);
+          }
+        } else {
+          // Trigger native browser validation UI
+          formRef.current?.reportValidity();
+        }
+      }, 0);
+    },
+    [formRef, captcha],
+  );
+
+  const setCaptchaWrapper = useCallback((value: string | null) => {
+    setAlerts([]);
+    setCaptcha(value || '');
+  }, []);
+
+  const onCubeNameChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const input = e.target;
+    setName(input.value);
+    if (input.validity.tooShort) {
+      setNameValid(false);
+      input.setCustomValidity('Cube name must be between 5 and 100 characters long.');
+    } else {
+      setNameValid(true);
+      input.setCustomValidity('');
+    }
+  }, []);
 
   return (
     <Modal isOpen={isOpen} setOpen={setOpen} sm>
@@ -41,17 +86,26 @@ const CreateCubeModal: React.FC<Props> = ({ isOpen, setOpen }) => {
             <Input
               label="Cube name:"
               value={name}
-              onChange={(e) => setName(e.target.value)}
-              maxLength={1000}
-              name="name"
+              onChange={onCubeNameChange}
               type="text"
+              otherInputProps={{
+                required: true,
+                minLength: 5,
+                maxLength: 100,
+              }}
+              valid={isNameValid}
             />
             <ChallengeInput question={challenge.question} answer={answer} setAnswer={setAnswer} name="answer" />
             <ReCAPTCHA
               sitekey={captchaSiteKey}
-              onChange={(value) => setCaptcha(value || '')}
+              onChange={setCaptchaWrapper}
               theme={user?.theme === 'dark' ? 'dark' : 'light'}
             />
+            {alerts.map(({ color, message }) => (
+              <Alert key={message} color={color} className="mt-2">
+                {message}
+              </Alert>
+            ))}
           </Flexbox>
         </ModalBody>
         <ModalFooter>
@@ -60,15 +114,7 @@ const CreateCubeModal: React.FC<Props> = ({ isOpen, setOpen }) => {
               <Spinner />
             </div>
           ) : (
-            <Button
-              type="submit"
-              block
-              color="primary"
-              onClick={() => {
-                setLoading(true);
-                formRef.current?.submit();
-              }}
-            >
+            <Button type="submit" block color="primary" onClick={handleSubmit}>
               Create
             </Button>
           )}


### PR DESCRIPTION
While working on the edit overview UX improvements I thought about doing the same for the create cube modal.

# Testing

## Before
No validation in the UI. Meaning it easy to have a cube name shorter than 5 characters.

## After
Min name length is highlighted when invalid / provides clear message
![new-min-length-cube-name-validation](https://github.com/user-attachments/assets/9161bef5-f085-43c9-bab5-bb88730e622f)

Security question field required
![new-required-security-question](https://github.com/user-attachments/assets/68e83b91-f341-46f6-93dc-da18392cb921)

Captcha not being set uses Alerts. Couldn't see how to attach form validation through the Recapthca library:
![new-required-captcha](https://github.com/user-attachments/assets/a12775d6-fd80-4c31-bfba-b56d1a5e1d1c)

Gif of the validation in total:
![new-create-cube-validation-total](https://github.com/user-attachments/assets/d06920e8-d3dc-477c-99a5-df863328f395)
