### PR TITLE
use batchpredict results before user picks, add draft weights to picks

### DIFF
--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -786,6 +786,10 @@ video {
   top: 100%;
 }
 
+.bottom-\[5\%\] {
+  bottom: 5%;
+}
+
 .z-10 {
   z-index: 10;
 }
@@ -1150,6 +1154,10 @@ video {
 
 .w-96 {
   width: 24rem;
+}
+
+.w-\[140px\] {
+  width: 140px;
 }
 
 .w-full {
@@ -2234,6 +2242,10 @@ video {
 
 .italic {
   font-style: italic;
+}
+
+.tracking-tight {
+  letter-spacing: -0.025em;
 }
 
 .text-bg {

--- a/src/client/components/Pack.tsx
+++ b/src/client/components/Pack.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import CardType from '../../datatypes/Card';
 import DraftLocation from '../drafting/DraftLocation';
+import Button from './base/Button';
 import { Card, CardBody, CardHeader } from './base/Card';
 import { Col, Row } from './base/Layout';
 import Text from './base/Text';
@@ -11,40 +12,98 @@ import FoilCardImage from './FoilCardImage';
 interface PackProps {
   pack: CardType[];
   loading?: boolean;
+  loadingPredictions?: boolean;
   title?: string;
   disabled?: boolean;
+  ratings?: number[];
+  error?: boolean;
+  onRetry?: () => void;
+  onPickMade?: () => void;
+  retryInProgress?: boolean;
+  onEndDraft?: () => void;
 }
 
-const Pack: React.FC<PackProps> = ({ pack, loading = false, title = 'Pack', disabled = false }) => {
+const Pack: React.FC<PackProps> = ({
+  pack = [],
+  loading = false,
+  loadingPredictions = false,
+  title = 'Pack',
+  disabled = false,
+  ratings,
+  error = false,
+  onRetry,
+  retryInProgress = false,
+}) => {
+  const [showRatings, setShowRatings] = useState(false);
+  const maxRating = ratings ? Math.max(...ratings) : 0;
+
+  useEffect(() => {
+    setShowRatings(false);
+  }, [pack]);
+
   return (
     <Card className="mt-3">
-      <CardHeader>
+      <CardHeader className="flex justify-between items-center">
         <Text semibold lg>
           {title}
         </Text>
+        {error ? (
+          <Button onClick={onRetry} color="danger" disabled={retryInProgress}>
+            {retryInProgress ? 'Retrying...' : 'Bot picks failed. Try again?'}
+          </Button>
+        ) : loadingPredictions ? (
+          <Button color="secondary" disabled>
+            Making Bot Picks...
+          </Button>
+        ) : (
+          ratings &&
+          ratings.length > 0 &&
+          !showRatings && (
+            <Button onClick={() => setShowRatings(true)} color="primary">
+              Show CubeCobra Bot Ratings
+            </Button>
+          )
+        )}
       </CardHeader>
       <CardBody>
-        {loading ? (
-          <div className="centered py-3">
-            <div className="spinner" />
+        <div className="flex">
+          <div className="flex-grow">
+            {loading ? (
+              <div className="centered py-3">
+                <div className="spinner" />
+              </div>
+            ) : (
+              <Row className="g-0" sm={4} lg={8}>
+                {pack.map((card, index) => {
+                  const isHighestRated = ratings && ratings[index] === maxRating;
+                  return (
+                    <Col key={`pack-${card.details?.scryfall_id}-${index}`} xs={1}>
+                      <div
+                        className={`relative ${isHighestRated && showRatings ? 'ring-[5px] ring-offset-0 ring-[#007BFF] rounded-lg' : ''}`}
+                      >
+                        {disabled || error ? (
+                          <FoilCardImage card={card} autocard />
+                        ) : (
+                          <DraggableCard location={DraftLocation.pack(index)} data-index={index} card={card} />
+                        )}
+                        {ratings && ratings[index] !== undefined && showRatings && (
+                          <div
+                            className={`absolute bottom-[5%] left-1/2 -translate-x-1/2 ${
+                              isHighestRated ? 'bg-[#007BFF]/95' : 'bg-gray-700/80'
+                            } text-white px-3 rounded-md text-xxs font-semibold tracking-tight`}
+                            title={`Bot rates this card ${Math.round(ratings[index] * 100)}% for this pick`}
+                          >
+                            {Math.round(ratings[index] * 100)}%
+                          </div>
+                        )}
+                      </div>
+                    </Col>
+                  );
+                })}
+              </Row>
+            )}
           </div>
-        ) : (
-          <Row className="g-0" sm={4} lg={8}>
-            {pack.map((card, index) => (
-              <Col
-                key={`pack-${card.details?.scryfall_id}`}
-                xs={1}
-                className="col-md-1-5 col-lg-1-5 col-xl-1-5 d-flex justify-content-center align-items-center"
-              >
-                {disabled ? (
-                  <FoilCardImage card={card} autocard />
-                ) : (
-                  <DraggableCard location={DraftLocation.pack(index)} data-index={index} card={card} />
-                )}
-              </Col>
-            ))}
-          </Row>
-        )}
+        </div>
       </CardBody>
     </Card>
   );

--- a/src/client/pages/CubeDraftPage.tsx
+++ b/src/client/pages/CubeDraftPage.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 import { DndContext } from '@dnd-kit/core';
-import type { PredictResponse } from 'src/router/routes/api/draftbots/batchpredict.ts';
 import type { State } from 'src/router/routes/draft/finish.ts';
 
 import { Card } from 'components/base/Card';
@@ -26,6 +25,39 @@ interface CubeDraftPageProps {
   draft: Draft;
   loginCallback?: string;
 }
+
+interface PredictResponse {
+  prediction: {
+    oracle: string;
+    rating: number;
+  }[][];
+}
+
+interface BatchPredictRequest {
+  pack: string[];
+  picks: string[];
+}
+
+const fetchBatchPredict = async (inputs: BatchPredictRequest[]): Promise<PredictResponse> => {
+  const response = await fetch('/api/draftbots/batchpredict', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ inputs }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch batch predictions: ${response.status}`);
+  }
+
+  return response.json();
+};
+
+const processPredictions = (json: PredictResponse, packCards: any[]) => {
+  // Create a map of oracle IDs to ratings
+  const predictionsMap = new Map(json.prediction[0].map((p) => [p.oracle, p.rating]));
+  // Then add ratings to packCards while maintaining pack order
+  return packCards.map((card) => predictionsMap.get(card.oracle_id) || 0);
+};
 
 const getInitialState = (draft: Draft): State => {
   const stepQueue: DraftStep[] = [];
@@ -52,11 +84,31 @@ const getInitialState = (draft: Draft): State => {
   };
 };
 
+interface DraftStatus {
+  loading: boolean;
+  predictionsLoading: boolean;
+  predictError: boolean;
+  retryInProgress: boolean;
+}
+
 const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallback }) => {
+  // Draft State
+  // These reflect the current state of the draft objects, including the cards in the pack, the picks made, and the ratings for each card.
   const [state, setState] = useLocalStorage(`draftstate-${draft.id}`, getInitialState(draft));
   const [mainboard, setMainboard] = useLocalStorage(`mainboard-${draft.id}`, setupPicks(2, 8));
   const [sideboard, setSideboard] = useLocalStorage(`sideboard-${draft.id}`, setupPicks(1, 8));
-  const [loading, setLoading] = useState(false);
+  const [ratings, setRatings] = useState<number[]>([]);
+  const [currentPredictions, setCurrentPredictions] = useState<PredictResponse | null>(null);
+
+  // Draft Status
+  // These are used to track the status of the draft itself, including loading, errors, etc.
+  const [draftStatus, setDraftStatus] = useState<DraftStatus>({
+    loading: false,
+    predictionsLoading: false,
+    predictError: false,
+    retryInProgress: false,
+  });
+
   const [dragStartTime, setDragStartTime] = useState<number | null>(null);
   const { csrfFetch } = useContext(CSRFContext);
 
@@ -78,40 +130,100 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
   );
 
   const endDraft = useCallback(async () => {
-    const response = await csrfFetch(`/draft/finish/${draft.id}`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        state,
-        mainboard,
-        sideboard,
-      }),
-    });
+    setDraftStatus((prev) => ({ ...prev, loading: true }));
 
-    if (response.ok) {
-      // redirect to /draft/deckbuilder/:id
-      window.location.href = `/draft/deckbuilder/${draft.id}`;
-    } else {
-      // eslint-disable-next-line no-console
-      console.error('error finishing draft: ', response);
+    try {
+      const response = await csrfFetch(`/draft/finish/${draft.id}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          state,
+          mainboard,
+          sideboard,
+        }),
+      });
+
+      // Force error if status is not 2xx range
+      if (!response.ok) {
+        throw new Error(`HTTP error! Status: ${response.status}`);
+      } else {
+        window.location.href = `/draft/deckbuilder/${draft.id}`;
+      }
+    } catch (err) {
+      console.error('endDraft error caught:', err);
+      setDraftStatus((prev) => ({ ...prev, loading: false }));
     }
-  }, [csrfFetch, draft.id, mainboard, sideboard, state]);
+  }, [csrfFetch, draft.id, mainboard, sideboard, state, setDraftStatus]);
+
+  const getPredictions = useCallback(
+    async (request: { state: any; packCards: { index: number; oracle_id: string }[] }) => {
+      setDraftStatus((prev) => ({ ...prev, predictionsLoading: true, predictError: false }));
+      try {
+        const inputs = request.state.seats.map((seat: any) => ({
+          pack: seat.pack
+            .map((index: number) => draft.cards[index]?.details?.oracle_id)
+            .filter((id: string | undefined): id is string => Boolean(id)),
+          picks: seat.picks
+            .map((index: number) => draft.cards[index]?.details?.oracle_id)
+            .filter((id: string | undefined): id is string => Boolean(id)),
+        }));
+
+        const json = await fetchBatchPredict(inputs);
+        setCurrentPredictions(json);
+        setRatings(processPredictions(json, request.packCards));
+        return json;
+      } catch (error) {
+        console.error('Error fetching predictions:', error, 'inputs', request.state);
+        setDraftStatus((prev) => ({ ...prev, predictError: true }));
+        return null;
+      } finally {
+        setDraftStatus((prev) => ({ ...prev, predictionsLoading: false }));
+      }
+    },
+    [draft.cards],
+  );
+
+  const handleRetryPredict = useCallback(async () => {
+    if (draftStatus.retryInProgress || !state?.seats?.[0]?.pack) {
+      return;
+    }
+
+    setDraftStatus((prev) => ({ ...prev, retryInProgress: true }));
+    try {
+      const currentState = state;
+      const packCards = currentState.seats[0].pack.map((index) => ({
+        index,
+        oracle_id: draft.cards[index]?.details?.oracle_id || '',
+      }));
+      await getPredictions({ state: currentState, packCards });
+    } finally {
+      setDraftStatus((prev) => ({ ...prev, retryInProgress: false }));
+    }
+  }, [state, draft.cards, getPredictions, draftStatus.retryInProgress, setDraftStatus]);
 
   const makePick = useCallback(
     async (index: number, location: location, row: number, col: number) => {
-      //first update mainboard or sideboard so it's snappy
-      const { board, setter } = getLocationReferences(location);
+      if (draftStatus.predictError || draftStatus.loading || draftStatus.predictionsLoading) {
+        console.log('Pick blocked:', {
+          predictError: draftStatus.predictError,
+          loading: draftStatus.loading,
+          predictionsLoading: draftStatus.predictionsLoading,
+        });
+        return;
+      }
 
-      setLoading(true);
+      setDraftStatus((prev) => ({ ...prev, loading: true }));
+      setRatings([]); // Clear ratings
       const newState = { ...state };
 
       // look at the current step
       const currentStep = newState.stepQueue[0];
 
-      //The board only changes when ther is a pick (human or auto) action
+      //The board only changes when there is a pick (human or auto) action
       if (currentStep.action.includes('pick')) {
+        const { board, setter } = getLocationReferences(location);
         board[row][col].push(state.seats[0].pack[index]);
         setter(board);
       }
@@ -127,36 +239,20 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
 
       if (!currentStep) {
         // This should never happen, but if it does, the draft finishing should be in progress
-        setLoading(false);
+        setDraftStatus((prev) => ({ ...prev, loading: false }));
         return;
       }
 
       if (currentStep.action === 'endpack' || currentStep.action === 'pass') {
         // This should never happen
-        setLoading(false);
+        setDraftStatus((prev) => ({ ...prev, loading: false }));
         return;
       }
 
       if (currentStep.action === 'pick' || currentStep.action === 'trash') {
-        // make call to draftbots
-        const response = await fetch(`/api/draftbots/batchpredict`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            inputs: state.seats.slice(1).map((seat) => ({
-              pack: seat.pack.map((index) => draft.cards[index].details?.oracle_id),
-              picks: seat.picks.map((index) => draft.cards[index].details?.oracle_id),
-            })),
-          }),
-        });
-
-        if (response.ok) {
-          const json = (await response.json()) as PredictResponse;
-
-          // get the highest rated card
-          const picks = json.prediction.map((seat, index) => {
+        // Use existing predictions for bot picks
+        if (currentPredictions?.prediction) {
+          const picks = currentPredictions.prediction.slice(1).map((seat, index) => {
             const pack = state.seats[index + 1].pack.map((i) => draft.cards[i].details?.oracle_id);
 
             if (pack.length === 0) {
@@ -213,12 +309,12 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
       }
 
       // get the next step
-      let nextStep = newState.stepQueue[0];
+      const nextStep = newState.stepQueue[0];
 
       // either pass the pack, open the next pack, or end the draft
       if (!nextStep) {
         // should never happen
-        setLoading(false);
+        setDraftStatus((prev) => ({ ...prev, loading: false }));
         return;
       }
 
@@ -238,12 +334,13 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
         newState.stepQueue.shift();
       }
 
-      // get the next step
-      nextStep = newState.stepQueue[0];
-
       if (nextStep.action === 'endpack') {
         // we open the next pack or end the draft
         if (draft.InitialState && state.pack === draft.InitialState[0].length) {
+          setState(newState);
+          setDraftStatus((prev) => ({ ...prev, loading: false }));
+
+          // Now attempt to end the draft
           await endDraft();
           return;
         }
@@ -258,12 +355,40 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
 
         // pop the step
         newState.stepQueue.shift();
+
+        // Clear ratings before opening new pack
+        setRatings([]);
+
+        // Get ratings for new pack after it's opened
+        if (newState.seats[0].pack.length > 0) {
+          const request = {
+            state: newState,
+            packCards: newState.seats[0].pack
+              .map((index) => ({
+                index,
+                oracle_id: draft.cards[index]?.details?.oracle_id || '',
+              }))
+              .filter((card): card is { index: number; oracle_id: string } => Boolean(card.oracle_id)),
+          };
+
+          await getPredictions(request);
+        }
       }
 
       setState(newState);
-      setLoading(false);
+      setDraftStatus((prev) => ({ ...prev, loading: false }));
     },
-    [draft.InitialState, draft.cards, draft.seats.length, endDraft, getLocationReferences, setState, state],
+    [
+      draft.InitialState,
+      draft.cards,
+      draft.seats.length,
+      endDraft,
+      getLocationReferences,
+      setState,
+      state,
+      currentPredictions,
+      getPredictions,
+    ],
   );
 
   const selectCardByIndex = useCallback(
@@ -374,20 +499,38 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
       state.stepQueue[0] &&
       (state.stepQueue[0].action === 'pickrandom' || state.stepQueue[0].action === 'trashrandom') &&
       state.seats[0].pack.length > 0 &&
-      !loading
+      !draftStatus.loading
     ) {
-      setLoading(true);
+      setDraftStatus((prev) => ({ ...prev, loading: true }));
       setTimeout(() => {
         //Automatically select a card from the pack, by picking a random index position within the available card pack
         selectCardByIndex(Math.floor(Math.random() * state.seats[0].pack.length));
       }, 1000);
     }
-  }, [selectCardByIndex, loading, state.stepQueue, state.seats]);
+  }, [selectCardByIndex, draftStatus.loading, state.stepQueue, state.seats]);
+
+  // P1P1 ratings fetch necessary, the rest come via makePick
+  useEffect(() => {
+    const fetchInitialRatings = async () => {
+      if (state?.seats?.[0]?.pack?.length > 0) {
+        const request = {
+          state,
+          packCards: state.seats[0].pack.map((index) => ({
+            index,
+            oracle_id: draft.cards[index]?.details?.oracle_id || '',
+          })),
+        };
+        await getPredictions(request);
+      }
+    };
+
+    fetchInitialRatings();
+  }, [draft.cards, state, getPredictions]);
 
   const packTitle: string = useMemo(() => {
     const nextStep = state.stepQueue[0];
 
-    if (loading) {
+    if (draftStatus.loading) {
       if (state.stepQueue.length <= 1) {
         return 'Finishing up draft...';
       }
@@ -409,38 +552,54 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
       default:
         return '';
     }
-  }, [state, loading]);
+  }, [state, draftStatus.loading]);
 
