### PR TITLE
Fix delete deck modal actions redirecting to the deck

### DIFF
--- a/src/client/components/LoadingButton.tsx
+++ b/src/client/components/LoadingButton.tsx
@@ -5,24 +5,27 @@ import Spinner from './base/Spinner';
 
 interface LoadingButtonProps extends Omit<ButtonProps, 'onClick'> {
   loading?: boolean | null;
-  onClick: () => void | Promise<void>;
+  onClick: (e: React.MouseEvent) => void | Promise<void>;
 }
 
 const LoadingButton: React.FC<LoadingButtonProps> = ({ onClick, loading = null, children, ...props }) => {
   const [stateLoading, setLoading] = useState(false);
 
-  const handleClick = useCallback(async () => {
-    setLoading(true);
-    await onClick();
-    setLoading(false);
-  }, [onClick]);
+  const handleClick = useCallback(
+    async (e: React.MouseEvent) => {
+      setLoading(true);
+      await onClick(e);
+      setLoading(false);
+    },
+    [onClick],
+  );
 
   const loadingControlled = loading !== null;
   const renderLoading = loadingControlled ? loading : stateLoading;
   const renderOnClick = loadingControlled ? onClick : handleClick;
 
   return (
-    <Button {...props} onClick={() => renderOnClick()} disabled={renderLoading}>
+    <Button {...props} onClick={(e) => renderOnClick(e)} disabled={renderLoading}>
       <div className={`centered`}>{renderLoading ? <Spinner className="position-absolute" /> : children}</div>
     </Button>
   );

--- a/src/client/components/modals/ConfirmDeleteModal.tsx
+++ b/src/client/components/modals/ConfirmDeleteModal.tsx
@@ -28,10 +28,24 @@ const ConfirmDeleteModal: React.FC<ConfirmDeleteModalProps> = ({ isOpen, setOpen
       </ModalBody>
       <ModalFooter>
         <Flexbox direction="row" className="w-full justify-end" gap="2">
-          <LoadingButton block color="danger" onClick={submitDelete}>
+          <LoadingButton
+            block
+            color="danger"
+            onClick={(e: React.MouseEvent) => {
+              e.stopPropagation();
+              submitDelete();
+            }}
+          >
             Delete
           </LoadingButton>
-          <Button block color="secondary" onClick={() => setOpen(false)}>
+          <Button
+            block
+            color="secondary"
+            onClick={(e: React.MouseEvent) => {
+              e.stopPropagation();
+              setOpen(false);
+            }}
+          >
             Close
           </Button>
         </Flexbox>

--- a/src/client/components/modals/DeckDeleteModal.tsx
+++ b/src/client/components/modals/DeckDeleteModal.tsx
@@ -22,6 +22,7 @@ const DeckDeleteModal: React.FC<DeckDeleteModalProps> = ({ deck, cubeID, nextURL
     });
 
     if (!response.ok) {
+      // eslint-disable-next-line no-console -- Debugging
       console.error(response);
     } else if (nextURL) {
       window.location.href = nextURL;


### PR DESCRIPTION
# Bug
From Discord bug report, which included that the deck may not even be deleted. Reported in Firefox on Android.

From testing locally I saw that the onclick of the DeckPreview row, which redirects to the deck page, is triggered after the clicks of the actions in the modal. I'm not 100% sure why given that the modal is rooted outside the row itself, but there was a similar bug in this area fixed a while ago with the same behaviour.

# Solution
Stop the event propagation when the delete confirmation modal buttons are clicked.

# Testing

## Before
Can see the click on close redirects to the deck page. Though it didn't occur on my local, I can see why the bug reporter saw the deleting the deck didn't actually delete but redirected them; if there is some latency of the delete API call the browser could cancel it before the server even begins to process it, or the deck page load gets the deck before the delete finishes syncing to the database.
![old-mobile-deck-delete-actions-act-weird](https://github.com/user-attachments/assets/7419cc21-767f-48f3-9fd3-8eb513a4d79c)

## After

Clicking close doesn't redirect, nor does delete.
![new-mobile-deck-delete-actions-sane](https://github.com/user-attachments/assets/b6446a85-d3f4-411a-9696-ad291ee213c8)
