### PR TITLE
create pendingPick state and allow users to load a pick while the bot…

### DIFF
--- a/src/client/components/Pack.tsx
+++ b/src/client/components/Pack.tsx
@@ -51,13 +51,13 @@ const Pack: React.FC<PackProps> = ({
             {retryInProgress ? 'Retrying...' : 'Bot picks failed. Try again?'}
           </Button>
         ) : (
-          ratings &&
-          ratings.length > 0 &&
-          !showRatings && (
-            <Button onClick={() => setShowRatings(true)} color="primary">
-              Show CubeCobra Bot Ratings
-            </Button>
-          )
+          <Button
+            className={ratings && ratings.length > 0 && !showRatings ? '' : 'invisible'}
+            onClick={() => setShowRatings(true)}
+            color="primary"
+          >
+            Show CubeCobra Bot Ratings
+          </Button>
         )}
       </CardHeader>
       <CardBody>

--- a/src/client/components/Pack.tsx
+++ b/src/client/components/Pack.tsx
@@ -26,7 +26,6 @@ interface PackProps {
 const Pack: React.FC<PackProps> = ({
   pack = [],
   loading = false,
-  loadingPredictions = false,
   title = 'Pack',
   disabled = false,
   ratings,
@@ -50,10 +49,6 @@ const Pack: React.FC<PackProps> = ({
         {error ? (
           <Button onClick={onRetry} color="danger" disabled={retryInProgress}>
             {retryInProgress ? 'Retrying...' : 'Bot picks failed. Try again?'}
-          </Button>
-        ) : loadingPredictions ? (
-          <Button color="secondary" disabled>
-            Making Bot Picks...
           </Button>
         ) : (
           ratings &&

--- a/src/client/pages/CubeDraftPage.tsx
+++ b/src/client/pages/CubeDraftPage.tsx
@@ -332,9 +332,9 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
       if (nextStep.action === 'endpack') {
         // we open the next pack or end the draft
         if (draft.InitialState && state.pack === draft.InitialState[0].length) {
+          setDraftStatus((prev) => ({ ...prev, loading: false }));
           newState.seats[0].picks = picks;
           setState(newState);
-          setDraftStatus((prev) => ({ ...prev, loading: false }));
 
           // Now attempt to end the draft
           await endDraft();

--- a/src/client/pages/CubeDraftPage.tsx
+++ b/src/client/pages/CubeDraftPage.tsx
@@ -547,7 +547,7 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
       if (target.type === locations.pack) {
         return;
       }
-      //Dragged a card from the pack to the deck or sideboard (the latter is off)
+      //Dragged a card from the pack to the deck or sideboard
       if (source.type === locations.pack) {
         if (target.type === locations.deck || target.type === locations.sideboard) {
           dragCardPick(source, target);

--- a/src/client/pages/CubeDraftPage.tsx
+++ b/src/client/pages/CubeDraftPage.tsx
@@ -3,7 +3,8 @@ import React, { useCallback, useContext, useEffect, useMemo, useState } from 're
 import { DndContext } from '@dnd-kit/core';
 import type { State } from 'src/router/routes/draft/finish.ts';
 
-import { Card } from 'components/base/Card';
+import { Card, CardBody, CardHeader } from 'components/base/Card';
+import Text from 'components/base/Text';
 import DeckStacks from 'components/DeckStacks';
 import Pack from 'components/Pack';
 import RenderToRoot from 'components/RenderToRoot';
@@ -31,6 +32,13 @@ interface PredictResponse {
     oracle: string;
     rating: number;
   }[][];
+}
+
+interface DraftStatus {
+  loading: boolean;
+  predictionsLoading: boolean;
+  predictError: boolean;
+  retryInProgress: boolean;
 }
 
 interface BatchPredictRequest {
@@ -84,13 +92,6 @@ const getInitialState = (draft: Draft): State => {
   };
 };
 
-interface DraftStatus {
-  loading: boolean;
-  predictionsLoading: boolean;
-  predictError: boolean;
-  retryInProgress: boolean;
-}
-
 const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallback }) => {
   // Draft State
   // These reflect the current state of the draft objects, including the cards in the pack, the picks made, and the ratings for each card.
@@ -99,6 +100,9 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
   const [sideboard, setSideboard] = useLocalStorage(`sideboard-${draft.id}`, setupPicks(1, 8));
   const [ratings, setRatings] = useState<number[]>([]);
   const [currentPredictions, setCurrentPredictions] = useState<PredictResponse | null>(null);
+
+  // Add state to track the pending pick made during predictionsLoading
+  const [pendingPick, setPendingPick] = useState<number | null>(null);
 
   // Draft Status
   // These are used to track the status of the draft itself, including loading, errors, etc.
@@ -206,23 +210,17 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
   }, [state, draft.cards, getPredictions, draftStatus.retryInProgress, setDraftStatus]);
 
   const makePick = useCallback(
-    async (index: number, location: location, row: number, col: number) => {
-      if (draftStatus.predictError || draftStatus.loading || draftStatus.predictionsLoading) {
-        return;
-      }
-
+    async (index: number, location: location) => {
       setDraftStatus((prev) => ({ ...prev, loading: true }));
       setRatings([]); // Clear ratings
       const newState = { ...state };
-
-      // look at the current step
       const currentStep = newState.stepQueue[0];
+      // User picks are combination of mainboard and sideboard.
+      const picks = location === locations.deck ? [...mainboard.flat(2), ...sideboard.flat(2)] : [];
 
-      //The board only changes when there is a pick (human or auto) action
       if (currentStep.action.includes('pick')) {
-        const { board, setter } = getLocationReferences(location);
-        board[row][col].push(state.seats[0].pack[index]);
-        setter(board);
+        // Most recent pick is already in this data at this point
+        newState.seats[0].picks = picks;
       }
 
       // if amount is more than 1
@@ -334,6 +332,7 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
       if (nextStep.action === 'endpack') {
         // we open the next pack or end the draft
         if (draft.InitialState && state.pack === draft.InitialState[0].length) {
+          newState.seats[0].picks = picks;
           setState(newState);
           setDraftStatus((prev) => ({ ...prev, loading: false }));
 
@@ -376,30 +375,64 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
       setDraftStatus((prev) => ({ ...prev, loading: false }));
     },
     [
-      draftStatus.predictError,
-      draftStatus.loading,
-      draftStatus.predictionsLoading,
       state,
       setState,
-      getLocationReferences,
       currentPredictions,
       draft.cards,
       draft.seats.length,
       draft.InitialState,
       endDraft,
       getPredictions,
+      mainboard,
+      sideboard,
     ],
   );
 
-  const selectCardByIndex = useCallback(
-    (packIndex: number) => {
-      const cardIndex = state.seats[0].pack[packIndex];
-      const card = draft.cards[cardIndex];
+  const mainboardCards = mainboard.map((row) => row.map((col) => col.map((index) => draft.cards[index])));
+  const sideboardCards = sideboard.map((row) => row.map((col) => col.map((index) => draft.cards[index])));
 
-      const { row, col } = getCardDefaultRowColumn(card);
-      makePick(packIndex, locations.deck, row, col);
+  // Function to handle initial drag, sets in the right place and sets it as pending if necessary
+  const dragCardPick = useCallback(
+    (source: DraftLocation, target: DraftLocation) => {
+      if (pendingPick !== null) return;
+
+      if (source.index < 0 || source.index >= state.seats[0].pack.length) return;
+
+      const cardIndex = state.seats[0].pack[source.index];
+      if (cardIndex === undefined || !draft.cards[cardIndex]) return;
+
+      // Update the board immediately
+      if (draftStatus.predictionsLoading) {
+        setPendingPick(source.index);
+
+        const setter = target.type === locations.deck ? setMainboard : setSideboard;
+        setter((prev) => {
+          const newBoard = prev.map((r) => r.map((c) => [...c]));
+          newBoard[target.row][target.col].push(cardIndex);
+          return newBoard;
+        });
+      } else {
+        const setter = target.type === locations.deck ? setMainboard : setSideboard;
+        setter((prev) => {
+          const newBoard = prev.map((r) => r.map((c) => [...c]));
+          newBoard[target.row][target.col].push(cardIndex);
+          return newBoard;
+        });
+
+        // Make the actual pick after the board update
+        makePick(source.index, target.type);
+      }
     },
-    [state.seats, draft.cards, makePick],
+    [
+      draftStatus.predictionsLoading,
+      draft.cards,
+      makePick,
+      pendingPick,
+      setPendingPick,
+      setMainboard,
+      setSideboard,
+      state.seats,
+    ],
   );
 
   const moveCardBetweenDeckStacks = useCallback(
@@ -419,6 +452,45 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
       }
     },
     [getLocationReferences],
+  );
+
+  // Clicking on a card in the pack adds it to mainboard and sets it as pending pick if necessary
+  const selectCardByIndex = useCallback(
+    (packIndex: number) => {
+      if (packIndex < 0 || packIndex >= state.seats[0].pack.length) {
+        return;
+      }
+
+      const cardIndex = state.seats[0].pack[packIndex];
+      if (cardIndex === undefined) {
+        return;
+      }
+
+      const card = draft.cards[cardIndex];
+      if (!card) {
+        return;
+      }
+
+      const { row, col } = getCardDefaultRowColumn(card);
+
+      if (draftStatus.predictionsLoading) {
+        setMainboard((prev) => {
+          const newBoard = prev.map((r) => r.map((c) => [...c]));
+          newBoard[row][col].push(cardIndex);
+          return newBoard;
+        });
+        setPendingPick(packIndex);
+      } else {
+        setMainboard((prev) => {
+          const newBoard = prev.map((r) => r.map((c) => [...c]));
+          newBoard[row][col].push(cardIndex);
+          return newBoard;
+        });
+
+        makePick(packIndex, locations.deck);
+      }
+    },
+    [state.seats, draft.cards, makePick, draftStatus.predictionsLoading, setMainboard, setPendingPick],
   );
 
   /*
@@ -450,11 +522,8 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
   const onMoveCard = useCallback(
     async (event: any) => {
       const { active, over } = event;
-
       //If drag and drop ends without a collision, eg outside the drag/drop area, do nothing
-      if (!over) {
-        return;
-      }
+      if (!over) return;
 
       const source = active.data.current as DraftLocation;
       const target = over.data.current as DraftLocation;
@@ -462,10 +531,11 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
       if (source.equals(target) && source.type === locations.pack) {
         // player dropped card back in the same location
         const dragTime = Date.now() - (dragStartTime ?? 0);
-
         if (dragTime < 200) {
+          // Click on card
           return selectCardByIndex(source.index);
         }
+        return;
       } else if (source.equals(target) && (source.type === locations.deck || source.type === locations.sideboard)) {
         //Clicking a card within the deck or sideboard should move it from one to the other
         applyCardClickOnDeckStack(source);
@@ -477,21 +547,43 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
       if (target.type === locations.pack) {
         return;
       }
-
+      //Dragged a card from the pack to the deck or sideboard (the latter is off)
       if (source.type === locations.pack) {
-        //Dragged a card from the pack to the deck or sideboard (the latter is off)
         if (target.type === locations.deck || target.type === locations.sideboard) {
-          makePick(source.index, target.type, target.row, target.col);
+          dragCardPick(source, target);
+          return;
         }
-
-        return;
       }
-
       //Otherwise the drag had nothing to do with the pack
       moveCardBetweenDeckStacks(source, target);
     },
-    [applyCardClickOnDeckStack, dragStartTime, makePick, moveCardBetweenDeckStacks, selectCardByIndex],
+    [applyCardClickOnDeckStack, dragStartTime, moveCardBetweenDeckStacks, selectCardByIndex, dragCardPick],
   );
+
+  // Converts pendingPicks into real picks when we're ready
+  useEffect(() => {
+    if (!draftStatus.predictionsLoading && pendingPick !== null) {
+      const packIndex = pendingPick;
+      // Clear pendingPick immediately to prevent race conditions
+      setPendingPick(null);
+
+      // Some checks to verify that the pending pick is still valid
+      if (packIndex < 0 || packIndex >= state.seats[0].pack.length) {
+        return;
+      }
+
+      const cardIndex = state.seats[0].pack[packIndex];
+      if (cardIndex === undefined) {
+        return;
+      }
+
+      if (!draft.cards[cardIndex]) {
+        return;
+      }
+
+      makePick(packIndex, locations.deck);
+    }
+  }, [draftStatus.predictionsLoading, pendingPick, makePick, state.seats, draft.cards, setPendingPick]);
 
   // this is the auto-pick logic
   useEffect(() => {
@@ -510,6 +602,7 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
   }, [selectCardByIndex, draftStatus.loading, state.stepQueue, state.seats]);
 
   // P1P1 ratings fetch necessary, the rest come via makePick
+  // InitialRatings could eventually come along with the initial state, would require some refactoring
   useEffect(() => {
     const fetchInitialRatings = async () => {
       if (state?.seats?.[0]?.pack?.length > 0) {
@@ -554,11 +647,11 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
     }
   }, [state, draftStatus.loading]);
 
-  const disabled =
+  const packDisabled =
     state.stepQueue[0].action === 'pickrandom' ||
     state.stepQueue[0].action === 'trashrandom' ||
     draftStatus.predictError ||
-    draftStatus.predictionsLoading;
+    pendingPick !== null;
 
   return (
     <MainLayout loginCallback={loginCallback}>
@@ -568,36 +661,45 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
             <div className="relative">
               {/* Only show the pack if there are actually cards to show */}
               {state?.seats?.[0]?.pack?.length > 0 ? (
-                <Pack
-                  pack={state.seats[0].pack.map((index) => draft.cards[index])}
-                  loading={draftStatus.loading}
-                  loadingPredictions={draftStatus.predictionsLoading}
-                  title={packTitle}
-                  disabled={disabled || draftStatus.predictError || draftStatus.retryInProgress}
-                  ratings={ratings}
-                  error={draftStatus.predictError}
-                  onRetry={handleRetryPredict}
-                  retryInProgress={draftStatus.retryInProgress}
-                />
+                draftStatus.predictionsLoading && pendingPick !== null ? (
+                  <Card className="mt-3">
+                    <CardHeader className="flex justify-between items-center">
+                      <Text semibold lg>
+                        Waiting for Bot Picks...
+                      </Text>
+                    </CardHeader>
+                    <CardBody>
+                      <div className="centered py-3">
+                        <div className="spinner" />
+                      </div>
+                    </CardBody>
+                  </Card>
+                ) : (
+                  <Pack
+                    // Just use state.seats[0].pack directly
+                    pack={state.seats[0].pack.map((index) => draft.cards[index])}
+                    loading={draftStatus.loading}
+                    title={packTitle}
+                    disabled={packDisabled || draftStatus.retryInProgress}
+                    ratings={ratings}
+                    error={draftStatus.predictError}
+                    onRetry={handleRetryPredict}
+                    retryInProgress={draftStatus.retryInProgress}
+                  />
+                )
               ) : (
                 <></>
               )}
               <Card className="my-3">
                 <DeckStacks
-                  cards={mainboard.map((row) => row.map((col) => col.map((index) => draft.cards[index])))}
+                  cards={mainboardCards}
                   title="Mainboard"
                   subtitle={makeSubtitle(mainboard.flat(3).map((index) => draft.cards[index]))}
                   locationType={locations.deck}
                   xs={4}
                   lg={8}
                 />
-                <DeckStacks
-                  cards={sideboard.map((row) => row.map((col) => col.map((index) => draft.cards[index])))}
-                  title="Sideboard"
-                  locationType={locations.sideboard}
-                  xs={4}
-                  lg={8}
-                />
+                <DeckStacks cards={sideboardCards} title="Sideboard" locationType={locations.sideboard} xs={4} lg={8} />
               </Card>
             </div>
           </DndContext>

--- a/src/client/utils/cardutil.ts
+++ b/src/client/utils/cardutil.ts
@@ -197,7 +197,10 @@ export const cardCmc = (card: Card): number => {
 
 export const cardId = (card: Card): string => card.cardID ?? card.details?.scryfall_id;
 
-export const cardType = (card: Partial<Card>): string => card.type_line ?? card.details?.type ?? '';
+export const cardType = (card: Partial<Card>): string => {
+  if (!card) return ''; // Defensive check for undefined card
+  return card.type_line ?? card.details?.type ?? '';
+};
 
 export const cardRarity = (card: Card): string => card.rarity ?? card.details?.rarity ?? '';
 


### PR DESCRIPTION
This PR updates the previous draft changes to enhance UX consistency and performance.  

## Key Changes  

- **Introduces `pendingPick` Concept in the code**
  - Allows users to make picks before bots complete their pick cycle.  
  - Pending picks are stored in state, and a `useEffect` converts them into real picks once the bot call resolves.  
  - This immediately triggers the next `fetchBatchPredict` call.  

- **UI Adjustments**  
  - Replaces the grey "Waiting for Bot Picks" button with *"Waiting for Bot Picks…"* in the top left to match the *"Waiting for next pack…"* pattern.  

- **Simplified State Management**  
  - Removed the lingering board mutation from `makePick` to simplify logic.  
  - The *mainboard/sideboard* state is now only affected by `onMoveCard`, while draft state changes occur inside `makePick`.  
  - (`makePick` might be better named something like `moveDraftForward`?)  

With these changes, users can once again pick as soon as cards appear on screen while still benefiting from the speed improvements and draft state consistency introduced in prior updates.  

## TODOs  

- Further UI improvements.  
- Start refactoring `CubeDraftPage` for style and readability once logic changes are verified.  
- Fix a bug from the last PR related to a custom draft pack ending with a "pass" step. This likely requires an additional line of logic in `makePick`.  