### PR TITLE
Update Tile component to use anchor instead of onClick so browser's normal ctrl/cmd click behaviour opens the cube in a new tab.

### DIFF
--- a/src/client/components/base/Tile.tsx
+++ b/src/client/components/base/Tile.tsx
@@ -12,10 +12,8 @@ interface TileProps {
 
 const Tile: React.FC<TileProps> = ({ className, children, href }) => {
   return (
-    <div
-      onClick={() => {
-        window.location.href = href;
-      }}
+    <a
+      href={href}
       className={classNames(
         'block bg-bg-accent shadow overflow-hidden border border-border',
         'hover:bg-bg-active cursor-pointer hover:border-border-active',
@@ -23,7 +21,7 @@ const Tile: React.FC<TileProps> = ({ className, children, href }) => {
       )}
     >
       <AspectRatioBox ratio={1}>{children}</AspectRatioBox>
-    </div>
+    </a>
   );
 };
 


### PR DESCRIPTION
# Testing

## After

Opening from dashboard or profile, using ctrl (Chrome and Firefox shown, also tested edge). It also works holding windows key (though that also opens the start menu so not advised)
![new-tile-component-ctrl-click-opens-new-window](https://github.com/user-attachments/assets/c46d5fc0-e55d-4316-bca7-638c52e7cce6)
![new-tile-component-ctrl-click-opens-new-tab2](https://github.com/user-attachments/assets/f270e659-4a4b-4646-bb9d-4149b8ea5bbc)
Regular clicking unaffected
