### PR TITLE
Fix replaced eslint action so that it works on push events as well

### DIFF
--- a/.github/actions/eslint/action.yml
+++ b/.github/actions/eslint/action.yml
@@ -21,6 +21,6 @@ runs:
         INPUT_CONFIG_PATH: ${{ inputs.config_path }}
         INPUT_ESLINT_FLAGS: ${{ inputs.eslint_flags }}
         INPUT_PRINT_CHANGED_FILES: ${{ inputs.print_changed_files }}
-        # Exact sha of the merged PR branch, coming from the pull_request event
-        INPUT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        # Pull request base SHA, or the SHA of the branch before push
+        INPUT_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
         INPUT_BRANCH_SHA: ${{ github.sha }}

--- a/.github/actions/eslint/script.sh
+++ b/.github/actions/eslint/script.sh
@@ -2,8 +2,7 @@
 set -e
 
 # Get files changed between base and head refs of the PR
-# origin/$GITHUB_BASE_REF requires the checkout-action to have fetch-depth: 0 to have history
-FILES=$(git diff --name-only --diff-filter=ACMR "origin/$GITHUB_BASE_REF"..."$INPUT_BRANCH_SHA")
+FILES=$(git diff --name-only --diff-filter=ACMR "$INPUT_BASE_SHA"..."$INPUT_BRANCH_SHA")
 
 if [ "${INPUT_PRINT_CHANGED_FILES}" == "true" ]
 then

--- a/.github/actions/eslint/script.sh
+++ b/.github/actions/eslint/script.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e
 
+if [ -z "$INPUT_BASE_SHA" ] || [ -z "$INPUT_BRANCH_SHA" ]
+then
+    echo "Skipping ESLint changed files check because missing one or both SHAs"
+    exit 0
+fi
+
 # Get files changed between base and head refs of the PR
 FILES=$(git diff --name-only --diff-filter=ACMR "$INPUT_BASE_SHA"..."$INPUT_BRANCH_SHA")
 


### PR DESCRIPTION
Originally tested on pull requests in my fork, but didn't think to test the push events on master.

# Testing

Pull request (on my fork): https://github.com/KaelenProctor/CubeCobra/actions/runs/13935482657/job/39002354104

Branch (on my fork): https://github.com/KaelenProctor/CubeCobra/actions/runs/13935497512/job/39002396078
I pushed the changes to my master branch, then undid by force pushing the old head commit.

