### PR TITLE
Support tag exact match searching

### DIFF
--- a/nearley/values.ne
+++ b/nearley/values.ne
@@ -146,8 +146,11 @@ colorCombinationValue ->
 
 @builtin "string.ne"
 
-stringSetElementOpValue -> ":" stringValue {% ([op, value]) => setElementOperation(op, value) %}
-  | ("=" | "!=" | "<>" | "<" | "<=" | ">" | ">=") integerValue {% ([[op], value]) => setCountOperation(op, value) %}
+# For string matching (with colon) if the string is quoted then exact match, otherwise partial
+stringSetElementOpValue -> ("=" | "!=" | "<>" | "<" | "<=" | ">" | ">=") integerValue {% ([[op], value]) => setCountOperation(op, value) %}
+  | ":" noQuoteStringValue {% ([, value]) => setElementOperation(':', value.toLowerCase()) %}
+  | ":" dqstring  {% ([, value]) => setElementOperation('=', value.toLowerCase()) %}
+  | ":" sqstring  {% ([, value]) => setElementOperation('=', value.toLowerCase()) %}
 
 stringOpValue -> equalityOperator stringValue {% ([op, value]) => stringOperation(op, value) %}
 

--- a/src/client/generated/filtering/cardFilters.js
+++ b/src/client/generated/filtering/cardFilters.js
@@ -1331,7 +1331,6 @@ var grammar = {
             return d.join("");
         }
         },
-    {"name": "stringSetElementOpValue", "symbols": [{"literal":":"}, "stringValue"], "postprocess": ([op, value]) => setElementOperation(op, value)},
     {"name": "stringSetElementOpValue$subexpression$1", "symbols": [{"literal":"="}]},
     {"name": "stringSetElementOpValue$subexpression$1$string$1", "symbols": [{"literal":"!"}, {"literal":"="}], "postprocess": function joiner(d) {return d.join('');}},
     {"name": "stringSetElementOpValue$subexpression$1", "symbols": ["stringSetElementOpValue$subexpression$1$string$1"]},
