### PR TITLE
Fix bug in card full names that resulted in Art Cards appearing before the actual cards

### DIFF
--- a/src/client/utils/cardutil.ts
+++ b/src/client/utils/cardutil.ts
@@ -17,6 +17,8 @@ import CategoryOverrides from '../res/CategoryOverrides.json';
 import LandCategories from '../res/LandCategories.json';
 import { arraysEqual } from './Util';
 
+export const ART_SERIES_CARD_SUFFIX = 'Art Card';
+
 export const COLOR_COMBINATIONS: string[][] = [
   [],
   ['W'],
@@ -701,6 +703,7 @@ export function getCardTagColorClass(tagColors: TagColor[], card: Card): string 
 }
 
 export default {
+  ART_SERIES_CARD_SUFFIX,
   cardTags,
   cardFinish,
   cardStatus,

--- a/src/jobs/update_cards.ts
+++ b/src/jobs/update_cards.ts
@@ -22,94 +22,7 @@ import * as cardutil from '../client/utils/cardutil';
 import { CardMetadata, fileToAttribute } from '../util/cardCatalog';
 import { reasonableCard } from '../util/carddb';
 import * as util from '../util/util';
-
-interface ScryfallCard {
-  id: string;
-  name: string;
-  lang: string;
-  set: string;
-  collector_number: string;
-  set_name: string;
-  released_at: string;
-  reprint: boolean;
-  border_color: string;
-  promo: boolean;
-  promo_types: string[];
-  digital: boolean;
-  finishes: string[];
-  prices: {
-    usd: string | null;
-    usd_foil: string | null;
-    usd_etched: string | null;
-    eur: string | null;
-    tix: string | null;
-  };
-  image_uris: {
-    small: string;
-    normal: string;
-    art_crop: string;
-  };
-  card_faces?: ScryfallCard[];
-  loyalty?: string;
-  power?: string;
-  toughness?: string;
-  type_line: string;
-  oracle_text: string;
-  mana_cost: string;
-  cmc: number;
-  colors: string[];
-  color_identity: string[];
-  keywords: string[];
-  produced_mana: string[];
-  legalities: {
-    legacy: string;
-    modern: string;
-    standard: string;
-    pioneer: string;
-    pauper: string;
-    brawl: string;
-    historic: string;
-    commander: string;
-    penny: string;
-    vintage: string;
-  };
-  layout: string;
-  rarity: string;
-  artist: string;
-  scryfall_uri: string;
-  mtgo_id: number;
-  textless: boolean;
-  tcgplayer_id: string;
-  oracle_id: string;
-  full_art: boolean;
-  flavor_text: string;
-  frame_effects: string[];
-  frame: string;
-  card_back_id: string;
-  artist_id: string;
-  illustration_id: string;
-  content_warning: boolean;
-  variation: boolean;
-  preview: {
-    source: string;
-    source_uri: string;
-    previewed_at: string;
-  };
-  related_uris: {
-    gatherer: string;
-    tcgplayer_decks: string;
-    edhrec: string;
-    mtgtop8: string;
-  };
-  all_parts: {
-    object: string;
-    id: string;
-    component: string;
-    name: string;
-    type_line: string;
-    uri: string;
-  }[];
-}
+import { convertName, ScryfallCard } from './utils/update_cards';
 
 interface Catalog {
   dict: Record<string, CardDetails>;
@@ -443,24 +356,6 @@ function convertId(card: ScryfallCard, preflipped: boolean) {
     return `${card.id}2`;
   }
   return card.id;
-}
-
-function convertName(card: ScryfallCard, preflipped: boolean) {
-  let str = card.name;
-
-  if (preflipped) {
-    str = str.substring(str.indexOf('/') + 2); // second name
-  } else if (card.name.includes('/') && card.layout !== 'split') {
-    // NOTE: we want split cards to include both names
-    // but other double face to use the first name
-    str = str.substring(0, str.indexOf('/')); // first name
-  }
-
-  if (card.layout === 'art_series') {
-    str = `${str} Art Card`;
-  }
-
-  return str.trim();
 }
 
 function getFaceAttributeSource(card: ScryfallCard, preflipped: boolean) {

--- a/src/jobs/utils/update_cards.ts
+++ b/src/jobs/utils/update_cards.ts
@@ -99,9 +99,13 @@ export function convertName(card: ScryfallCard, preflipped: boolean) {
     str = str.substring(0, str.indexOf('/')); // first name
   }
 
+  //Trim the card name here before potentially adding art series suffix.
+  //Important the first or second name was extracted
+  str = str.trim();
+
   if (card.layout === 'art_series') {
     str = `${str} ${ART_SERIES_CARD_SUFFIX}`;
   }
 
-  return str.trim();
+  return str;
 }

--- a/src/jobs/utils/update_cards.ts
+++ b/src/jobs/utils/update_cards.ts
@@ -1,0 +1,107 @@
+import { ART_SERIES_CARD_SUFFIX } from '../../client/utils/cardutil';
+
+export interface ScryfallCard {
+  id: string;
+  name: string;
+  lang: string;
+  set: string;
+  collector_number: string;
+  set_name: string;
+  released_at: string;
+  reprint: boolean;
+  border_color: string;
+  promo: boolean;
+  promo_types: string[];
+  digital: boolean;
+  finishes: string[];
+  prices: {
+    usd: string | null;
+    usd_foil: string | null;
+    usd_etched: string | null;
+    eur: string | null;
+    tix: string | null;
+  };
+  image_uris: {
+    small: string;
+    normal: string;
+    art_crop: string;
+  };
+  card_faces?: ScryfallCard[];
+  loyalty?: string;
+  power?: string;
+  toughness?: string;
+  type_line: string;
+  oracle_text: string;
+  mana_cost: string;
+  cmc: number;
+  colors: string[];
+  color_identity: string[];
+  keywords: string[];
+  produced_mana: string[];
+  legalities: {
+    legacy: string;
+    modern: string;
+    standard: string;
+    pioneer: string;
+    pauper: string;
+    brawl: string;
+    historic: string;
+    commander: string;
+    penny: string;
+    vintage: string;
+  };
+  layout: string;
+  rarity: string;
+  artist: string;
+  scryfall_uri: string;
+  mtgo_id: number;
+  textless: boolean;
+  tcgplayer_id: string;
+  oracle_id: string;
+  full_art: boolean;
+  flavor_text: string;
+  frame_effects: string[];
+  frame: string;
+  card_back_id: string;
+  artist_id: string;
+  illustration_id: string;
+  content_warning: boolean;
+  variation: boolean;
+  preview: {
+    source: string;
+    source_uri: string;
+    previewed_at: string;
+  };
+  related_uris: {
+    gatherer: string;
+    tcgplayer_decks: string;
+    edhrec: string;
+    mtgtop8: string;
+  };
+  all_parts: {
+    object: string;
+    id: string;
+    component: string;
+    name: string;
+    type_line: string;
+    uri: string;
+  }[];
+}
+
+export function convertName(card: ScryfallCard, preflipped: boolean) {
+  let str = card.name;
+
+  if (preflipped) {
+    str = str.substring(str.indexOf('/') + 2); // second name
+  } else if (card.name.includes('/') && card.layout !== 'split') {
+    // NOTE: we want split cards to include both names
+    // but other double face to use the first name
+    str = str.substring(0, str.indexOf('/')); // first name
+  }
+
+  if (card.layout === 'art_series') {
+    str = `${str} ${ART_SERIES_CARD_SUFFIX}`;
+  }
+
+  return str.trim();
+}

--- a/tests/jobs/update_cards.test.ts
+++ b/tests/jobs/update_cards.test.ts
@@ -1,0 +1,55 @@
+import { ART_SERIES_CARD_SUFFIX } from '../../src/client/utils/cardutil';
+import { convertName, ScryfallCard } from '../../src/jobs/utils/update_cards';
+
+//TODO: Expand as more tests are added
+const createScryfallCard = (name: string, layout: string): ScryfallCard => {
+  return {
+    name,
+    layout,
+  } as ScryfallCard;
+};
+
+describe('convertName', () => {
+  it('Plain card name', async () => {
+    const card = createScryfallCard('Hypnotic Siren', 'normal');
+    const result = convertName(card, false);
+    expect(result).toEqual('Hypnotic Siren');
+  });
+
+  it('Trims whitespace', async () => {
+    const card = createScryfallCard('    Hypnotic Siren   ', 'normal');
+    const result = convertName(card, false);
+    expect(result).toEqual('Hypnotic Siren');
+  });
+
+  it('Backside of transforming card', async () => {
+    const card = createScryfallCard('Ajani, Nacatl Pariah // Ajani, Nacatl Avenger', 'transform');
+    const result = convertName(card, false);
+    expect(result).toEqual('Ajani, Nacatl Pariah');
+  });
+
+  it('Backside of transforming card', async () => {
+    const card = createScryfallCard('Ajani, Nacatl Pariah // Ajani, Nacatl Avenger', 'transform');
+    const result = convertName(card, true);
+    expect(result).toEqual('Ajani, Nacatl Avenger');
+  });
+
+  it('Split card is always full name', async () => {
+    const card = createScryfallCard('Alive // Well', 'split');
+    const result = convertName(card, false);
+    expect(result).toEqual('Alive // Well');
+  });
+
+  it('Frontside of art series card', async () => {
+    //Art cards use the same name on both sides
+    const card = createScryfallCard('Island // Island', 'art_series');
+    const result = convertName(card, false);
+    expect(result).toEqual(`Island ${ART_SERIES_CARD_SUFFIX}`);
+  });
+
+  it('Backside of art series card', async () => {
+    const card = createScryfallCard('Island // Island', 'art_series');
+    const result = convertName(card, true);
+    expect(result).toEqual(`Island ${ART_SERIES_CARD_SUFFIX}`);
+  });
+});

--- a/tests/utils/utils.test.ts
+++ b/tests/utils/utils.test.ts
@@ -1,0 +1,292 @@
+import { normalizeName } from '../../src/client/utils/cardutil';
+import util from '../../src/util/util';
+
+describe('turnToTree', () => {
+  //Fix the seed for consistency in tests
+  const SHUFFLE_SEED = '1742131471000';
+
+  it('Empty list is empty tree', () => {
+    const result = util.turnToTree([]);
+    expect(result).toEqual({});
+  });
+
+  const deepCardNames = [
+    'Serra Angel',
+    'Serra Paladin',
+    'Serra Advocate',
+    'Serra Ascendant',
+    'Serra Avenger',
+    'Serra Bestiary',
+    "Serra's Hymn",
+  ];
+
+  const deepTreeCases = [
+    { descriptor: 'sorted', cardNames: deepCardNames },
+    { descriptor: 'unsorted', cardNames: util.shuffle(deepCardNames, SHUFFLE_SEED) },
+  ];
+
+  it.each(deepTreeCases)('Deep tree of card names ($descriptor)', async ({ cardNames }) => {
+    const normalizedNames = cardNames.map((name: string) => normalizeName(name));
+
+    const expectedTree = {
+      s: {
+        e: {
+          r: {
+            r: {
+              a: {
+                ' ': {
+                  a: {
+                    n: {
+                      g: {
+                        e: {
+                          l: {
+                            $: {},
+                          },
+                        },
+                      },
+                    },
+                    d: {
+                      v: {
+                        o: {
+                          c: {
+                            a: {
+                              t: {
+                                e: {
+                                  $: {},
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                    s: {
+                      c: {
+                        e: {
+                          n: {
+                            d: {
+                              a: {
+                                n: {
+                                  t: {
+                                    $: {},
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                    v: {
+                      e: {
+                        n: {
+                          g: {
+                            e: {
+                              r: {
+                                $: {},
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                  b: {
+                    e: {
+                      s: {
+                        t: {
+                          i: {
+                            a: {
+                              r: {
+                                y: {
+                                  $: {},
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                  p: {
+                    a: {
+                      l: {
+                        a: {
+                          d: {
+                            i: {
+                              n: {
+                                $: {},
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+                "'": {
+                  s: {
+                    ' ': {
+                      h: {
+                        y: {
+                          m: {
+                            n: {
+                              $: {},
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = util.turnToTree(normalizedNames);
+    expect(result).toEqual(expectedTree);
+  });
+
+  const wideCardNames = ['Gravecrawler', 'Island Art Card', "Kykar, Wind's Fury", 'Mutilate', 'Vesuva'];
+
+  const wideTreeCases = [
+    { descriptor: 'sorted', cardNames: wideCardNames },
+    { descriptor: 'unsorted', cardNames: util.shuffle(wideCardNames, SHUFFLE_SEED) },
+  ];
+
+  it.each(wideTreeCases)('Wide tree of card names ($descriptor)', async ({ cardNames }) => {
+    const normalizedNames = cardNames.map((name: string) => normalizeName(name));
+
+    const expectedTree = {
+      g: {
+        r: {
+          a: {
+            v: {
+              e: {
+                c: {
+                  r: {
+                    a: {
+                      w: {
+                        l: {
+                          e: {
+                            r: {
+                              $: {},
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      i: {
+        s: {
+          l: {
+            a: {
+              n: {
+                d: {
+                  ' ': {
+                    a: {
+                      r: {
+                        t: {
+                          ' ': {
+                            c: {
+                              a: {
+                                r: {
+                                  d: {
+                                    $: {},
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      k: {
+        y: {
+          k: {
+            a: {
+              r: {
+                ',': {
+                  ' ': {
+                    w: {
+                      i: {
+                        n: {
+                          d: {
+                            "'": {
+                              s: {
+                                ' ': {
+                                  f: {
+                                    u: {
+                                      r: {
+                                        y: {
+                                          $: {},
+                                        },
+                                      },
+                                    },
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      m: {
+        u: {
+          t: {
+            i: {
+              l: {
+                a: {
+                  t: {
+                    e: {
+                      $: {},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      v: {
+        e: {
+          s: {
+            u: {
+              v: {
+                a: {
+                  $: {},
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = util.turnToTree(normalizedNames);
+    expect(result).toEqual(expectedTree);
+  });
+});


### PR DESCRIPTION
From Discord feature request https://discord.com/channels/592787488523943937/1350090569023619092

Once I dug into it and walked through the tree names -> card names logic, I found that the full names of art cards had two spaces between the name and "art card". After searching the tree through each character the user has typed, it then does a depth first search from there until a maximum number of names are found. From testing spaces are before other characters in the tree, whereas [ are before other characters. Thus due to the double space in the full name for art cards, they took precedence over the rest. See images below to help illustrate

I've typed "island" and this shows the tree after it has traversed through those characters:
![image](https://github.com/user-attachments/assets/63c7d971-88c7-4ff7-a57e-67b09e3c693b)
The `[` sub-tree is all the full names of island cards, whereas `a` takes you to the art cards and `f` takes you to "island fish jasconius" (that's a card???).

In comparison this is the same in the current CubeCobra. Due to the double space, the art cards end up before the `[` sub-tree.
![image](https://github.com/user-attachments/assets/65181d6c-a138-4cc8-8613-427432821a68)
Depending on how many printings a card name has the art cards will use up the maximum number of names to show.

# Testing

## Before

When search names, the art cards were after the actual card:
![old-art-cards-last-with-no-versions](https://github.com/user-attachments/assets/054ff7ce-ad9b-404b-99f2-68f7efd2476f)
![old-art-cards-after-with-no-versions2](https://github.com/user-attachments/assets/86b3e19a-b94b-4469-84bb-5c2e3bcca9a6)
![old-art-cards-after-with-no-versions3](https://github.com/user-attachments/assets/810f7490-89c3-4412-ab05-8e3461bb8825)

But when searching versions the art cards were first:
![old-art-cards-first](https://github.com/user-attachments/assets/580fa5b4-0262-4c33-ae30-edec9bbe4afa)
![old-art-cards-first2](https://github.com/user-attachments/assets/cd92d3f3-da9b-4272-a375-0dfa6eb1b62e)
![old-art-cards-can-be-full](https://github.com/user-attachments/assets/8ab2a2b1-2dd4-4f54-bb59-0f855b97273a)

## After

When search names, same behaviour:
![new-art-cards-after-actual-no-versions](https://github.com/user-attachments/assets/91941444-e911-43b7-9696-e53666f0b541)
![new-art-cards-after-actual-no-versions2](https://github.com/user-attachments/assets/257738ec-e9f6-4e54-8980-439f83016364)
![new-art-cards-after-actual-no-versions3](https://github.com/user-attachments/assets/34eaeaed-85bb-4b99-b4da-e666acd770ab)

When searching versions, now art cards are after real cards:
![new-art-cards-after-actual](https://github.com/user-attachments/assets/2fec3f2b-a040-4bc9-b8f2-1b94b7f09cdc)
![new-art-cards-after-actual2](https://github.com/user-attachments/assets/430b3f06-a76f-4d63-9605-8d9380a0d82d)
![new-art-cards-after-actual3](https://github.com/user-attachments/assets/1e9ecf01-03bd-4405-82d3-5232c083fe63)
