### PR TITLE
Prevent last step of a pack in custom draft format from being a "pass", which stalls the draft

### DIFF
--- a/src/client/components/CustomPackCard.tsx
+++ b/src/client/components/CustomPackCard.tsx
@@ -174,7 +174,10 @@ const CustomPackCard: React.FC<CustomPackCardProps> = ({
               <Button
                 className="me-2"
                 color="accent"
-                onClick={() => setPack({ ...pack, steps: [...steps, ...DEFAULT_STEPS] })}
+                /* The default steps are pick then pass. The default for a pack is N of those pairs, minus the last pick.
+                 * So most commonly for a new step we want to add a pass then pick, thus reverse.
+                 */
+                onClick={() => setPack({ ...pack, steps: [...steps, ...DEFAULT_STEPS.reverse()] })}
               >
                 Add Step
               </Button>

--- a/src/client/components/CustomPackCard.tsx
+++ b/src/client/components/CustomPackCard.tsx
@@ -2,7 +2,8 @@ import React, { useMemo } from 'react';
 
 import { ChevronDownIcon, ChevronUpIcon } from '@primer/octicons-react';
 
-import { buildDefaultSteps, DEFAULT_STEPS, DraftAction, Pack } from '../../datatypes/Draft';
+import { DraftAction, Pack } from '../../datatypes/Draft';
+import { buildDefaultSteps, DEFAULT_STEPS } from '../../util/draftutil';
 import useToggle from '../hooks/UseToggle';
 import Button from './base/Button';
 import { Card, CardFooter, CardHeader } from './base/Card';

--- a/src/client/components/modals/CustomDraftFormatModal.tsx
+++ b/src/client/components/modals/CustomDraftFormatModal.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useMemo, useState } from 'react';
 
-import { createDefaultDraftFormat, DEFAULT_PACK, DraftFormat, getErrorsInFormat } from '../../../datatypes/Draft';
+import { createDefaultDraftFormat, DEFAULT_PACK, DraftFormat } from '../../../datatypes/Draft';
+import { getErrorsInFormat } from '../../../util/draftutil';
 import CubeContext from '../../contexts/CubeContext';
 import Alert from '../base/Alert';
 import Button from '../base/Button';

--- a/src/client/components/modals/CustomDraftFormatModal.tsx
+++ b/src/client/components/modals/CustomDraftFormatModal.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useMemo, useState } from 'react';
 
-import { createDefaultDraftFormat, DEFAULT_PACK, DraftFormat } from '../../../datatypes/Draft';
-import { getErrorsInFormat } from '../../../util/draftutil';
+import { DraftFormat } from '../../../datatypes/Draft';
+import { createDefaultDraftFormat, DEFAULT_PACK, getErrorsInFormat } from '../../../util/draftutil';
 import CubeContext from '../../contexts/CubeContext';
 import Alert from '../base/Alert';
 import Button from '../base/Button';

--- a/src/client/drafting/createdraft.ts
+++ b/src/client/drafting/createdraft.ts
@@ -2,8 +2,9 @@ import seedrandom from 'seedrandom';
 
 import Card from '../../datatypes/Card';
 import Cube from '../../datatypes/Cube';
-import Draft, { buildDefaultSteps, createDefaultDraftFormat, DraftFormat, DraftState } from '../../datatypes/Draft';
+import Draft, { DraftFormat, DraftState } from '../../datatypes/Draft';
 import User from '../../datatypes/User';
+import { buildDefaultSteps, createDefaultDraftFormat } from '../../util/draftutil';
 import { arraysEqual, fromEntries } from '../utils/Util';
 import { compileFilter, Filter } from './draftFilter';
 

--- a/src/client/drafting/createdraft.ts
+++ b/src/client/drafting/createdraft.ts
@@ -4,7 +4,7 @@ import Card from '../../datatypes/Card';
 import Cube from '../../datatypes/Cube';
 import Draft, { DraftFormat, DraftState } from '../../datatypes/Draft';
 import User from '../../datatypes/User';
