### PR TITLE
Fix error where type in typeStatus and typeOwner could be undefined, for podcast episodes specifically.

### DIFF
--- a/src/dynamo/models/content.ts
+++ b/src/dynamo/models/content.ts
@@ -234,13 +234,13 @@ const content = {
   put: async (document: Article | Episode | Podcast | Video, type: ContentType) => {
     document.id = document.id || uuidv4();
 
+    document.type = type;
     const { content, body, ownerId } = normalizeContentForWriting(document);
 
     await putBody(content.id, body);
 
     return client.put({
       ...content,
-      type,
       owner: ownerId,
     });
   },


### PR DESCRIPTION
Set type on the document before call to normalizeContentForWriting. Articles, Podcasts, and Videos must at least be saved once for them to be published (let along content set) and that would have gone through update() with the type loaded properly.

Episodes get pulled in via Content.getByTypeAndStatus and then new episodes are created if their guid doesn't exist in the retrieved episodes, using the podcastGuid property. But with typeStatus and typeOwner having undefined instead of type by this bug, the episodes aren't seen as existing and then pulled again.

These episodes aren't seen on the podcast page itself because that also uses Content.getByTypeAndStatus. Whereas the dashboard pulls via Content.getByStatus.