### PR TITLE
Fix Playtest data CSV containing card ID instead of name, so different than the UI

### DIFF
--- a/src/client/analytics/PlaytestData.tsx
+++ b/src/client/analytics/PlaytestData.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useMemo } from 'react';
 
-import { encodeName, mainboardRate, pickRate } from 'utils/cardutil';
+import { cardName, cardNameLower, cardOracleId, encodeName, mainboardRate, pickRate } from 'utils/cardutil';
 import { fromEntries } from 'utils/Util';
 
 import Card, { DefaultElo } from '../../datatypes/Card';
@@ -29,7 +29,7 @@ const AutocardItem = withAutocard('div');
 const renderCardLink = (card: Card) => (
   <AutocardItem className="p-0" key={card.index} card={card}>
     <a href={`/tool/card/${encodeName(card.cardID)}`} target="_blank" rel="noopener noreferrer">
-      {card.details?.name}
+      {cardName(card)}
     </a>
   </AutocardItem>
 );
@@ -39,7 +39,7 @@ const renderPercent = (val: number) => {
 };
 
 const compareCardNames = (a: Card, b: Card): number => {
-  return (a?.details?.name_lower || '').localeCompare(b.details?.name_lower || '');
+  return cardNameLower(a).localeCompare(cardNameLower(b));
 };
 
 const PlaytestData: React.FC<PlaytestDataProps> = ({ cubeAnalytics }) => {
@@ -47,12 +47,7 @@ const PlaytestData: React.FC<PlaytestDataProps> = ({ cubeAnalytics }) => {
   const cards = changedCards.mainboard;
 
   const cardDict = useMemo(
-    () =>
-      fromEntries(
-        cards
-          .filter((card) => card.details && card.details.oracle_id)
-          .map((card) => [card.details?.oracle_id || '', card]),
-      ),
+    () => fromEntries(cards.filter((card) => cardOracleId(card)).map((card) => [cardOracleId(card), card])),
     [cards],
   );
 

--- a/src/client/analytics/PlaytestData.tsx
+++ b/src/client/analytics/PlaytestData.tsx
@@ -62,7 +62,7 @@ const PlaytestData: React.FC<PlaytestDataProps> = ({ cubeAnalytics }) => {
         .filter(([oracle]) => cardDict[oracle])
         .map(([oracle, { elo, mainboards, sideboards, picks, passes }]) => ({
           card: {
-            exportValue: oracle,
+            exportValue: cardName(cardDict[oracle]),
             ...cardDict[oracle],
           },
           elo: Math.round(elo || DefaultElo),

--- a/src/client/components/SortableTable.tsx
+++ b/src/client/components/SortableTable.tsx
@@ -45,7 +45,8 @@ export const compareStrings = (a: any, b: any): number => a?.toString?.()?.local
 export const SortableTable: React.FC<SortableTableProps> = ({ data, defaultSortConfig, sortFns, columnProps }) => {
   const { items, requestSort, sortConfig } = useSortableData(data, defaultSortConfig, sortFns);
 
-  const exportData = data.map((row) =>
+  //Export CSV data uses same sort as the table shown
+  const exportData = items.map((row) =>
     fromEntries(
       Object.entries(row).map(([key, value]) => {
         if (value.exportValue) {


### PR DESCRIPTION
Reported in Discord.

Most changes are utilizing cardutil functions more, for consistency. As also asked in contributor Discord, we can easily make the export CSV use the same sorting the UI is which seems like a nice quality of life improvement.

# Testing

## Before

Screenshot showing both CSV output and table in the UI, see "card" column has card oracle ids.
![old-playtest-csv-card-ids-instead-of-name](https://github.com/user-attachments/assets/d5d169f0-ca09-4058-bb9d-412e51b5894d)

## After

Again showing both, but "card" is the card name
![new-playtest-csv-card-name](https://github.com/user-attachments/assets/c6996c80-b23f-4fb5-9984-d4e51dafb2a6)