-import { buildDefaultSteps, createDefaultDraftFormat, normalizeDraftFormatSteps } from '../../util/draftutil';
+import { buildDefaultSteps, createDefaultDraftFormat } from '../../util/draftutil';
 import { arraysEqual, fromEntries } from '../utils/Util';
 import { compileFilter, Filter } from './draftFilter';
 
@@ -293,7 +293,7 @@ export const createDraft = (
   nextCardFn = createNextCardFn(cubeCards, format.multiples, rng);
 
   //TODO: Add the endpack steps here instead of in frontend
-  const result: CreatePacksResult = createPacks(normalizeDraftFormatSteps(format), seats, nextCardFn);
+  const result: CreatePacksResult = createPacks(format, seats, nextCardFn);
 
   if (!result.ok) {
     throw new Error(`Could not create draft:\n${result.messages.join('\n')}`);

--- a/src/client/drafting/createdraft.ts
+++ b/src/client/drafting/createdraft.ts
@@ -4,7 +4,7 @@ import Card from '../../datatypes/Card';
 import Cube from '../../datatypes/Cube';
 import Draft, { DraftFormat, DraftState } from '../../datatypes/Draft';
 import User from '../../datatypes/User';
-import { buildDefaultSteps, createDefaultDraftFormat } from '../../util/draftutil';
+import { buildDefaultSteps, createDefaultDraftFormat, normalizeDraftFormatSteps } from '../../util/draftutil';
 import { arraysEqual, fromEntries } from '../utils/Util';
 import { compileFilter, Filter } from './draftFilter';
 
@@ -292,7 +292,8 @@ export const createDraft = (
 
   nextCardFn = createNextCardFn(cubeCards, format.multiples, rng);
 
-  const result: CreatePacksResult = createPacks(format, seats, nextCardFn);
+  //TODO: Add the endpack steps here instead of in frontend
+  const result: CreatePacksResult = createPacks(normalizeDraftFormatSteps(format), seats, nextCardFn);
 
   if (!result.ok) {
     throw new Error(`Could not create draft:\n${result.messages.join('\n')}`);

--- a/src/client/layouts/MainLayout.tsx
+++ b/src/client/layouts/MainLayout.tsx
@@ -48,4 +48,6 @@ const MainLayout: React.FC<MainLayoutProps> = ({ children, loginCallback = '/' }
   );
 };
 
+MainLayout.displayName = 'MainLayout';
+
 export default MainLayout;

--- a/src/client/pages/CubeDraftPage.tsx
+++ b/src/client/pages/CubeDraftPage.tsx
@@ -76,7 +76,15 @@ const getInitialState = (draft: Draft): State => {
     const seat = draft.InitialState[0];
 
     for (const pack of seat) {
-      stepQueue.push(...pack.steps, { action: 'endpack', amount: null });
+      const stepsLength = pack.steps.length;
+      if (stepsLength === 0) {
+        continue;
+      }
+
+      //Backwards compatability, add endpack step to the end of the pack if the backend hasn't already
+      if (pack.steps[stepsLength - 1]?.action !== 'endpack') {
+        stepQueue.push(...pack.steps, { action: 'endpack', amount: null });
+      }
     }
   }
 

--- a/src/client/pages/CubeDraftPage.tsx
+++ b/src/client/pages/CubeDraftPage.tsx
@@ -737,4 +737,6 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
   );
 };
 
+CubeDraftPage.displayName = 'CubeDraftPage';
+
 export default RenderToRoot(CubeDraftPage);

--- a/src/datatypes/Draft.ts
+++ b/src/datatypes/Draft.ts
@@ -35,56 +35,10 @@ export const DEFAULT_PACK: Pack = Object.freeze({ slots: [''], steps: DEFAULT_ST
 
 export const buildDefaultSteps: (cards: number) => DraftStep[] = (cards) => {
   // the length should be cards*2-1, because the last step is always a pass
-  const steps = new Array(cards).fill(DEFAULT_STEPS).flat();
+  const steps: DraftStep[] = new Array(cards).fill(DEFAULT_STEPS).flat();
+  //use normalize
   steps.pop();
   return steps;
-};
-
-export const getErrorsInFormat = (format: DraftFormat) => {
-  const errors = [];
-  if (!format?.packs) return ['Internal error in the format.'];
-  if (!format.title.trim()) errors.push('title must not be empty.');
-  if (format.packs.length === 0) errors.push('Format must have at least 1 pack.');
-
-  if (format.defaultSeats !== undefined) {
-    if (!Number.isFinite(format.defaultSeats)) errors.push('Default seat count must be a number.');
-    if (format.defaultSeats < 2 || format.defaultSeats > 16)
-      errors.push('Default seat count must be between 2 and 16.');
-  }
-
-  for (let i = 0; i < format.packs.length; i++) {
-    const pack = format.packs[i];
-
-    let amount = 0;
-
-    if (!pack.steps) {
-      // this is ok, it just means the pack is a default pack
-      continue;
-    }
-
-    for (const step of pack.steps) {
-      if (step === null) {
-        continue;
-      }
-
-      const { action, amount: stepAmount } = step;
-
-      if (action === 'pass') {
-        continue;
-      }
-
-      if (stepAmount !== null) {
-        amount += stepAmount;
-      } else {
-        amount += 1;
-      }
-    }
-
-    if (amount !== pack.slots.length) {
-      errors.push(`Pack ${i + 1} has ${pack.slots.length} slots but has steps to pick or trash ${amount} cards.`);
-    }
-  }
-  return errors.length === 0 ? null : errors;
 };
 
 export const createDefaultDraftFormat = (packsPerPlayer: number, cardsPerPack: number): DraftFormat => {

--- a/src/datatypes/Draft.ts
+++ b/src/datatypes/Draft.ts
@@ -26,34 +26,6 @@ export type DraftState = {
   steps: DraftStep[];
 }[][];
 
-export const DEFAULT_STEPS: DraftStep[] = [
-  { action: 'pick', amount: 1 },
-  { action: 'pass', amount: null },
-];
-
-export const DEFAULT_PACK: Pack = Object.freeze({ slots: [''], steps: DEFAULT_STEPS });
-
-export const buildDefaultSteps: (cards: number) => DraftStep[] = (cards) => {
-  // the length should be cards*2-1, because the last step is always a pass
-  const steps: DraftStep[] = new Array(cards).fill(DEFAULT_STEPS).flat();
-  //use normalize
-  steps.pop();
-  return steps;
-};
-
-export const createDefaultDraftFormat = (packsPerPlayer: number, cardsPerPack: number): DraftFormat => {
-  return {
-    title: `Standard Draft`,
-    packs: Array.from({ length: packsPerPlayer }, () => ({
-      slots: Array.from({ length: cardsPerPack }, () => '*'),
-      steps: buildDefaultSteps(cardsPerPack),
-    })),
-    multiples: false,
-    markdown: '',
-    defaultSeats: 8,
-  };
-};
-
 export interface DraftmancerPick {
   booster: number[];
   pick: number;

--- a/src/dynamo/models/cube.js
+++ b/src/dynamo/models/cube.js
@@ -9,6 +9,7 @@ const { getHashRowsForMetadata } = require('./cubeHash');
 const cubeHash = require('./cubeHash');
 const User = require('./user');
 import { cardFromId, getPlaceholderCard } from '../../util/carddb';
+const { normalizeDraftFormatSteps } = require('../../util/draftutil');
 const cloudwatch = require('../../util/cloudwatch');
 
 const DEFAULT_BASICS = [
@@ -165,6 +166,12 @@ const hydrate = async (cube) => {
   cube.owner = await User.getById(cube.owner);
   cube.image = getImageData(cube.imageName);
 
+  const draftFormats = cube?.formats || [];
+  //Correct bad custom draft formats on load, so any page using them are using good versions
+  for (let format of draftFormats) {
+    format = normalizeDraftFormatSteps(format);
+  }
+
   return cube;
 };
 
@@ -174,6 +181,13 @@ const batchHydrate = async (cubes) => {
   return cubes.map((cube) => {
     cube.owner = owners.find((owner) => owner.id === cube.owner);
     cube.image = getImageData(cube.imageName);
+
+    const draftFormats = cube?.formats || [];
+    //Correct bad custom draft formats on load, so any page using them are using good versions
+    for (let format of draftFormats) {
+      format = normalizeDraftFormatSteps(format);
+    }
+
     return cube;
   });
 };

--- a/src/util/draftutil.ts
+++ b/src/util/draftutil.ts
@@ -339,3 +339,50 @@ export const normalizeDraftSteps = (steps: DraftStep[]): DraftStep[] => {
 
   return steps;
 };
+
+export const getErrorsInFormat = (format: DraftFormat) => {
+  const errors = [];
+  if (!format?.packs) return ['Internal error in the format.'];
+  if (!format.title.trim()) errors.push('title must not be empty.');
+  if (format.packs.length === 0) errors.push('Format must have at least 1 pack.');
+
+  if (format.defaultSeats !== undefined) {
+    if (!Number.isFinite(format.defaultSeats)) errors.push('Default seat count must be a number.');
+    if (format.defaultSeats < 2 || format.defaultSeats > 16)
+      errors.push('Default seat count must be between 2 and 16.');
+  }
+
+  for (let i = 0; i < format.packs.length; i++) {
+    const pack = format.packs[i];
+
+    let amount = 0;
+
+    if (!pack.steps) {
+      // this is ok, it just means the pack is a default pack
+      continue;
+    }
+
+    for (const step of pack.steps) {
+      if (step === null) {
+        continue;
+      }
+
+      const { action, amount: stepAmount } = step;
+
+      if (action === 'pass') {
+        continue;
+      }
+
+      if (stepAmount !== null) {
+        amount += stepAmount;
+      } else {
+        amount += 1;
+      }
+    }
+
+    if (amount !== pack.slots.length) {
+      errors.push(`Pack ${i + 1} has ${pack.slots.length} slots but has steps to pick or trash ${amount} cards.`);
+    }
+  }
+  return errors.length === 0 ? null : errors;
+};

--- a/src/util/draftutil.ts
+++ b/src/util/draftutil.ts
@@ -352,7 +352,7 @@ export const getErrorsInFormat = (format: DraftFormat) => {
 
     const stepsLength = pack.steps.length;
     const lastStep = pack.steps[stepsLength - 1];
-    if (lastStep.action === 'pass') {
+    if (lastStep?.action === 'pass') {
       errors.push(`Pack ${i + 1} cannot end with a pass action.`);
     }
 

--- a/src/util/draftutil.ts
+++ b/src/util/draftutil.ts
@@ -1,6 +1,6 @@
 import { cardCmc, cardType, cmcColumn } from '../client/utils/cardutil';
 import Card from '../datatypes/Card';
-import Draft, { DraftStep } from '../datatypes/Draft';
+import Draft, { DraftFormat, DraftStep } from '../datatypes/Draft';
 
 interface Step {
   action: string;
@@ -313,4 +313,29 @@ export const setupPicks: (rows: number, cols: number) => any[][][] = (rows: numb
     res.push(row);
   }
   return res;
+};
+
+export const normalizeDraftFormatSteps = (format: DraftFormat): DraftFormat => {
+  for (let packNum = 0; packNum < format.packs.length; packNum++) {
+    const steps = format.packs[packNum].steps;
+
+    //Nothing to do for null steps. Null represents default steps
+    if (steps === null) {
+      continue;
+    }
+
+    format.packs[packNum].steps = normalizeDraftSteps(steps);
+  }
+
+  return format;
+};
+
+export const normalizeDraftSteps = (steps: DraftStep[]): DraftStep[] => {
+  const stepsLength = steps.length;
+  const lastStep = steps[stepsLength - 1];
+  if (lastStep.action === 'pass') {
+    steps.pop();
+  }
+
+  return steps;
 };

--- a/src/util/draftutil.ts
+++ b/src/util/draftutil.ts
@@ -362,6 +362,12 @@ export const getErrorsInFormat = (format: DraftFormat) => {
       continue;
     }
 
+    const stepsLength = pack.steps.length;
+    const lastStep = pack.steps[stepsLength - 1];
+    if (lastStep.action === 'pass') {
+      errors.push(`Pack ${i + 1} cannot end with a pass action.`);
+    }
+
     for (const step of pack.steps) {
       if (step === null) {
         continue;

--- a/src/util/draftutil.ts
+++ b/src/util/draftutil.ts
@@ -103,28 +103,6 @@ export const getStepList = (initialState: any[]): FlattenedStep[] =>
     ])
     .flat();
 
-export const nextStep = (draft: Draft, cardsPicked: number): string | null => {
-  if (!draft.InitialState) {
-    return null;
-  }
-
-  const steps = getStepList(draft.InitialState);
-
-  let picks = 0;
-
-  for (const step of steps) {
-    if (picks >= cardsPicked) {
-      return step.action;
-    }
-
-    if (step.action !== 'pass' && step.action !== 'endpack') {
-      picks += 1;
-    }
-  }
-
-  return null;
-};
-
 export const getDrafterState = (draft: Draft, seatNumber: number, pickNumber: number): DrafterState => {
   if (!draft.InitialState) {
     return {

--- a/src/util/draftutil.ts
+++ b/src/util/draftutil.ts
@@ -1,6 +1,6 @@
 import { cardCmc, cardType, cmcColumn } from '../client/utils/cardutil';
 import Card from '../datatypes/Card';
-import Draft, { DraftFormat, DraftStep } from '../datatypes/Draft';
+import Draft, { DraftFormat, DraftStep, Pack } from '../datatypes/Draft';
 
 interface Step {
   action: string;
@@ -391,4 +391,32 @@ export const getErrorsInFormat = (format: DraftFormat) => {
     }
   }
   return errors.length === 0 ? null : errors;
+};
+
+export const DEFAULT_STEPS: DraftStep[] = [
+  { action: 'pick', amount: 1 },
+  { action: 'pass', amount: null },
+];
+
+export const DEFAULT_PACK: Pack = Object.freeze({ slots: [''], steps: DEFAULT_STEPS });
+
+export const buildDefaultSteps: (cards: number) => DraftStep[] = (cards) => {
+  // the length should be cards*2-1, because the last step is always a pass
+  const steps: DraftStep[] = new Array(cards).fill(DEFAULT_STEPS).flat();
+  //use normalize
+  steps.pop();
+  return steps;
+};
+
+export const createDefaultDraftFormat = (packsPerPlayer: number, cardsPerPack: number): DraftFormat => {
+  return {
+    title: `Standard Draft`,
+    packs: Array.from({ length: packsPerPlayer }, () => ({
+      slots: Array.from({ length: cardsPerPack }, () => '*'),
+      steps: buildDefaultSteps(cardsPerPack),
+    })),
+    multiples: false,
+    markdown: '',
+    defaultSeats: 8,
+  };
 };

--- a/tests/cube/draft/createPacks.test.ts
+++ b/tests/cube/draft/createPacks.test.ts
@@ -1,13 +1,8 @@
 import seedrandom from 'seedrandom';
 
 import { createPacks, CreatePacksResult, DraftResult, NextCardFn } from '../../../src/client/drafting/createdraft';
-import {
-  buildDefaultSteps,
-  createDefaultDraftFormat,
-  DraftFormat,
-  DraftState,
-  Pack,
-} from '../../../src/datatypes/Draft';
+import { DraftFormat, DraftState, Pack } from '../../../src/datatypes/Draft';
+import { buildDefaultSteps, createDefaultDraftFormat } from '../../../src/util/draftutil';
 
 describe('createPacks', () => {
   beforeEach(() => {

--- a/tests/cube/draft/draftutils.test.ts
+++ b/tests/cube/draft/draftutils.test.ts
@@ -6,17 +6,19 @@ const createMockDraftFormat = (overrides?: Partial<DraftFormat>): DraftFormat =>
     title: 'Custom Draft',
     packs: [
       {
-        slots: ['*'],
+        slots: ['*', '*'],
         steps: [
           { action: 'pick', amount: 1 },
           { action: 'pass', amount: null },
+          { action: 'pick', amount: 1 },
         ],
       },
       {
-        slots: ['*'],
+        slots: ['*', '*'],
         steps: [
           { action: 'pick', amount: 1 },
           { action: 'pass', amount: null },
+          { action: 'pick', amount: 1 },
         ],
       },
     ],
@@ -190,12 +192,29 @@ describe('getErrorsInFormat', () => {
           steps: [
             { action: 'pick', amount: 1 },
             { action: 'pass', amount: null },
+            { action: 'pick', amount: 1 },
           ],
         },
       ],
     });
     const result = getErrorsInFormat(format);
-    expect(result).toContain('Pack 1 has 3 slots but has steps to pick or trash 1 cards.');
+    expect(result).toContain('Pack 1 has 3 slots but has steps to pick or trash 2 cards.');
+  });
+
+  it('returns error when pack steps end in pass', () => {
+    const format = createMockDraftFormat({
+      packs: [
+        {
+          slots: ['*'],
+          steps: [
+            { action: 'pick', amount: 1 },
+            { action: 'pass', amount: null },
+          ],
+        },
+      ],
+    });
+    const result = getErrorsInFormat(format);
+    expect(result).toContain('Pack 1 cannot end with a pass action.');
   });
 
   it('handles multiple errors', () => {

--- a/tests/cube/draft/draftutils.test.ts
+++ b/tests/cube/draft/draftutils.test.ts
@@ -2,6 +2,7 @@ import { DraftAction, DraftFormat, DraftStep } from '../../../src/datatypes/Draf
 import {
   buildDefaultSteps,
   createDefaultDraftFormat,
+  defaultStepsForLength,
   getErrorsInFormat,
   normalizeDraftFormatSteps,
   normalizeDraftSteps,
@@ -37,6 +38,14 @@ const createMockDraftFormat = (overrides?: Partial<DraftFormat>): DraftFormat =>
 };
 
 describe('normalizeDraftSteps', () => {
+  it('Handles empty steps', () => {
+    const steps: DraftStep[] = [];
+
+    const normalizedSteps = normalizeDraftSteps(steps);
+    expect(normalizedSteps.length).toEqual(0);
+    expect(normalizedSteps).toEqual([]);
+  });
+
   it('Removes the last step if it is pass, as that is invalid', () => {
     const steps: DraftStep[] = [
       { action: 'pick', amount: 1 },
@@ -307,5 +316,27 @@ describe('createDefaultDraftFormat', () => {
     expect(format.packs).toHaveLength(1);
     expect(format.packs[0].slots).toHaveLength(1);
     expect(format.packs[0].steps).toHaveLength(1);
+  });
+});
+
+describe('defaultStepsForLength', () => {
+  it('Creates valid steps', () => {
+    const steps = defaultStepsForLength(5);
+    expect(steps).toEqual([
+      { action: 'pick', amount: 1 },
+      { action: 'pass', amount: 1 },
+      { action: 'pick', amount: 1 },
+      { action: 'pass', amount: 1 },
+      { action: 'pick', amount: 1 },
+      { action: 'pass', amount: 1 },
+      { action: 'pick', amount: 1 },
+      { action: 'pass', amount: 1 },
+      { action: 'pick', amount: 1 },
+    ]);
+  });
+
+  it('Handles zero steps', () => {
+    const steps = defaultStepsForLength(0);
+    expect(steps).toEqual([]);
   });
 });

--- a/tests/cube/draft/draftutils.test.ts
+++ b/tests/cube/draft/draftutils.test.ts
@@ -1,0 +1,127 @@
+import { DraftAction, DraftFormat, DraftStep } from '../../../src/datatypes/Draft';
+import { normalizeDraftFormatSteps, normalizeDraftSteps } from '../../../src/util/draftutil';
+
+const createMockDraftFormat = (overrides?: Partial<DraftFormat>): DraftFormat => {
+  return {
+    title: 'Custom Draft',
+    packs: [
+      {
+        slots: ['*'],
+        steps: [
+          { action: 'pick', amount: 1 },
+          { action: 'pass', amount: null },
+        ],
+      },
+      {
+        slots: ['*'],
+        steps: [
+          { action: 'pick', amount: 1 },
+          { action: 'pass', amount: null },
+        ],
+      },
+    ],
+    multiples: false,
+    markdown: 'Text',
+    html: 'Text',
+    defaultSeats: 4,
+    ...overrides,
+  };
+};
+
+describe('normalizeDraftSteps', () => {
+  it('Removes the last step if it is pass, as that is invalid', () => {
+    const steps: DraftStep[] = [
+      { action: 'pick', amount: 1 },
+      { action: 'pass', amount: null },
+      { action: 'pick', amount: 1 },
+      { action: 'pass', amount: null },
+    ];
+
+    const normalizedSteps = normalizeDraftSteps(steps);
+    expect(normalizedSteps.length).toEqual(3);
+    expect(normalizedSteps).toEqual([
+      { action: 'pick', amount: 1 },
+      { action: 'pass', amount: null },
+      { action: 'pick', amount: 1 },
+    ]);
+  });
+
+  //endpack is not an action users can choose, the backend automatically adds to the end of each pack
+  const validLastActions: DraftAction[] = ['pick', 'pickrandom', 'trash', 'trashrandom', 'endpack'];
+
+  it.each(validLastActions)('No changes for a %s last step', (lastAction) => {
+    const steps: DraftStep[] = [
+      { action: 'pick', amount: 1 },
+      { action: 'pass', amount: null },
+      { action: 'pick', amount: 1 },
+      { action: lastAction, amount: null },
+    ];
+
+    const normalizedSteps = normalizeDraftSteps(steps);
+    expect(normalizedSteps.length).toEqual(4);
+    expect(normalizedSteps).toEqual([
+      { action: 'pick', amount: 1 },
+      { action: 'pass', amount: null },
+      { action: 'pick', amount: 1 },
+      { action: lastAction, amount: null },
+    ]);
+  });
+});
+
+describe('normalizeDraftFormatSteps', () => {
+  it('Does nothing when steps are null', () => {
+    const format = createMockDraftFormat({
+      packs: [
+        {
+          slots: ['*', '*'],
+          steps: null,
+        },
+        {
+          slots: ['*'],
+          steps: null,
+        },
+      ],
+    });
+
+    const normalizedFormat = normalizeDraftFormatSteps(format);
+    expect(normalizedFormat).toEqual(format);
+  });
+
+  it('Normalizes steps that end in pass', () => {
+    const format = createMockDraftFormat({
+      packs: [
+        {
+          slots: ['*'],
+          steps: [
+            { action: 'pick', amount: 1 },
+            { action: 'pass', amount: null },
+          ],
+        },
+        {
+          slots: ['*', '*'],
+          steps: [
+            { action: 'pick', amount: 1 },
+            { action: 'pass', amount: null },
+            { action: 'pick', amount: 2 },
+          ],
+        },
+        {
+          slots: ['*'],
+          steps: [
+            { action: 'pick', amount: 1 },
+            { action: 'pass', amount: null },
+          ],
+        },
+      ],
+    });
+
+    const normalizedFormat = normalizeDraftFormatSteps(format);
+    expect(normalizedFormat.packs[0].steps).toEqual([{ action: 'pick', amount: 1 }]);
+    expect(normalizedFormat.packs[1].steps).toEqual([
+      { action: 'pick', amount: 1 },
+      { action: 'pass', amount: null },
+      { action: 'pick', amount: 2 },
+    ]);
+    expect(normalizedFormat.packs[2].steps).toEqual([{ action: 'pick', amount: 1 }]);
+  });
+});

--- a/tests/cube/draft/draftutils.test.ts
+++ b/tests/cube/draft/draftutils.test.ts
@@ -252,6 +252,52 @@ describe('getErrorsInFormat', () => {
     expect(result).toContain('Pack 1 has 2 slots but has steps to pick or trash 1 cards.');
     expect(result?.length).toBe(3);
   });
+
+  it('handles null for amount in a non-pass step', () => {
+    const format = createMockDraftFormat({
+      title: 'Foobar',
+      defaultSeats: 4,
+      packs: [
+        {
+          slots: ['*', '*'],
+          steps: [
+            { action: 'pick', amount: 2 },
+            { action: 'pass', amount: null },
+            { action: 'pick', amount: null },
+          ],
+        },
+      ],
+    });
+    const result = getErrorsInFormat(format);
+    expect(result).toContain('Pack 1 has 2 slots but has steps to pick or trash 3 cards.');
+    expect(result?.length).toBe(1);
+  });
+
+  it('handles null steps', () => {
+    const format = createMockDraftFormat({
+      title: 'Foobar',
+      defaultSeats: 4,
+      packs: [
+        {
+          slots: ['*', '*', '*'],
+          steps: [
+            { action: 'pick', amount: 1 },
+            { action: 'pass', amount: null },
+            { action: 'pick', amount: 1 },
+          ],
+        },
+        {
+          slots: ['*', '*'],
+          //@ts-expect-error -- Steps can be an array or null, the array shouldn't contain null. But this cases gets to full coverage
+          steps: [null, null, null],
+        },
+      ],
+    });
+    const result = getErrorsInFormat(format);
+    expect(result).toContain('Pack 1 has 3 slots but has steps to pick or trash 2 cards.');
+    expect(result).toContain('Pack 2 has 2 slots but has steps to pick or trash 0 cards.');
+    expect(result?.length).toBe(2);
+  });
 });
 
 describe('buildDefaultSteps', () => {


### PR DESCRIPTION
# Problem
If the last step of a pack is "pass" the draft cannot proceed. When building the step queue from the pack steps, after each pack there is an "endpack" step added which is what swaps to the next pack.

# Solution
As discussed in Discord we want to:
a) Validate custom drafts cannot be saved with a "pass" as the last step in a pack
b) Fix (normalize) custom draft formats when loaded, so a bad state isn't used to create a draft

# Testing
In the master branch I setup a couple of draft formats for a cube where the last step is a "pass".
Lots of unit tests added to help prevent regressions in the future.

## Before

Gif of what happens when getting to the end of pack 1 on master and gets stuck on the last "pass" step.
![old-pack-ending-pass-stalls-draft](https://github.com/user-attachments/assets/3c638467-f8fb-43b7-b0a6-731972ca2e08)


Image of the format stored as loaded into the playtest page, where you can see the last "pass" step.
![old-ending-pass-steps-stored](https://github.com/user-attachments/assets/8674684f-f4df-4069-86cf-3b99e0e37bc7)

Same thing but looking direct at dynamo content.
![custom-draft-with-ending-pass-step-stored](https://github.com/user-attachments/assets/30437354-38d1-414e-887e-a49f60dd749a)

Custom draft format UI not highlighting the error of having a "pass" as the last step in a pack.
![old-ending-pass-step-not-marked-as-invalid](https://github.com/user-attachments/assets/a6f9dc59-7d32-4318-b039-6980557af652)


## After

New validation error for a pack ending in a "pass" step.
![new-custom-draft-validation-on-ending-pass-step](https://github.com/user-attachments/assets/9a9c2cf4-ec30-41c8-a5f5-d2b3b5918a2c)

And after fixing that:
![new-custom-draft-add-step-is-valid](https://github.com/user-attachments/assets/b0c87002-2e56-4c40-8b37-6d11fc82eb9d)

Additionally now the "Add step" button adds pass then pick (instead of pick then pass) which prevents it from being an immediate validation error in relation to the last step being a valid action.
![new-custom-format-add-slot-then-add-step-is-valid](https://github.com/user-attachments/assets/4fdc063a-6bbd-423b-92e7-6ae6ec7e7d13)

Gif of a draft using a custom format that is saved with a last step of "pass", but the normalization on read fixed that.
![new-draft-doesnt-get-stuck-at-end-of-pack](https://github.com/user-attachments/assets/73da85c4-711e-499c-93a7-540f1374e075)

Due to the normalization on load, editing the custom draft doesn't show the last step pass and then saving the format will fix the stored version to a good state.
![new-pack-normalization-fixes-last-step-pass-on-next-save](https://github.com/user-attachments/assets/cd49ebe8-800e-4115-a679-177120262212)
