### PR TITLE
Improvements to the mobile viewport size so modals fit better (fingers crossed)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,7 +4,8 @@
 
 When it comes to manually testing Frontend components, the key areas of focus are:
 
-1. Test in both Desktop and Mobile browsers (browser dev tools helps a lot here). Doubly important when the UI contains any responsive aspects
+1. Test in both Desktop and Mobile browsers (browser dev tools helps a lot here). Doubly important when the UI contains any responsive aspects.
+   1. **NOTE:** When doing anything with view port height, using actual mobile devices is better since dev tools emulation doesn't do things like notches, address bars, or OS buttons.
 2. Test in multiple modern browsers (both desktop and mobile)
 3. Compare and contrast (with screenshots/videos) the before and after UI differences to include in the PR
 

--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -2770,7 +2770,7 @@ img.mana-symbol-sm {
 }
 
 .max-h-95\/100 {
-  max-height: 95vh;
+  max-height: 95dvh;
 }
 
 @media (min-width: 640px) {

--- a/src/client/components/base/Modal.tsx
+++ b/src/client/components/base/Modal.tsx
@@ -71,7 +71,7 @@ export const Modal: React.FC<ModalProps> = ({
                       'relative transform rounded-md border border-border bg-bg-accent text-left text-text shadow-xl transition-all w-full flex flex-col',
                       {
                         /* To be scrollable the modal must have a maximum height, and here we make it the whole viewport (minus some margin basically)
-                         * 95% of the view port height (vh units) works well for both desktop and mobile
+                         * 95% of the dynamic view port height (dvh units) works well for both desktop and mobile
                          */
                         'overflow-hidden max-h-95/100': scrollable,
                       },

--- a/src/client/components/card/CardModal.tsx
+++ b/src/client/components/card/CardModal.tsx
@@ -393,89 +393,87 @@ const CardModal: React.FC<CardModalProps> = ({
           <Spinner lg />
         )}
       </ModalBody>
-      <ModalFooter>
-        {canEdit && (
-          <>
-            {card.markedForDelete ? (
-              <>
-                <Button
-                  color="primary"
-                  block
-                  className="items-center text-sm"
-                  onClick={() => revertRemove(card.removeIndex!, card.board!)}
-                >
-                  Revert Removal
-                </Button>
-                &nbsp;
-              </>
-            ) : (
-              <>
-                <Button
-                  color="danger"
-                  block
-                  className="items-center text-sm"
-                  onClick={() => {
-                    removeCard(card.index!, card.board!);
-                    setOpen(false);
-                  }}
-                >
-                  Remove
-                </Button>
-                &nbsp;
-                {card.board === 'mainboard' ? (
-                  <>
-                    <Button
-                      color="accent"
-                      block
-                      className="items-center text-sm"
-                      onClick={() => {
-                        moveCard(card.index!, card.board!, 'maybeboard');
-                        setOpen(false);
-                      }}
-                    >
-                      To Maybeboard
-                    </Button>
-                    &nbsp;
-                  </>
-                ) : (
-                  <>
-                    <Button
-                      color="accent"
-                      block
-                      className="items-center text-sm"
-                      onClick={() => {
-                        moveCard(card.index!, card.board!, 'mainboard');
-                        setOpen(false);
-                      }}
-                    >
-                      To Mainboard
-                    </Button>
-                    &nbsp;
-                  </>
-                )}
-              </>
-            )}
-            {card.editIndex !== undefined && (
-              <>
-                <Button
-                  color="primary"
-                  block
-                  className="items-center text-sm"
-                  onClick={() => {
-                    if (card.editIndex !== undefined && card.board !== undefined) {
-                      revertEdit(card.editIndex, card.board);
-                    }
-                  }}
-                >
-                  Revert Edit
-                </Button>
-                &nbsp;
-              </>
-            )}
-            &nbsp;
-          </>
-        )}
-      </ModalFooter>
+      {canEdit && (
+        <ModalFooter>
+          {card.markedForDelete ? (
+            <>
+              <Button
+                color="primary"
+                block
+                className="items-center text-sm"
+                onClick={() => revertRemove(card.removeIndex!, card.board!)}
+              >
+                Revert Removal
+              </Button>
+              &nbsp;
+            </>
+          ) : (
+            <>
+              <Button
+                color="danger"
+                block
+                className="items-center text-sm"
+                onClick={() => {
+                  removeCard(card.index!, card.board!);
+                  setOpen(false);
+                }}
+              >
+                Remove
+              </Button>
+              &nbsp;
+              {card.board === 'mainboard' ? (
+                <>
+                  <Button
+                    color="accent"
+                    block
+                    className="items-center text-sm"
+                    onClick={() => {
+                      moveCard(card.index!, card.board!, 'maybeboard');
+                      setOpen(false);
+                    }}
+                  >
+                    To Maybeboard
+                  </Button>
+                  &nbsp;
+                </>
+              ) : (
+                <>
+                  <Button
+                    color="accent"
+                    block
+                    className="items-center text-sm"
+                    onClick={() => {
+                      moveCard(card.index!, card.board!, 'mainboard');
+                      setOpen(false);
+                    }}
+                  >
+                    To Mainboard
+                  </Button>
+                  &nbsp;
+                </>
+              )}
+            </>
+          )}
+          {card.editIndex !== undefined && (
+            <>
+              <Button
+                color="primary"
+                block
+                className="items-center text-sm"
+                onClick={() => {
+                  if (card.editIndex !== undefined && card.board !== undefined) {
+                    revertEdit(card.editIndex, card.board);
+                  }
+                }}
+              >
+                Revert Edit
+              </Button>
+              &nbsp;
+            </>
+          )}
+          &nbsp;
+        </ModalFooter>
+      )}
     </Modal>
   );
 };

--- a/src/client/css/stylesheet.css
+++ b/src/client/css/stylesheet.css
@@ -348,5 +348,5 @@ img.mana-symbol-sm {
 }
 
 .max-h-95\/100 {
-  max-height: 95vh;
+  max-height: 95dvh;
 }


### PR DESCRIPTION
Switched to dvh units as dynamic view height, which is supposed to handle when the viewport isn't fully height due to things like the OS buttons or notches.

Also made it so the footer of the CardModal only shows when you can edit, as otherwise its just a weird empty space.

# Testing

## Desktop

### Before

Desktop Edge not logged in, the footer even though empty makes the body scrollable.
![image](https://github.com/user-attachments/assets/acd3d3e7-bbdb-445c-a728-f08fc9cd18df)

### After

Desktop Edge not logged in, by removing the footer still scrollable and sized the same, though looks a tad different.
![image](https://github.com/user-attachments/assets/977a8ed0-3b98-49c7-b332-1efd2ddc114a)

## Mobile 
Ran out of free credits in things like Browserstack nor could I test everything, but what I saw was promising.

### Before

In some browsers the buttons didn't show as the modal didn't really shrink to fit the view port. Which wasn't that different than before given on mobile it stacks left then right column, and the buttons were all at the end of the right column.

Android Edge not logged in:
![old-android-edge-not-logged-in](https://github.com/user-attachments/assets/55b37220-5712-4acc-854d-b2bde7076265)

iOS Chrome not logged in:
![old-ios-chrome-not-logging-in](https://github.com/user-attachments/assets/8888f8af-577f-4825-a0b8-23eb6e74f0e7)

iOS Safari not logged in:
![old-ios-safari-not-logging-in](https://github.com/user-attachments/assets/4450a735-78ce-4a6c-93c5-4768caa75055)

### After

Now the modal bottom is clearly visible above the end of the viewport, and if logged in the action buttons are visible.

iOS Safari logged in:
![ios-safari-logged-in](https://github.com/user-attachments/assets/a6c14581-75d8-4a9f-b31d-065a502aff08)

iOS Safari not logged in:
![ios-safari-not-logged-in](https://github.com/user-attachments/assets/f55c3303-b8d4-4d9c-b8d7-c0bb83cc74d3)

Android Chrome logged in:
![new-android-chrome-logged-in](https://github.com/user-attachments/assets/78670c34-406a-45bc-acbb-5fcf3165c7b5)

Android Chrome not logged in:
![new-android-chrome-not-logging-in](https://github.com/user-attachments/assets/51c10fa2-4d00-441b-a4bd-571e1b8a6744)