@@ -1344,6 +1343,9 @@ var grammar = {
     {"name": "stringSetElementOpValue$subexpression$1$string$4", "symbols": [{"literal":">"}, {"literal":"="}], "postprocess": function joiner(d) {return d.join('');}},
     {"name": "stringSetElementOpValue$subexpression$1", "symbols": ["stringSetElementOpValue$subexpression$1$string$4"]},
     {"name": "stringSetElementOpValue", "symbols": ["stringSetElementOpValue$subexpression$1", "integerValue"], "postprocess": ([[op], value]) => setCountOperation(op, value)},
+    {"name": "stringSetElementOpValue", "symbols": [{"literal":":"}, "noQuoteStringValue"], "postprocess": ([, value]) => setElementOperation(':', value.toLowerCase())},
+    {"name": "stringSetElementOpValue", "symbols": [{"literal":":"}, "dqstring"], "postprocess": ([, value]) => setElementOperation('=', value.toLowerCase())},
+    {"name": "stringSetElementOpValue", "symbols": [{"literal":":"}, "sqstring"], "postprocess": ([, value]) => setElementOperation('=', value.toLowerCase())},
     {"name": "stringOpValue", "symbols": ["equalityOperator", "stringValue"], "postprocess": ([op, value]) => stringOperation(op, value)},
     {"name": "stringContainOpValue", "symbols": ["equalityOperator", "stringValue"], "postprocess": ([op, value]) => stringContainOperation(op, value)},
     {"name": "stringExactOpValue", "symbols": ["equalityOperator", "stringValue"], "postprocess": ([op, value]) => equalityOperation(op, value)},

--- a/src/client/pages/FiltersPage.tsx
+++ b/src/client/pages/FiltersPage.tsx
@@ -458,7 +458,22 @@ const FiltersPage: React.FC<FiltersPageProps> = ({ loginCallback }) => (
                 rows={[
                   {
                     query: <code>tag:Signed</code>,
-                    description: 'All cards in a cube who have a tag which contains Signed, case insensitive.',
+                    description:
+                      'All cards in a cube who have a tag which contains Signed, case insensitive. eg Matches tags "Signed", "Unsigned", "Signed by", or "Redesigned"',
+                  },
+                  {
+                    query: <code>tag:Signed Blood</code>,
+                    description:
+                      'This is a combination filter of tag and name, matching all cards who have a tag containing Signed, and whose name contains Blood',
+                  },
+                  {
+                    query: <code>tag:"Signed"</code>,
+                    description: 'All cards in a cube who have a tag that exactly matches Signed, case insensitive.',
+                  },
+                  {
+                    query: <code>tag:'Counter Synergy'</code>,
+                    description:
+                      'All cards in a cube who have a tag that exactly matches "Counter Synergy", case insensitive.',
                   },
                   {
                     query: <code>tags=0</code>,


### PR DESCRIPTION
# Problem

After implementing partial matching in https://github.com/dekkerglen/CubeCobra/pull/2609 there [was feedback](https://github.com/dekkerglen/CubeCobra/pull/2609#issuecomment-2659862507) that made some scenarios worse. Such as having tags like Signed and Unsigned, and now searching for `Signed` showed both whereas before it would only show Signed.

# Solution
I choose to do `tag:word` to mean partial match and `tag:"phrase"` to be exact.

The problem with `tag=phrase` being exact is that would be ambiguous; currently the grammar does tag=number and number is a subset of string. So unless we removed the ambiguity via complicated stuff like the first character after tag= cannot be a number then any string, but then we'd have weird edge cases like `tag=1st copy` or something not being allowed.

# Testing
Added the unit tests first and then implemented the change, though ended up having to make some adjustments.

## Before

Signed partial match hits "signed" and "unsigned"
![old-signed-partial1](https://github.com/user-attachments/assets/728ee827-972c-47bd-b5e6-bcad43b107f3)

"Unsigned" matches
![old-signed-partial2](https://github.com/user-attachments/assets/11878c01-04e3-497c-ad93-c38c1ed8ccde)

To only see "Signed" have to use multiple filters
![old-signed-partial3](https://github.com/user-attachments/assets/585faf18-6007-4645-835e-16e152493fca)

## After

Partial matching examples:
![new-tag-partial-matching](https://github.com/user-attachments/assets/a606926c-4c30-4e74-8ec0-f94881d387ae)
![new-tag-partial-matching2](https://github.com/user-attachments/assets/a8e3e193-d183-4d98-9d90-9ffe63d5e789)
![new-tag-partial-matching3](https://github.com/user-attachments/assets/d5bea6e9-c415-43ed-8c5e-48d4b095e324)
![new-tag-partial-matching4](https://github.com/user-attachments/assets/40bac656-0e79-4a13-b6ae-f55e92ed8d04)

Partial plus name match:
![new-tag-partial-matching-multiple-words](https://github.com/user-attachments/assets/1ae53a20-98b4-4b29-af07-dc540df845a2)

Exact matching examples:

![new-tag-exact-matching](https://github.com/user-attachments/assets/fd25395b-a2d7-44df-97ea-88cacd100569)
![new-tag-exact-matching2](https://github.com/user-attachments/assets/844a0ee5-fa65-434d-9b2c-86727b1f3283)
![new-tag-exact-matching3](https://github.com/user-attachments/assets/75fd2fc1-6c8d-4b9f-8e74-73b36fbe9fdb)
![new-tag-exact-matching4](https://github.com/user-attachments/assets/2a6f04e6-b27c-4487-90da-4a18fed5afb7)

Updated tag filter examples:
![new-tag-filter-descriptions](https://github.com/user-attachments/assets/52e5d298-53f1-4b6b-94e4-d17277a7996c)



