### PR TITLE
Fix vote count being stored in the wrong attribute, not aligned with the vote count index.

### DIFF
--- a/src/datatypes/CardPackage.ts
+++ b/src/datatypes/CardPackage.ts
@@ -15,7 +15,7 @@ export type UnhydratedCardPackage = {
   cards: string[]; //List of card ids
   keywords: string[];
   voters: string[]; //List of user ids
-  votecount: number;
+  voteCount: number;
 };
 
 type CardPackage = Omit<UnhydratedCardPackage, 'id' | 'owner' | 'cards'> & {

--- a/src/dynamo/models/package.ts
+++ b/src/dynamo/models/package.ts
@@ -16,7 +16,7 @@ const client = createClient({
     {
       name: 'ByVoteCount',
       partitionKey: 'status',
-      sortKey: 'votecount',
+      sortKey: 'voteCount',
     },
     {
       name: 'ByDate',
@@ -32,7 +32,7 @@ const client = createClient({
   attributes: {
     id: 'S',
     status: 'S',
-    votecount: 'N',
+    voteCount: 'N',
     date: 'N',
     owner: 'S',
   },
@@ -57,7 +57,7 @@ const createHydratedPackage = (
     cards: cards,
     keywords: document.keywords,
     voters: document.voters,
-    votecount: document.votecount,
+    voteCount: document.voteCount,
   } as CardPackage;
 };
 
@@ -165,7 +165,7 @@ const packages = {
       cards: cardIds,
       voters: document.voters,
       keywords: document.keywords,
-      votecount: document.voters.length,
+      voteCount: document.voters.length,
     });
     return id;
   },


### PR DESCRIPTION
Thankfully the vote count is byproduct of the voters list, so the data isn't lost. Simply need to revote on packages so they get correctly reindexed.

Bug introduced here in the conversion from JS to Typescript.
https://github.com/dekkerglen/CubeCobra/pull/2577/files#diff-75b2f9936deebf62d26be85c57fe79be1b31b1f37ad1200c2530de5890c588cf
Likely I took the FIELDS.<blah> trimmed FIELDS. and then lowercased. Which in retrospect was a dumb way to do it.

# Testing

## Before
In production I voted on a package like https://cubecobra.com/packages/4486a329-3c37-41a5-818d-bf472e800b8a as I was trying to correct the packages after bug fix https://github.com/dekkerglen/CubeCobra/pull/2619 was merged. Then I noticed the package disappeared from the list. I thought at first I broke it, but was at least able to find the package by ID so I knew it wasn't gone. Then I noticed sorting by date made it show up, so it was something specific to voting.

## After
To test this I updated in dynamo some packages to the approved status, which was necessary since looking at "your packages" with vote sorting does not use the indexes at all.

Once I set that up I could see the packages not showing. By taking a closer look at my index vs the code I noticed the casing typo. Updating the code from `votecount` to `voteCount` and then unvote/revote the packages, I could see them in the vote sorting!

# After deploy
I will need to find and revote on the packages that disappeared from the index. My plan is get all the ideas using the date sort, compare against vote sort, and update.