### PR TITLE
Replace tj-actions after compromise

### DIFF
--- a/.github/actions/eslint/action.yml
+++ b/.github/actions/eslint/action.yml
@@ -21,5 +21,6 @@ runs:
         INPUT_CONFIG_PATH: ${{ inputs.config_path }}
         INPUT_ESLINT_FLAGS: ${{ inputs.eslint_flags }}
         INPUT_PRINT_CHANGED_FILES: ${{ inputs.print_changed_files }}
+        # Exact sha of the merged PR branch, coming from the pull_request event
         INPUT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         INPUT_BRANCH_SHA: ${{ github.sha }}

--- a/.github/actions/eslint/action.yml
+++ b/.github/actions/eslint/action.yml
@@ -1,0 +1,25 @@
+name: 'Run ESlint on changed files'
+description: 'Run ESlint on changed files'
+author: 'KaelenProctor'
+inputs:
+  config_path:
+    description: 'CONFIG_PATH'
+    required: true
+  eslint_flags:
+    description: 'ESLINT_FLAGS'
+    required: true
+  print_changed_files:
+    description: 'PRINT_CHANGED_FILES'
+    default: false
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - run: .github/actions/eslint/script.sh
+      shell: bash
+      env:
+        INPUT_CONFIG_PATH: ${{ inputs.config_path }}
+        INPUT_ESLINT_FLAGS: ${{ inputs.eslint_flags }}
+        INPUT_PRINT_CHANGED_FILES: ${{ inputs.print_changed_files }}
+        INPUT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        INPUT_BRANCH_SHA: ${{ github.sha }}

--- a/.github/actions/eslint/script.sh
+++ b/.github/actions/eslint/script.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+# Get files changed between base and head refs of the PR
+FILES=$(git diff --name-only --diff-filter=ACMR "origin/$GITHUB_BASE_REF"..."$INPUT_BRANCH_SHA")
+
+if [ "${INPUT_PRINT_CHANGED_FILES}" == "true" ]
+then
+    echo "Changed files:"
+    echo "#####################"
+    for f in "${FILES[@]}"
+    do
+        echo "$f"
+    done
+    echo ""
+    echo ""
+fi
+
+if [ ${#FILES[@]} -ne 0 ]
+then
+    # Pass them through ESLint
+    echo "ESLint output":
+    echo "#####################"
+
+    # Don't quote ESLINT flags or FILES, as need to be treated as separate arguments
+    "$(npm root)"/.bin/eslint -c "${INPUT_CONFIG_PATH}" $INPUT_ESLINT_FLAGS ${FILES[@]}
+fi
+

--- a/.github/actions/eslint/script.sh
+++ b/.github/actions/eslint/script.sh
@@ -2,6 +2,7 @@
 set -e
 
 # Get files changed between base and head refs of the PR
+# origin/$GITHUB_BASE_REF requires the checkout-action to have fetch-depth: 0 to have history
 FILES=$(git diff --name-only --diff-filter=ACMR "origin/$GITHUB_BASE_REF"..."$INPUT_BRANCH_SHA")
 
 if [ "${INPUT_PRINT_CHANGED_FILES}" == "true" ]
@@ -22,6 +23,7 @@ then
     echo "ESLint output":
     echo "#####################"
 
+    # Path to ESLint executable aligned with prettier script
     # Don't quote ESLINT flags or FILES, as need to be treated as separate arguments
     "$(npm root)"/.bin/eslint -c "${INPUT_CONFIG_PATH}" $INPUT_ESLINT_FLAGS ${FILES[@]}
 fi

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Cache node_modules
         id: cache-node-modules
@@ -41,11 +43,10 @@ jobs:
       - name: Run eslint on changed files
         # Always run both eslint and prettier
         if: always()
-        uses: tj-actions/eslint-changed-files@v25
+        uses: ./.github/actions/eslint
         with:
           config_path: 'eslint.config.mjs'
-          extra_args: '--max-warnings=0 --no-warn-ignored'
-          reporter: github-pr-review
+          eslint_flags: '--max-warnings=0 --no-warn-ignored'
 
       - name: Run Prettier on changed files
         # Always run both eslint and prettier

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # To use with eslint script
           fetch-depth: 0
 
       - name: Cache node_modules

--- a/src/client/components/modals/TagColorsModal.tsx
+++ b/src/client/components/modals/TagColorsModal.tsx
@@ -79,6 +79,7 @@ const TagColorsModal: React.FC<TagColorsModalProps> = ({ isOpen, setOpen }) => {
       if (response.ok) {
         setTagColors(colors);
       } else {
+        // eslint-disable-next-line no-console -- Debugging
         console.error('Request failed.');
       }
       setLoading(false);

--- a/src/client/hooks/useLocalStorage.ts
+++ b/src/client/hooks/useLocalStorage.ts
@@ -14,6 +14,7 @@ const useLocalStorage = <T>(key: string, initialValue: T): [T, Dispatch<SetState
       return item ? JSON.parse(item) : initialValue;
     } catch (error) {
       // If error also return initialValue
+      // eslint-disable-next-line no-console -- Debugging
       console.error(error);
       return initialValue;
     }
@@ -32,6 +33,7 @@ const useLocalStorage = <T>(key: string, initialValue: T): [T, Dispatch<SetState
       }
     } catch (error) {
       // A more advanced implementation would handle the error case
+      // eslint-disable-next-line no-console -- Debugging
       console.error(error);
     }
   };

--- a/src/util/downloadModel.js
+++ b/src/util/downloadModel.js
@@ -32,6 +32,7 @@ const downloadFromS3 = async () => {
     }
 
     fs.writeFileSync(file.Key, res.Body);
+    // eslint-disable-next-line no-console -- Debugging
     console.log(`Downloaded ${file.Key}`);
   }
 };


### PR DESCRIPTION
Simplest replacement possible. If we wanted to explore again having the issues posted onto the PR as comments, we'd need to beef the thing up.

Example of failing eslint: https://github.com/KaelenProctor/CubeCobra/actions/runs/13872806888/job/38821502067?pr=12