-  const disabled = state.stepQueue[0].action === 'pickrandom' || state.stepQueue[0].action === 'trashrandom';
+  const disabled =
+    state.stepQueue[0].action === 'pickrandom' ||
+    state.stepQueue[0].action === 'trashrandom' ||
+    draftStatus.predictError ||
+    draftStatus.predictionsLoading;
 
   return (
     <MainLayout loginCallback={loginCallback}>
       <DisplayContextProvider cubeID={cube.id}>
         <CubeLayout cube={cube} activeLink="playtest">
           <DndContext onDragEnd={onMoveCard} onDragStart={() => setDragStartTime(Date.now())}>
-            <Pack
-              pack={state.seats[0].pack.map((index) => draft.cards[index])}
-              loading={loading}
-              title={packTitle}
-              disabled={disabled}
-            />
-            <Card className="my-3">
-              <DeckStacks
-                cards={mainboard.map((row) => row.map((col) => col.map((index) => draft.cards[index])))}
-                title="Mainboard"
-                subtitle={makeSubtitle(mainboard.flat(3).map((index) => draft.cards[index]))}
-                locationType={locations.deck}
-                xs={4}
-                lg={8}
-              />
-              <DeckStacks
-                cards={sideboard.map((row) => row.map((col) => col.map((index) => draft.cards[index])))}
-                title="Sideboard"
-                locationType={locations.sideboard}
-                xs={4}
-                lg={8}
-              />
-            </Card>
+            <div className="relative">
+              {/* Only show the pack if there are actually cards to show */}
+              {state?.seats?.[0]?.pack?.length > 0 ? (
+                <Pack
+                  pack={state.seats[0].pack.map((index) => draft.cards[index])}
+                  loading={draftStatus.loading}
+                  loadingPredictions={draftStatus.predictionsLoading}
+                  title={packTitle}
+                  disabled={disabled || draftStatus.predictError || draftStatus.retryInProgress}
+                  ratings={ratings}
+                  error={draftStatus.predictError}
+                  onRetry={handleRetryPredict}
+                  retryInProgress={draftStatus.retryInProgress}
+                />
+              ) : (
+                <></>
+              )}
+              <Card className="my-3">
+                <DeckStacks
+                  cards={mainboard.map((row) => row.map((col) => col.map((index) => draft.cards[index])))}
+                  title="Mainboard"
+                  subtitle={makeSubtitle(mainboard.flat(3).map((index) => draft.cards[index]))}
+                  locationType={locations.deck}
+                  xs={4}
+                  lg={8}
+                />
+                <DeckStacks
+                  cards={sideboard.map((row) => row.map((col) => col.map((index) => draft.cards[index])))}
+                  title="Sideboard"
+                  locationType={locations.sideboard}
+                  xs={4}
+                  lg={8}
+                />
+              </Card>
+            </div>
           </DndContext>
         </CubeLayout>
       </DisplayContextProvider>

--- a/src/client/pages/CubeDraftPage.tsx
+++ b/src/client/pages/CubeDraftPage.tsx
@@ -379,14 +379,17 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
       setDraftStatus((prev) => ({ ...prev, loading: false }));
     },
     [
-      draft.InitialState,
+      draftStatus.predictError,
+      draftStatus.loading,
+      draftStatus.predictionsLoading,
+      state,
+      setState,
+      getLocationReferences,
+      currentPredictions,
       draft.cards,
       draft.seats.length,
+      draft.InitialState,
       endDraft,
-      getLocationReferences,
-      setState,
-      state,
-      currentPredictions,
       getPredictions,
     ],
   );

