### PR TITLE
UX improvements for large modals. Scrollable bodies so that buttons can live in the footer and always be visible

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,21 @@
+# Testing
+
+## Frontend testing
+
+When it comes to manually testing Frontend components, the key areas of focus are:
+
+1. Test in both Desktop and Mobile browsers (browser dev tools helps a lot here). Doubly important when the UI contains any responsive aspects
+2. Test in multiple modern browsers (both desktop and mobile)
+3. Compare and contrast (with screenshots/videos) the before and after UI differences to include in the PR
+
+### Accessibility
+
+It would also be ideal to test with accessibility in mind such as keyboard navigation, though CubeCobra doesn't have standards for that at this time.
+
+One easy accessibility aspect to keep in mind when dealing with foreground text vs background colors, and ensuring there is enough contrast. A tool such as the [Web Accessibility in Mind constrast checker](https://webaim.org/resources/contrastchecker/) makes it easy to validate the foreground/background colors meet at least the AA standard.
+
+## Unit tests
+
+Unit tests are written via Jest. See [Tests Readme](../tests/README.md) for more details about how the Unit tests are organized.
+
+In the ideal world business logic within frontend Components (eg .tsx files) would be separated from the UI components themselves, for separation of concerns and easier focus of unit testing each part.

--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -1092,6 +1092,10 @@ video {
   height: 1.5rem;
 }
 
+.h-\[calc\(100vh-2rem\)\] {
+  height: calc(100vh - 2rem);
+}
+
 .h-full {
   height: 100%;
 }
@@ -1202,6 +1206,10 @@ video {
 
 .max-w-screen-xl {
   max-width: 1280px;
+}
+
+.flex-1 {
+  flex: 1 1 0%;
 }
 
 .flex-shrink {

--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -2769,6 +2769,10 @@ img.mana-symbol-sm {
   display: inline-block;
 }
 
+.max-h-1\/2 {
+  max-height: 50vh;
+}
+
 @media (min-width: 640px) {
   .sm\:container {
     width: 100%;

--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -3399,6 +3399,14 @@ img.mana-symbol-sm {
     grid-template-columns: repeat(9, minmax(0, 1fr));
   }
 
+  .md\:flex-nowrap {
+    flex-wrap: nowrap;
+  }
+
+  .md\:justify-start {
+    justify-content: flex-start;
+  }
+
   .md\:px-4 {
     padding-left: 1rem;
     padding-right: 1rem;

--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -3198,6 +3198,10 @@ img.mana-symbol-sm {
     display: block;
   }
 
+  .sm\:flex {
+    display: flex;
+  }
+
   .sm\:hidden {
     display: none;
   }
@@ -3269,6 +3273,14 @@ img.mana-symbol-sm {
 
   .sm\:grid-cols-9 {
     grid-template-columns: repeat(9, minmax(0, 1fr));
+  }
+
+  .sm\:flex-row {
+    flex-direction: row;
+  }
+
+  .sm\:gap-2 {
+    gap: 0.5rem;
   }
 
   .sm\:text-sm {

--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -1092,10 +1092,6 @@ video {
   height: 1.5rem;
 }
 
-.h-\[calc\(100vh-2rem\)\] {
-  height: calc(100vh - 2rem);
-}
-
 .h-full {
   height: 100%;
 }
@@ -2771,6 +2767,10 @@ img.mana-symbol-sm {
 
 .max-h-1\/2 {
   max-height: 50vh;
+}
+
+.max-h-95\/100 {
+  max-height: 95vh;
 }
 
 @media (min-width: 640px) {

--- a/src/client/components/ColorCheck.tsx
+++ b/src/client/components/ColorCheck.tsx
@@ -110,7 +110,14 @@ export const ColorChecksAddon: React.FC<ColorChecksAddonProps> = ({
   return (
     <div className="block w-full">
       {label && <label className="block text-sm font-medium text-text">{label}</label>}
-      <Flexbox direction="row" gap="1">
+      <Flexbox
+        direction="row"
+        gap="1"
+        wrap={'wrap'}
+        alignItems={'center'}
+        //flex-wrap / center for mobile which results in the colors showing in 2 rows, no wrapping / start for larger
+        className="justify-center md:justify-start flex-wrap md:flex-nowrap"
+      >
         {colors.map(([color, short]) => (
           <ColorCheckButton
             key={short}

--- a/src/client/components/GroupModal.tsx
+++ b/src/client/components/GroupModal.tsx
@@ -328,15 +328,13 @@ const GroupModal: React.FC<GroupModalProps> = ({
           </Col>
         </Row>
       </ModalBody>
-      <ModalFooter>
+      <ModalFooter className="grid grid-cols-2 gap-2 sm:flex sm:flex-row sm:gap-2">
         <Button block color="primary" disabled={!fieldsChanged} onClick={applyChanges}>
           Apply all
         </Button>
-        &nbsp;
         <Button block color="danger" onClick={removeAll}>
           Remove all
         </Button>
-        &nbsp;
         <Button
           color="accent"
           block
@@ -347,7 +345,6 @@ const GroupModal: React.FC<GroupModalProps> = ({
         >
           All to Maybeboard
         </Button>
-        &nbsp;
         <Button
           color="accent"
           block
@@ -358,13 +355,11 @@ const GroupModal: React.FC<GroupModalProps> = ({
         >
           All to Mainboard
         </Button>
-        &nbsp;
         {anyCardRemoved && (
           <>
             <Button block color="primary" onClick={revertRemoval}>
               Revert removal
             </Button>
-            &nbsp;
           </>
         )}
         {anyCardChanged && (
@@ -372,7 +367,6 @@ const GroupModal: React.FC<GroupModalProps> = ({
             <Button block color="primary" onClick={bulkRevertEditAll}>
               Revert edits
             </Button>
-            &nbsp;
           </>
         )}
       </ModalFooter>

--- a/src/client/components/GroupModal.tsx
+++ b/src/client/components/GroupModal.tsx
@@ -204,7 +204,7 @@ const GroupModal: React.FC<GroupModalProps> = ({
         <Row>
           <Col xs={6}>
             <Flexbox direction="col" gap="2">
-              <div className="overflow-y-auto">
+              <div className="overflow-y-auto max-h-1/2">
                 <ListGroup>
                   {cards.map((card, index) => (
                     <AutocardListItem

--- a/src/client/components/GroupModal.tsx
+++ b/src/client/components/GroupModal.tsx
@@ -14,7 +14,7 @@ import Input from './base/Input';
 import { Col, Flexbox, Row } from './base/Layout';
 import Link from './base/Link';
 import { ListGroup } from './base/ListGroup';
-import { Modal, ModalBody, ModalHeader } from './base/Modal';
+import { Modal, ModalBody, ModalFooter, ModalHeader } from './base/Modal';
 import RadioButtonGroup from './base/RadioButtonGroup';
 import Select from './base/Select';
 import Text from './base/Text';
@@ -198,9 +198,9 @@ const GroupModal: React.FC<GroupModalProps> = ({
   const totalPriceTix = cards.length ? cards.reduce((total, card) => total + (cardTix(card) ?? 0), 0) : 0;
 
   return (
-    <Modal lg isOpen={isOpen} setOpen={setOpen}>
+    <Modal lg isOpen={isOpen} setOpen={setOpen} scrollable>
       <ModalHeader setOpen={setOpen}>Edit Selected ({cards.length} cards)</ModalHeader>
-      <ModalBody>
+      <ModalBody scrollable>
         <Row>
           <Col xs={6}>
             <Flexbox direction="col" gap="2">
@@ -324,46 +324,58 @@ const GroupModal: React.FC<GroupModalProps> = ({
                 tagColors={tagColors}
                 suggestions={allTags}
               />
-              <Button block color="primary" disabled={!fieldsChanged} onClick={applyChanges}>
-                Apply to all
-              </Button>
-              <Button block color="danger" onClick={removeAll}>
-                Remove all from cube
-              </Button>
-              <Button
-                color="accent"
-                block
-                onClick={() => {
-                  bulkMoveCard(cardsWithBoardAndIndex(cards), 'maybeboard');
-                  setOpen(false);
-                }}
-              >
-                Move all to Maybeboard
-              </Button>
-              <Button
-                color="accent"
-                block
-                onClick={() => {
-                  bulkMoveCard(cardsWithBoardAndIndex(cards), 'mainboard');
-                  setOpen(false);
-                }}
-              >
-                Move all to Mainboard
-              </Button>
-              {anyCardRemoved && (
-                <Button block color="primary" onClick={revertRemoval}>
-                  Revert removal of removed cards
-                </Button>
-              )}
-              {anyCardChanged && (
-                <Button block color="primary" onClick={bulkRevertEditAll}>
-                  Revert changes of edited cards
-                </Button>
-              )}
             </Flexbox>
           </Col>
         </Row>
       </ModalBody>
+      <ModalFooter>
+        <Button block color="primary" disabled={!fieldsChanged} onClick={applyChanges}>
+          Apply all
+        </Button>
+        &nbsp;
+        <Button block color="danger" onClick={removeAll}>
+          Remove all
+        </Button>
+        &nbsp;
+        <Button
+          color="accent"
+          block
+          onClick={() => {
+            bulkMoveCard(cardsWithBoardAndIndex(cards), 'maybeboard');
+            setOpen(false);
+          }}
+        >
+          All to Maybeboard
+        </Button>
+        &nbsp;
+        <Button
+          color="accent"
+          block
+          onClick={() => {
+            bulkMoveCard(cardsWithBoardAndIndex(cards), 'mainboard');
+            setOpen(false);
+          }}
+        >
+          All to Mainboard
+        </Button>
+        &nbsp;
+        {anyCardRemoved && (
+          <>
+            <Button block color="primary" onClick={revertRemoval}>
+              Revert removal
+            </Button>
+            &nbsp;
+          </>
+        )}
+        {anyCardChanged && (
+          <>
+            <Button block color="primary" onClick={bulkRevertEditAll}>
+              Revert edits
+            </Button>
+            &nbsp;
+          </>
+        )}
+      </ModalFooter>
     </Modal>
   );
 };

--- a/src/client/components/GroupModal.tsx
+++ b/src/client/components/GroupModal.tsx
@@ -204,7 +204,7 @@ const GroupModal: React.FC<GroupModalProps> = ({
         <Row>
           <Col xs={6}>
             <Flexbox direction="col" gap="2">
-              <div className="overflow-y-auto max-h-1/2">
+              <div className="overflow-y-auto max-h-1/2 border border-border-secondary rounded-md">
                 <ListGroup>
                   {cards.map((card, index) => (
                     <AutocardListItem

--- a/src/client/components/base/CardList.tsx
+++ b/src/client/components/base/CardList.tsx
@@ -18,19 +18,21 @@ interface CardListProps {
 const CardList: React.FC<CardListProps> = ({ cards }) => {
   return (
     <Flexbox direction="col" className="border border-border-secondary rounded-md">
-      {cards.map((card, index) => (
-        <AutocardItem
-          key={cardId(card)}
-          card={card}
-          className={classNames(`bg-card-${getCardColorClass(card)}`, 'px-2 py-0.5 truncate text-sm', {
-            'rounded-t-md': index === 0,
-            'rounded-b-md': index === cards.length - 1,
-            'border-t border-border-secondary': index !== 0,
-          })}
-        >
-          {cardName(card)}
-        </AutocardItem>
-      ))}
+      <div className="overflow-y-auto max-h-1/2">
+        {cards.map((card, index) => (
+          <AutocardItem
+            key={cardId(card)}
+            card={card}
+            className={classNames(`bg-card-${getCardColorClass(card)}`, 'px-2 py-0.5 truncate text-sm', {
+              'rounded-t-md': index === 0,
+              'rounded-b-md': index === cards.length - 1,
+              'border-t border-border-secondary': index !== 0,
+            })}
+          >
+            {cardName(card)}
+          </AutocardItem>
+        ))}
+      </div>
     </Flexbox>
   );
 };

--- a/src/client/components/base/Modal.tsx
+++ b/src/client/components/base/Modal.tsx
@@ -72,9 +72,14 @@ interface ModalHeaderProps {
   setOpen: (open: boolean) => void;
 }
 
-export const ModalHeader: React.FC<ModalHeaderProps> = ({ children, className, setOpen }) => {
+export const ModalHeader: React.FC<ModalHeaderProps> = ({ children, className = '', setOpen }) => {
   return (
-    <div className={`bg-bg-accent-accent font-semibold text-xl p-2 flex ${className}`}>
+    <div
+      className={classNames({
+        'bg-bg-accent-accent font-semibold text-xl p-2 flex': true,
+        [className]: !!className,
+      })}
+    >
       {children}
       <button type="button" className="ml-auto" onClick={() => setOpen(false)}>
         <XIcon size={24} />

--- a/src/client/components/base/Modal.tsx
+++ b/src/client/components/base/Modal.tsx
@@ -14,9 +14,22 @@ interface ModalProps {
   lg?: boolean;
   xl?: boolean;
   xxl?: boolean;
+  //If you set scrollable on the modal also set it on the ModalBody
+  scrollable?: boolean;
 }
 
-export const Modal: React.FC<ModalProps> = ({ children, isOpen, setOpen, xs, sm, md, lg, xl, xxl }) => {
+export const Modal: React.FC<ModalProps> = ({
+  children,
+  isOpen,
+  setOpen,
+  xs,
+  sm,
+  md,
+  lg,
+  xl,
+  xxl,
+  scrollable = false,
+}) => {
   return (
     <Transition show={isOpen}>
       <Dialog as="div" className="relative z-30" onClose={() => setOpen(false)}>
@@ -53,7 +66,19 @@ export const Modal: React.FC<ModalProps> = ({ children, isOpen, setOpen, xs, sm,
                 leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
               >
                 <div className="p-4 pb-20">
-                  <DialogPanel className="relative transform rounded-md border border-border bg-bg-accent text-left text-text shadow-xl transition-all w-full flex flex-col max-h-modal">
+                  <DialogPanel
+                    className={classNames(
+                      'relative transform rounded-md border border-border bg-bg-accent text-left text-text shadow-xl transition-all w-full flex flex-col',
+                      {
+                        /* To be scrollable the modal must have a fixed height, and here we make it the whole viewport (minus some margin basically)
+                         * 100vh is 100% of view port height (vh). Subtract 2rem gives about the same gap from bottom as from top of modal
+                         */
+                        'overflow-hidden h-[calc(100vh-2rem)]': scrollable,
+                        //If not scrollable, the contents of the modal define its height
+                        'max-h-modal': !scrollable,
+                      },
+                    )}
+                  >
                     {children}
                   </DialogPanel>
                 </div>
@@ -101,14 +126,24 @@ interface ModalBodyProps {
   children: React.ReactNode;
   className?: string;
   fixed?: boolean;
+  //If you set scrollable on the modal also set it on the Modal
+  scrollable?: boolean;
 }
 
-export const ModalBody: React.FC<ModalBodyProps> = ({ children, className = '', fixed = false }) => {
+export const ModalBody: React.FC<ModalBodyProps> = ({
+  children,
+  className = '',
+  fixed = false,
+  scrollable = false,
+}) => {
   return (
     <div
       className={classNames({
         'p-3': true,
-        'grow border-y border-border': !fixed,
+        'border-y border-border': !fixed,
+        //Sets the body to overflow so it can scroll, with flex so it grows
+        'flex-1 overflow-y-auto': scrollable,
+        grow: !scrollable,
         [className]: !!className,
       })}
     >

--- a/src/client/components/base/Modal.tsx
+++ b/src/client/components/base/Modal.tsx
@@ -70,12 +70,10 @@ export const Modal: React.FC<ModalProps> = ({
                     className={classNames(
                       'relative transform rounded-md border border-border bg-bg-accent text-left text-text shadow-xl transition-all w-full flex flex-col',
                       {
-                        /* To be scrollable the modal must have a fixed height, and here we make it the whole viewport (minus some margin basically)
-                         * 100vh is 100% of view port height (vh). Subtract 2rem gives about the same gap from bottom as from top of modal
+                        /* To be scrollable the modal must have a maximum height, and here we make it the whole viewport (minus some margin basically)
+                         * 95% of the view port height (vh units) works well for both desktop and mobile
                          */
-                        'overflow-hidden h-[calc(100vh-2rem)]': scrollable,
-                        //If not scrollable, the contents of the modal define its height
-                        'max-h-modal': !scrollable,
+                        'overflow-hidden max-h-95/100': scrollable,
                       },
                     )}
                   >

--- a/src/client/components/card/CardModal.tsx
+++ b/src/client/components/card/CardModal.tsx
@@ -39,7 +39,7 @@ import Badge from '../base/Badge';
 import Button from '../base/Button';
 import Input from '../base/Input';
 import { Col, Flexbox, Row } from '../base/Layout';
-import { Modal, ModalBody, ModalHeader } from '../base/Modal';
+import { Modal, ModalBody, ModalFooter, ModalHeader } from '../base/Modal';
 import Select from '../base/Select';
 import Spinner from '../base/Spinner';
 import Tag from '../base/Tag';
@@ -142,12 +142,22 @@ const CardModal: React.FC<CardModalProps> = ({
   );
 
   return (
-    <Modal lg isOpen={isOpen} setOpen={setOpen}>
+    <Modal lg isOpen={isOpen} setOpen={setOpen} scrollable>
       <ModalHeader setOpen={setOpen}>
-        {cardName(card)} {card.markedForDelete && <Badge color="danger">Marked for Removal</Badge>}
-        {card.editIndex !== undefined && <Badge color="warning">*Pending Edit*</Badge>}
+        {cardName(card)}
+        &nbsp;
+        {card.markedForDelete && (
+          <>
+            <Badge color="danger">Marked for Removal</Badge>&nbsp;
+          </>
+        )}
+        {card.editIndex !== undefined && (
+          <>
+            <Badge color="warning">*Pending Edit*</Badge>&nbsp;
+          </>
+        )}
       </ModalHeader>
-      <ModalBody>
+      <ModalBody scrollable>
         {versions ? (
           <Row>
             <Col xs={12} sm={6}>
@@ -376,64 +386,6 @@ const CardModal: React.FC<CardModalProps> = ({
                     ))}
                   </Flexbox>
                 )}
-                {canEdit && (
-                  <>
-                    {card.markedForDelete ? (
-                      <Button color="primary" block onClick={() => revertRemove(card.removeIndex!, card.board!)}>
-                        Revert Removal
-                      </Button>
-                    ) : (
-                      <>
-                        <Button
-                          color="danger"
-                          block
-                          onClick={() => {
-                            removeCard(card.index!, card.board!);
-                            setOpen(false);
-                          }}
-                        >
-                          Remove from cube
-                        </Button>
-                        {card.board === 'mainboard' ? (
-                          <Button
-                            color="accent"
-                            block
-                            onClick={() => {
-                              moveCard(card.index!, card.board!, 'maybeboard');
-                              setOpen(false);
-                            }}
-                          >
-                            Move to Maybeboard
-                          </Button>
-                        ) : (
-                          <Button
-                            color="accent"
-                            block
-                            onClick={() => {
-                              moveCard(card.index!, card.board!, 'mainboard');
-                              setOpen(false);
-                            }}
-                          >
-                            Move to Mainboard
-                          </Button>
-                        )}
-                      </>
-                    )}
-                    {card.editIndex !== undefined && (
-                      <Button
-                        color="primary"
-                        block
-                        onClick={() => {
-                          if (card.editIndex !== undefined && card.board !== undefined) {
-                            revertEdit(card.editIndex, card.board);
-                          }
-                        }}
-                      >
-                        Revert Edit
-                      </Button>
-                    )}
-                  </>
-                )}
               </Flexbox>
             </Col>
           </Row>
@@ -441,6 +393,89 @@ const CardModal: React.FC<CardModalProps> = ({
           <Spinner lg />
         )}
       </ModalBody>
+      <ModalFooter>
+        {canEdit && (
+          <>
+            {card.markedForDelete ? (
+              <>
+                <Button
+                  color="primary"
+                  block
+                  className="items-center text-sm"
+                  onClick={() => revertRemove(card.removeIndex!, card.board!)}
+                >
+                  Revert Removal
+                </Button>
+                &nbsp;
+              </>
+            ) : (
+              <>
+                <Button
+                  color="danger"
+                  block
+                  className="items-center text-sm"
+                  onClick={() => {
+                    removeCard(card.index!, card.board!);
+                    setOpen(false);
+                  }}
+                >
+                  Remove
+                </Button>
+                &nbsp;
+                {card.board === 'mainboard' ? (
+                  <>
+                    <Button
+                      color="accent"
+                      block
+                      className="items-center text-sm"
+                      onClick={() => {
+                        moveCard(card.index!, card.board!, 'maybeboard');
+                        setOpen(false);
+                      }}
+                    >
+                      To Maybeboard
+                    </Button>
+                    &nbsp;
+                  </>
+                ) : (
+                  <>
+                    <Button
+                      color="accent"
+                      block
+                      className="items-center text-sm"
+                      onClick={() => {
+                        moveCard(card.index!, card.board!, 'mainboard');
+                        setOpen(false);
+                      }}
+                    >
+                      To Mainboard
+                    </Button>
+                    &nbsp;
+                  </>
+                )}
+              </>
+            )}
+            {card.editIndex !== undefined && (
+              <>
+                <Button
+                  color="primary"
+                  block
+                  className="items-center text-sm"
+                  onClick={() => {
+                    if (card.editIndex !== undefined && card.board !== undefined) {
+                      revertEdit(card.editIndex, card.board);
+                    }
+                  }}
+                >
+                  Revert Edit
+                </Button>
+                &nbsp;
+              </>
+            )}
+            &nbsp;
+          </>
+        )}
+      </ModalFooter>
     </Modal>
   );
 };

--- a/src/client/components/modals/AddGroupToCubeModal.tsx
+++ b/src/client/components/modals/AddGroupToCubeModal.tsx
@@ -9,7 +9,7 @@ import Alert from '../base/Alert';
 import Button from '../base/Button';
 import CardList from '../base/CardList';
 import { Flexbox } from '../base/Layout';
-import { Modal, ModalBody, ModalFooter,ModalHeader } from '../base/Modal';
+import { Modal, ModalBody, ModalFooter, ModalHeader } from '../base/Modal';
 import Select from '../base/Select';
 import LoadingButton from '../LoadingButton';
 
@@ -59,7 +59,7 @@ const AddGroupToCubeModal: React.FC<AddGroupToCubeModalProps> = ({ cards, isOpen
       setAlerts([...alerts, { color: 'danger', message: 'Error, could not add card' }]);
     }
     setLoadingSubmit(false);
-  }, [selectedCube, cards, packid, board, alerts, setOpen]);
+  }, [csrfFetch, selectedCube, cards, packid, board, alerts, setOpen]);
 
   if (!cubes || cubes.length === 0) {
     return (

--- a/src/client/components/modals/AddToCubeModal.tsx
+++ b/src/client/components/modals/AddToCubeModal.tsx
@@ -95,9 +95,6 @@ const AddToCubeModal: React.FC<AddToCubeModalProps> = ({
                 Analytics
               </Button>
             )}
-            <Button block color="secondary" onClick={() => setOpen(false)}>
-              Close
-            </Button>
           </Flexbox>
         </ModalFooter>
       </Modal>
@@ -135,9 +132,6 @@ const AddToCubeModal: React.FC<AddToCubeModalProps> = ({
             value={selectedBoard}
             setValue={(val) => setSelectedBoard(val)}
           />
-          <LoadingButton block loading={loading} color="primary" onClick={add}>
-            Add
-          </LoadingButton>
         </Flexbox>
       </ModalBody>
       <ModalFooter>
@@ -147,9 +141,9 @@ const AddToCubeModal: React.FC<AddToCubeModalProps> = ({
               Analytics
             </Button>
           )}
-          <Button block color="secondary" onClick={() => setOpen(false)}>
-            Close
-          </Button>
+          <LoadingButton block loading={loading} color="primary" onClick={add}>
+            Add
+          </LoadingButton>
         </Flexbox>
       </ModalFooter>
     </Modal>

--- a/src/client/components/modals/AddToCubeModal.tsx
+++ b/src/client/components/modals/AddToCubeModal.tsx
@@ -75,9 +75,9 @@ const AddToCubeModal: React.FC<AddToCubeModalProps> = ({
 
   if (!cubes || cubes.length === 0) {
     return (
-      <Modal isOpen={isOpen} setOpen={setOpen} sm>
+      <Modal isOpen={isOpen} setOpen={setOpen} sm scrollable>
         <ModalHeader setOpen={setOpen}>{card.name}</ModalHeader>
-        <ModalBody className="centered">
+        <ModalBody className="centered" scrollable>
           <Flexbox direction="col" alignItems="center" gap="2">
             <ImageFallback
               className="w-full mb-3"
@@ -105,9 +105,9 @@ const AddToCubeModal: React.FC<AddToCubeModalProps> = ({
   }
 
   return (
-    <Modal isOpen={isOpen} setOpen={setOpen} sm>
+    <Modal isOpen={isOpen} setOpen={setOpen} sm scrollable>
       <ModalHeader setOpen={setOpen}>{`Add ${card.name} to Cube`}</ModalHeader>
-      <ModalBody>
+      <ModalBody scrollable>
         <Flexbox direction="col" alignItems="center" gap="2">
           {alerts.map(({ color, message }) => (
             <Alert key={message} color={color} className="mt-2">

--- a/src/client/components/modals/AdvancedFilterModal.tsx
+++ b/src/client/components/modals/AdvancedFilterModal.tsx
@@ -26,9 +26,9 @@ const AdvancedFilterModal: React.FC<AdvancedFilterModalProps> = ({ isOpen, setOp
   const cubeId = cube ? cube.id : null;
 
   return (
-    <Modal isOpen={isOpen} setOpen={setOpen} lg>
+    <Modal isOpen={isOpen} setOpen={setOpen} lg scrollable>
       <ModalHeader setOpen={setOpen}>Advanced Filters</ModalHeader>
-      <ModalBody>
+      <ModalBody scrollable>
         <Flexbox direction="col" gap="2">
           <Input
             name="name"

--- a/src/client/components/modals/CubeOverviewModal.tsx
+++ b/src/client/components/modals/CubeOverviewModal.tsx
@@ -85,13 +85,13 @@ const CubeOverviewModal: React.FC<CubeOverviewModalProps> = ({ isOpen, setOpen, 
   }, [csrfFetch, state]);
 
   return (
-    <Modal lg isOpen={isOpen} setOpen={setOpen}>
+    <Modal lg isOpen={isOpen} setOpen={setOpen} scrollable>
       <ModalHeader setOpen={setOpen}>
         <Text semibold lg>
           Edit Overview
         </Text>
       </ModalHeader>
-      <ModalBody>
+      <ModalBody scrollable>
         <Flexbox direction="col" gap="2">
           <Input
             label="Cube Name"

--- a/src/client/components/modals/CustomDraftFormatModal.tsx
+++ b/src/client/components/modals/CustomDraftFormatModal.tsx
@@ -36,13 +36,13 @@ const CustomDraftFormatModal: React.FC<CustomDraftFormatModalProps> = ({ isOpen,
   }, [format, formatIndex]);
 
   return (
-    <Modal isOpen={isOpen} setOpen={setOpen} lg>
+    <Modal isOpen={isOpen} setOpen={setOpen} lg scrollable>
       <ModalHeader setOpen={setOpen}>
         <Text lg semibold>
           Create Custom Draft Format
         </Text>
       </ModalHeader>
-      <ModalBody>
+      <ModalBody scrollable>
         <CSRFForm method="POST" action={`/cube/format/add/${cube.id}`} formData={formdata} ref={formRef}>
           <Flexbox direction="col" gap="2">
             <Input

--- a/src/client/components/modals/FollowersModal.tsx
+++ b/src/client/components/modals/FollowersModal.tsx
@@ -60,13 +60,13 @@ const FollowersModal: React.FC<FollowersModalProps> = ({ type, id, isOpen, setOp
   }, [csrfFetch, type, id, followers]);
 
   return (
-    <Modal lg isOpen={isOpen} setOpen={setOpen}>
+    <Modal lg isOpen={isOpen} setOpen={setOpen} scrollable>
       <ModalHeader setOpen={setOpen}>
         <Text semibold lg>
           Followers
         </Text>
       </ModalHeader>
-      <ModalBody>
+      <ModalBody scrollable>
         <Row className="justify-content-center">
           {followers.map((follower) => (
             <Col key={follower.id} xs={6} sm={4} lg={3}>

--- a/src/client/components/modals/TagColorsModal.tsx
+++ b/src/client/components/modals/TagColorsModal.tsx
@@ -139,9 +139,9 @@ const TagColorsModal: React.FC<TagColorsModalProps> = ({ isOpen, setOpen }) => {
   );
 
   return (
-    <Modal isOpen={isOpen} setOpen={setOpen} md>
+    <Modal isOpen={isOpen} setOpen={setOpen} md scrollable>
       <ModalHeader setOpen={setOpen}>{canEdit ? 'Set Tag Colors' : 'Tag Colors'}</ModalHeader>
-      <ModalBody>
+      <ModalBody scrollable>
         {showTagColors ? (
           <LoadingButton
             block

--- a/src/client/components/modals/TagColorsModal.tsx
+++ b/src/client/components/modals/TagColorsModal.tsx
@@ -79,6 +79,7 @@ const TagColorsModal: React.FC<TagColorsModalProps> = ({ isOpen, setOpen }) => {
       if (response.ok) {
         setTagColors(colors);
       } else {
+        // eslint-disable-next-line no-console -- Debugging
         console.error('Request failed.');
       }
       setLoading(false);

--- a/src/client/css/stylesheet.css
+++ b/src/client/css/stylesheet.css
@@ -346,3 +346,7 @@ img.mana-symbol-sm {
 .max-h-1\/2 {
   max-height: 50vh;
 }
+
+.max-h-95\/100 {
+  max-height: 95vh;
+}

--- a/src/client/css/stylesheet.css
+++ b/src/client/css/stylesheet.css
@@ -342,3 +342,7 @@ img.mana-symbol-sm {
 .markdown .text-center img.max-w-full {
 	display: inline-block;
 }
+
+.max-h-1\/2 {
+  max-height: 50vh;
+}


### PR DESCRIPTION
# High level changes

1. Add scrollable support to Modal component (Modal and ModalBody specifically)
2. Update many large models (see below) to be scrollable
3. Move the primary action buttons of the Card and (Card)GroupModals, in the Cube list space, to the modal footer so they appear while the body is scrollable
4. Make the Card lists in the GroupModal and Package modal scrollable
5. Add responsive design for Colour buttons in the Card/Group modals. Instead of being skewed, the buttons appear on 2 rows (2x3)
6. Add responsive design to the action buttons of the (Card)Group Modal, so they stack in two rows on mobile
7. Very minor fix in ModalHeader to prevent "undefined" in class names when the classNames property is unset

## Modals made scrollable

- AdvancedFilterModal
- CardModal
- CubeOverviewModal
- FollowersModal
- TagColorsModal
- AddToCubeModal (shown when clicking "Add to another cube" in CardModal)
- CustomDraftFormatModal
- GroupModal (set of cards in cube list)
- AddGroupToCubeModal

## Looking for feedback on:
1. The button text changes, too little context now?
2. On mobile the max height might be a bit long, as the footer is sometimes off the screen when I test with responsive mode via dev tools

## Modals that might make sense to be scrollable but weren't changed

- BasicsModal
- CustomizeBasicsModal
- CreatePackageModal

All of these show cards in a grid with 5 cards per row. So normally fits fine without scrolling (using the Basics modals as example) but if there were a lot of basics or a big card package, then scrolling might be nice.

# Testing
Overall test cases:
1. Desktop vs Mobile
3. Multiple browsers: Chrome, Firefox, Edge
4. With on-screen keyboards from Windows or browser extensions - **The browser extension keyboards I tested will cover up the footer of modals, but that is also true with current modals.** 
5. Checked all modals including ones that didn't change

| Modal | View type | Before | After |
|--------|--------|--------|--------|
| CardModal | Desktop | ![image](https://github.com/user-attachments/assets/40834f0b-f4ac-4280-b48a-69271d392212) | ![image](https://github.com/user-attachments/assets/bc3b66d5-5256-4ed3-89b2-2c577fd73b31) |
| CardModal | Mobile| ![image](https://github.com/user-attachments/assets/09896854-7e74-4550-905d-dcbcdfd7e893) | ![image](https://github.com/user-attachments/assets/de701171-0b2c-4dfd-a0d3-de45c6d193d0) |
| GroupModal | Desktop | ![old-desktop-group-modal](https://github.com/user-attachments/assets/d93d765d-a55d-4494-895a-6bbf84d6b50b) | ![new-desktop-group-modal2](https://github.com/user-attachments/assets/1b857abc-e958-449d-9920-696a7f780a0c) | 
| GroupModal | Mobile | ![old-mobile-group-modal](https://github.com/user-attachments/assets/456c4fd7-ecc4-4b05-9e7b-68781a1e43de) | ![new-mobile-group-modal2](https://github.com/user-attachments/assets/9d36129c-c764-44ee-b2ad-1ba1eeaba967) | 
| AdvancedFilterModal | Desktop | ![image](https://github.com/user-attachments/assets/b3acec20-5a81-47a6-9772-5614be39a768) | ![image](https://github.com/user-attachments/assets/193c98d1-9214-4103-8010-ac0f246880c9) | 
| AdvancedFilterModal | Mobile | N/A  | N/A | 
| CubeOverviewModal | Desktop | ![image](https://github.com/user-attachments/assets/fcabb9d4-1720-4fb7-b133-6230394a8bf5) | ![image](https://github.com/user-attachments/assets/2eaca101-002f-444f-9f0b-9b82c2f0a48d) | 
| CubeOverviewModal | Mobile | ![image](https://github.com/user-attachments/assets/4b3f7e93-5428-4421-829e-913f1a8e37f6) | ![image](https://github.com/user-attachments/assets/ef9ae1f7-ca7e-4546-8553-885e955ef76d) | 
| FollowersModal | Desktop | ![image](https://github.com/user-attachments/assets/27e98232-7593-47d7-a730-e55c0e0c6bdc) | ![image](https://github.com/user-attachments/assets/4a140750-523e-4f36-84ce-3cf7e44e4f98)  | 
| FollowersModal | Mobile | ![image](https://github.com/user-attachments/assets/d11457c9-6576-40cd-bba1-13f58545c2f4) | ![image](https://github.com/user-attachments/assets/f4b576ef-e512-4a55-aa88-6f6f823595a1) | 
| TagColorsModal | Desktop | ![image](https://github.com/user-attachments/assets/a1a81fe6-a419-48c0-a281-1f59413c1a6e) | ![image](https://github.com/user-attachments/assets/81248d50-fa22-47e3-9c35-2e270e92d35b) | 
| TagColorsModal | Mobile | ![old-mobile-tag-colors](https://github.com/user-attachments/assets/670bf278-bed8-4278-b0d5-dba0eaf5f035) | ![new-mobile-tag-colors](https://github.com/user-attachments/assets/3654e758-7054-4cc8-94d2-27d5199b51e5)  | 
| AddToCubeModal | Desktop | ![image](https://github.com/user-attachments/assets/048fee42-fbcd-43e7-b9c3-5255bd776fae) | ![new-desktop-add-card-to-another-cube2](https://github.com/user-attachments/assets/0b385d6b-9f33-4edb-b74d-99bd1d972cfa) | 
| AddToCubeModal | Mobile | ![image](https://github.com/user-attachments/assets/c1217fba-2587-4f62-bd57-94e0d7ce0997)  | ![new-mobile-add-card-to-another-cube2](https://github.com/user-attachments/assets/bc70dee5-ddde-40e0-9cd4-4d82dc3e89ab) | 
| CustomDraftFormatModal | Desktop | ![image](https://github.com/user-attachments/assets/659123aa-6ece-420f-a5b0-b17efb54a3b8) | ![image](https://github.com/user-attachments/assets/0446abdb-b878-4e03-a45e-902dbb462b57) | 
| CustomDraftFormatModal | Mobile | ![image](https://github.com/user-attachments/assets/7de57edc-fe8a-4706-83f0-1ffdcf086292) | ![image](https://github.com/user-attachments/assets/0a0a79b1-7003-48a3-bc82-2a162f1f3b73) | 
| AddGroupToCubeModal | Desktop | ![image](https://github.com/user-attachments/assets/4d82716c-d323-462f-9e24-50c6d5ce13be) | ![image](https://github.com/user-attachments/assets/45017083-f833-4985-9a36-ec09967532a8) |
| AddGroupToCubeModal | Mobile | ![image](https://github.com/user-attachments/assets/f7692ff9-bd70-40dc-8930-95d30c8fdd81) | ![image](https://github.com/user-attachments/assets/a8460cf1-8852-44f8-904e-99674010ce41) |