### PR TITLE
Fix error where frontend causes a 404 on redirect because the short id changed.

### DIFF
--- a/src/client/components/modals/CubeOverviewModal.tsx
+++ b/src/client/components/modals/CubeOverviewModal.tsx
@@ -75,11 +75,11 @@ const CubeOverviewModal: React.FC<CubeOverviewModalProps> = ({ isOpen, setOpen, 
       }),
     });
 
+    const body = await response.json();
     if (response.ok) {
       //Reload page to ensure state is updated
-      window.location.reload();
+      window.location.replace(body.redirect);
     } else {
-      const body = await response.json();
       setAlerts([{ color: 'danger', message: body.error }]);
     }
   }, [csrfFetch, state]);

--- a/src/router/routes/cube/api/editoverview.ts
+++ b/src/router/routes/cube/api/editoverview.ts
@@ -3,7 +3,7 @@ import Cube from '../../../../dynamo/models/cube';
 import CubeHash from '../../../../dynamo/models/cubeHash';
 import { csrfProtection, ensureAuth } from '../../../../routes/middleware';
 import { Request, Response } from '../../../../types/express';
-import { isCubeViewable } from '../../../../util/cubefn';
+import { getCubeId, isCubeViewable } from '../../../../util/cubefn';
 import util from '../../../../util/util';
 
 export const editOverviewHandler = async (req: Request, res: Response) => {
@@ -125,7 +125,10 @@ export const editOverviewHandler = async (req: Request, res: Response) => {
     cube.tags = updatedCube.tags.filter((tag) => tag && tag.length > 0).map((tag) => tag.toLowerCase());
 
     await Cube.update(cube);
-    res.status(200).json({ success: 'Cube updated successfully' });
+
+    const redirect = `/cube/overview/${getCubeId(cube)}`;
+
+    res.status(200).json({ success: 'Cube updated successfully', redirect });
   } catch (err) {
     const error = err as Error;
     req.logger.error(error.message, error.stack);


### PR DESCRIPTION
Return the direct portion of the URL to use instead of a reload.

# Testing

## Before

Save a cube without a short id, reloads fine
![old-save-cube-add-short-id-continues-using-guid](https://github.com/user-attachments/assets/dd8d8ac5-47ec-4100-97e8-2f5b131b3389)

Saving a cube to add a short id reloads using the GUID

Save a cube with a short id change, 404
![old-save-cube-change-short-id-404](https://github.com/user-attachments/assets/0753e77c-fc24-46f2-a062-19bbf574c6ff)

Save a cube and remove the short id, 404
![old-save-cube-remove-shortid-404](https://github.com/user-attachments/assets/390e3b1c-bbae-40f5-9a32-01699cce20f1)

## After

Save a cube without a short id, redirects to the GUID URL
![new-save-cube-without-short-id-redirects-to-guid](https://github.com/user-attachments/assets/4da8e245-276d-488e-8ffc-ec0d05d92ec3)

Save a cube adding a short id, redirects to the short ID URL
![new-save-cube-adding-short-id-redirects-to-shortid](https://github.com/user-attachments/assets/c364e041-787a-45b8-a3ea-86018f13d09c)

Save a cube with a short id, redirects to it
![new-save-cube-with-shortid-redirects-to-it](https://github.com/user-attachments/assets/ffc2b2ee-5970-45c3-aec9-d895502ed492)

Save a cube and change the short id, redirects to the new one
![new-save-cube-change-shortid-redirects-to-new](https://github.com/user-attachments/assets/19c91dbb-da0e-4c1b-8fd8-82935847fff1)

Save a cube and remove the short id, redirects to the GUID URL
![new-save-cube-remove-shortid-redirects-to-guid](https://github.com/user-attachments/assets/fb909131-c38b-4f3a-85cc-d6dd814a7d51)