--- a/src/client/pages/CubeDraftPage.tsx
+++ b/src/client/pages/CubeDraftPage.tsx
@@ -152,6 +152,7 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
         window.location.href = `/draft/deckbuilder/${draft.id}`;
       }
     } catch (err) {
+      // eslint-disable-next-line no-console
       console.error('endDraft error caught:', err);
       setDraftStatus((prev) => ({ ...prev, loading: false }));
     }
@@ -175,6 +176,7 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
         setRatings(processPredictions(json, request.packCards));
         return json;
       } catch (error) {
+        // eslint-disable-next-line no-console
         console.error('Error fetching predictions:', error, 'inputs', request.state);
         setDraftStatus((prev) => ({ ...prev, predictError: true }));
         return null;
@@ -206,11 +208,6 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
   const makePick = useCallback(
     async (index: number, location: location, row: number, col: number) => {
       if (draftStatus.predictError || draftStatus.loading || draftStatus.predictionsLoading) {
-        console.log('Pick blocked:', {
-          predictError: draftStatus.predictError,
-          loading: draftStatus.loading,
-          predictionsLoading: draftStatus.predictionsLoading,
-        });
         return;
       }
 


### PR DESCRIPTION
Major Changes

**Faster Draft UI**

The batchPredict call (which fetches ML weights used for bot picks) now runs and updates the draft as the pack loads, ensuring the next pack is ready immediately instead of waiting on the server between picks.

**Retry on Failure**

Added a retry button for batchPredict failures. Previously, failures could corrupt the local draft state, as a makePick call might start but not complete. While that should no longer happen due to the sequencing changes, users still need a way to recover from a failed batchPredict that prevents them from making a next pick. The retry button addresses this.

**ML Prediction Weights**

Added a button to view ML prediction weights for the current pack, similar to the existing pick-by-pick breakdown. If users have frequent questions about the numbers, we may want to add helper text for clarification. The blue-highlighted card represents the choice a bot would make in the user’s position.

**TODOs**

Refactor CubeDraftPage— still too wild, draft logic should move to a custom hook.
Properly handle EndDraft failures
Prefetch next pack's images for even smoother UI
Add fancy draft animations
