### PR TITLE
Fix matched cards in CSV upload not tracked when user is asked to correct misidentified cards

### DIFF
--- a/src/routes/cube/helper.js
+++ b/src/routes/cube/helper.js
@@ -26,7 +26,7 @@ async function updateCubeAndBlog(req, res, cube, cards, cardsToWrite, changelog,
         canEdit: true,
         cubeID: req.params.id,
         missing,
-        added: added.map((add) => add.scryfall_id),
+        added: added.map((add) => add.cardID || add.scryfall_id),
       });
     }
 
@@ -122,7 +122,8 @@ async function bulkUpload(req, res, list, cube) {
       mainboard.push(...newCards);
       maybeboard.push(...newMaybe);
 
-      added.concat(newCards, newMaybe);
+      //Replaced concat with push b/c concat returns new array, and added is const so can't reassign
+      added.push(...newCards, ...newMaybe);
     } else {
       // upload is in TXT format
       for (const itemUntrimmed of lines) {

--- a/tests/cube/helper/uploads.test.ts
+++ b/tests/cube/helper/uploads.test.ts
@@ -1,0 +1,404 @@
+import { FeedTypes } from '../../../src/datatypes/Feed';
+import Blog from '../../../src/dynamo/models/blog';
+import Changelog from '../../../src/dynamo/models/changelog';
+import Cube from '../../../src/dynamo/models/cube';
+import Feed from '../../../src/dynamo/models/feed';
+import { bulkUpload } from '../../../src/routes/cube/helper';
+import * as carddb from '../../../src/util/carddb';
+import * as cubefn from '../../../src/util/cubefn';
+import * as render from '../../../src/util/render';
+import * as util from '../../../src/util/util';
+import { createCardDetails, createCube, createUser } from '../../test-utils/data';
+
+jest.mock('../../../src/dynamo/models/cube');
+jest.mock('../../../src/dynamo/models/blog');
+jest.mock('../../../src/dynamo/models/changelog');
+jest.mock('../../../src/dynamo/models/feed');
+jest.mock('../../../src/util/carddb');
+jest.mock('../../../src/util/cubefn');
+jest.mock('../../../src/util/render');
+jest.mock('../../../src/util/util');
+
+describe('Bulk Upload', () => {
+  const flashMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('CSV Upload', () => {
+    it('should handle CSV upload with valid cards. Minimum 4 commas in the first line to detect as CSV', async () => {
+      const owner = createUser({ following: ['user1'] });
+      const cube = createCube({ owner });
+
+      const csvContent = 'name,CMC,Type,Color,Rarity\nLightning Bolt,1,Instant,R,C';
+
+      //No defined type for this
+      const mockCard = {
+        name: 'Lightning Bolt',
+        cmc: 1,
+        type_line: 'Instant',
+        colors: ['R'],
+        addedTmsp: new Date().valueOf().toString(),
+        cardID: 'abcdefg-hijklmn',
+      };
+
+      (Cube.getCards as jest.Mock).mockResolvedValue({ mainboard: [], maybeboard: [] });
+      (Changelog.put as jest.Mock).mockResolvedValue('changelog-id');
+      (Blog.put as jest.Mock).mockResolvedValue('blog-id');
+      (cubefn.CSVtoCards as jest.Mock).mockReturnValue({ newCards: [mockCard], newMaybe: [], missing: [] });
+
+      await bulkUpload({ user: owner, flash: flashMock, params: { id: cube.id } }, {}, csvContent, cube);
+
+      expect(Cube.updateCards).toHaveBeenCalledWith(cube.id, {
+        mainboard: [mockCard],
+        maybeboard: [],
+      });
+      expect(Changelog.put).toHaveBeenCalledWith(
+        {
+          mainboard: {
+            adds: [{ cardID: 'abcdefg-hijklmn' }],
+          },
+        },
+        cube.id,
+      );
+      expect(Blog.put).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: owner.id,
+          cube: cube.id,
+          title: expect.stringContaining('Cube Bulk Import'),
+          changelist: 'changelog-id',
+        }),
+      );
+      expect(Feed.batchPut).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: 'blog-id',
+            to: 'user1',
+            type: FeedTypes.BLOG,
+          }),
+        ]),
+      );
+      expect(flashMock).toHaveBeenCalledWith('success', 'All cards successfully added.');
+    });
+
+    it('should add valid cards in the CSV to existing cards in the cube', async () => {
+      const owner = createUser({ following: ['user1'] });
+      const cube = createCube({ owner });
+
+      const csvContent = 'name,CMC,Type,Color,Rarity\nLightning Bolt,1,Instant,R,C';
+
+      //No defined type for this
+      const mockCard = {
+        name: 'Lightning Bolt',
+        cmc: 1,
+        type_line: 'Instant',
+        colors: ['R'],
+        addedTmsp: new Date().valueOf().toString(),
+        cardID: 'abcdefg-hijklmn',
+      };
+
+      const mockMainboardCard = {
+        name: 'Ancestral Recall',
+        cmc: 1,
+        type_line: 'Instant',
+        colors: ['U'],
+        addedTmsp: '1742649530000',
+        cardID: 'red-blue',
+      };
+
+      const mockMaybeboardCard = {
+        name: 'Healing Salve',
+        cmc: 1,
+        type_line: 'Instant',
+        colors: ['W'],
+        addedTmsp: '1742649580000',
+        cardID: 'bad-boy',
+      };
+
+      (Cube.getCards as jest.Mock).mockResolvedValue({
+        mainboard: [mockMainboardCard],
+        maybeboard: [mockMaybeboardCard],
+      });
+      (Changelog.put as jest.Mock).mockResolvedValue('changelog-id');
+      (Blog.put as jest.Mock).mockResolvedValue('blog-id');
+      (cubefn.CSVtoCards as jest.Mock).mockReturnValue({ newCards: [mockCard], newMaybe: [], missing: [] });
+
+      await bulkUpload({ user: owner, flash: flashMock, params: { id: cube.id } }, {}, csvContent, cube);
+
+      expect(Cube.updateCards).toHaveBeenCalledWith(cube.id, {
+        mainboard: [mockMainboardCard, mockCard],
+        maybeboard: [mockMaybeboardCard],
+      });
+      expect(Changelog.put).toHaveBeenCalledWith(
+        {
+          mainboard: {
+            adds: [{ cardID: 'abcdefg-hijklmn' }],
+          },
+        },
+        cube.id,
+      );
+      expect(Blog.put).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: owner.id,
+          cube: cube.id,
+          title: expect.stringContaining('Cube Bulk Import'),
+          changelist: 'changelog-id',
+        }),
+      );
+      expect(Feed.batchPut).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: 'blog-id',
+            to: 'user1',
+            type: FeedTypes.BLOG,
+          }),
+        ]),
+      );
+      expect(flashMock).toHaveBeenCalledWith('success', 'All cards successfully added.');
+    });
+
+    it('should handle CSV upload with missing cards', async () => {
+      const owner = createUser();
+      const cube = createCube({ owner });
+      const csvContent = 'name,CMC,Type,Color,Rarity\nNotARealCard,1,Instant,R,C';
+
+      (Cube.getCards as jest.Mock).mockResolvedValue({ mainboard: [], maybeboard: [] });
+      (cubefn.CSVtoCards as jest.Mock).mockReturnValue({
+        newCards: [],
+        newMaybe: [],
+        missing: ['NotARealCard'],
+      });
+
+      await bulkUpload({ user: owner, flash: flashMock, params: { id: cube.id } }, {}, csvContent, cube);
+
+      expect(render.render).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        'BulkUploadPage',
+        expect.objectContaining({
+          added: [],
+          missing: expect.arrayContaining(['NotARealCard']),
+        }),
+      );
+    });
+
+    it('should handle CSV upload with added and missing cards', async () => {
+      const owner = createUser();
+      const cube = createCube({ owner });
+      const csvContent = 'name,CMC,Type,Color,Rarity\nNotARealCard,1,Instant,R,C\nLightning Bolt,1,Instant,R,C';
+
+      const mockCard = {
+        name: 'Lightning Bolt',
+        cmc: 1,
+        type_line: 'Instant',
+        colors: ['R'],
+        addedTmsp: new Date().valueOf().toString(),
+        cardID: 'abcdefg-hijklmn',
+      };
+
+      (Cube.getCards as jest.Mock).mockResolvedValue({ mainboard: [], maybeboard: [] });
+      (cubefn.CSVtoCards as jest.Mock).mockReturnValue({
+        newCards: [mockCard],
+        newMaybe: [],
+        missing: ['NotARealCard'],
+      });
+
+      await bulkUpload({ user: owner, flash: flashMock, params: { id: cube.id } }, {}, csvContent, cube);
+
+      expect(render.render).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        'BulkUploadPage',
+        expect.objectContaining({
+          added: ['abcdefg-hijklmn'],
+          missing: expect.arrayContaining(['NotARealCard']),
+        }),
+      );
+    });
+  });
+
+  describe('Text Upload', () => {
+    const mockAddCardToBoardImpl = (
+      idToCardMap: Map<string, any>,
+    ): ((board: any, _cube: any, cardDetails: any) => void) => {
+      return (board, _cube, cardDetails) => {
+        const id = cardDetails.scryfall_id;
+        if (idToCardMap.has(id)) {
+          board.push(idToCardMap.get(id));
+        }
+      };
+    };
+
+    it('should handle text upload with valid cards', async () => {
+      const owner = createUser({ following: ['user1'] });
+      const cube = createCube({ owner });
+      const textContent = '2x Lightning Bolt\nDark Ritual';
+
+      const lbDetails = createCardDetails({
+        name: 'Lightning Bolt',
+        scryfall_id: 'bolt-id',
+      });
+
+      const mockLbCard = {
+        tags: [],
+        status: 'Owned',
+        colors: lbDetails.color_identity,
+        cmc: lbDetails.cmc,
+        cardID: lbDetails.scryfall_id,
+        type_line: lbDetails.type,
+        addedTmsp: new Date(),
+        finish: 'Non-foil',
+      };
+
+      const drDetails = createCardDetails({
+        name: 'Dark Ritual',
+        scryfall_id: 'dark-rit',
+      });
+
+      const mockDrCard = {
+        tags: [],
+        status: 'Owned',
+        colors: drDetails.color_identity,
+        cmc: drDetails.cmc,
+        cardID: drDetails.scryfall_id,
+        type_line: drDetails.type,
+        addedTmsp: new Date(),
+        finish: 'Non-foil',
+      };
+
+      (Cube.getCards as jest.Mock).mockResolvedValue({ mainboard: [], maybeboard: [] });
+      (carddb.getMostReasonable as jest.Mock).mockReturnValueOnce(lbDetails);
+      (carddb.getMostReasonable as jest.Mock).mockReturnValueOnce(drDetails);
+      (carddb.cardFromId as jest.Mock).mockReturnValueOnce(lbDetails);
+      (carddb.cardFromId as jest.Mock).mockReturnValueOnce(drDetails);
+      (Changelog.put as jest.Mock).mockResolvedValue('changelog-id');
+      (util.addCardToCube as jest.Mock).mockImplementation(
+        mockAddCardToBoardImpl(
+          new Map([
+            [lbDetails.scryfall_id, mockLbCard],
+            [drDetails.scryfall_id, mockDrCard],
+          ]),
+        ),
+      );
+
+      await bulkUpload({ user: owner, flash: flashMock, params: { id: cube.id } }, {}, textContent, cube);
+
+      expect(Cube.updateCards).toHaveBeenCalledWith(cube.id, {
+        mainboard: [mockLbCard, mockLbCard, mockDrCard],
+        maybeboard: [],
+      });
+      expect(Changelog.put).toHaveBeenCalledWith(
+        {
+          mainboard: {
+            adds: [{ cardID: 'bolt-id' }, { cardID: 'bolt-id' }, { cardID: 'dark-rit' }],
+          },
+        },
+        cube.id,
+      );
+      expect(Blog.put).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: owner.id,
+          cube: cube.id,
+          title: expect.stringContaining('Cube Bulk Import'),
+          changelist: 'changelog-id',
+        }),
+      );
+      expect(Feed.batchPut).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: 'blog-id',
+            to: 'user1',
+            type: FeedTypes.BLOG,
+          }),
+        ]),
+      );
+      expect(flashMock).toHaveBeenCalledWith('success', 'All cards successfully added.');
+    });
+
+    //TODO: Expand on
+    it('should handle text upload with set specifications', async () => {
+      const owner = createUser({ following: ['user1'] });
+      const cube = createCube({ owner });
+      const textContent = 'Lightning Bolt (LEA) 123';
+
+      (Cube.getCards as jest.Mock).mockResolvedValue({ mainboard: [], maybeboard: [] });
+      (carddb.getIdsFromName as jest.Mock).mockReturnValue(['bolt-id']);
+      (carddb.cardFromId as jest.Mock).mockReturnValue({
+        set: 'lea',
+        collector_number: '123',
+        name: 'Lightning Bolt',
+      });
+      (Changelog.put as jest.Mock).mockResolvedValue('changelog-id');
+
+      await bulkUpload({ user: owner, flash: flashMock, params: { id: cube.id } }, {}, textContent, cube);
+
+      expect(Cube.updateCards).toHaveBeenCalled();
+      expect(flashMock).toHaveBeenCalledWith('success', 'All cards successfully added.');
+    });
+
+    it('should handle text upload with missing cards', async () => {
+      const owner = createUser({ following: ['user1'] });
+      const cube = createCube({ owner });
+      const textContent = 'NotARealCard\nAlsoNotReal';
+
+      (Cube.getCards as jest.Mock).mockResolvedValue({ mainboard: [], maybeboard: [] });
+      (carddb.getMostReasonable as jest.Mock).mockReturnValue(null);
+
+      await bulkUpload({ user: owner, flash: flashMock, params: { id: cube.id } }, {}, textContent, cube);
+
+      expect(render.render).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        'BulkUploadPage',
+        expect.objectContaining({
+          missing: expect.arrayContaining(['NotARealCard', 'AlsoNotReal']),
+        }),
+      );
+    });
+
+    it('should handle text upload with added and missing cards', async () => {
+      const owner = createUser({ following: ['user1'] });
+      const cube = createCube({ owner });
+      const textContent = 'Healing Salve\nAlsoNotReal';
+
+      const hsDetails = createCardDetails({
+        name: 'Healing Salve',
+        scryfall_id: 'healing-salve',
+      });
+
+      const mockHsCard = {
+        tags: [],
+        status: 'Owned',
+        colors: hsDetails.color_identity,
+        cmc: hsDetails.cmc,
+        cardID: hsDetails.scryfall_id,
+        type_line: hsDetails.type,
+        addedTmsp: new Date(),
+        finish: 'Non-foil',
+      };
+
+      (Cube.getCards as jest.Mock).mockResolvedValue({ mainboard: [], maybeboard: [] });
+      (carddb.getMostReasonable as jest.Mock).mockReturnValueOnce(hsDetails);
+      (carddb.getMostReasonable as jest.Mock).mockReturnValueOnce(null);
+      (carddb.cardFromId as jest.Mock).mockReturnValueOnce(hsDetails);
+      (carddb.cardFromId as jest.Mock).mockReturnValueOnce(null);
+
+      (util.addCardToCube as jest.Mock).mockImplementation(
+        mockAddCardToBoardImpl(new Map([[hsDetails.scryfall_id, mockHsCard]])),
+      );
+
+      await bulkUpload({ user: owner, flash: flashMock, params: { id: cube.id } }, {}, textContent, cube);
+
+      expect(render.render).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        'BulkUploadPage',
+        expect.objectContaining({
+          added: ['healing-salve'],
+          missing: expect.arrayContaining(['AlsoNotReal']),
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
# Problem
Two linked problems reported:
a) One name of a split cards, such as Collision // Colossus, is not matched by the CSV upload
b) When there are misidentified cards in the CSV upload the correctly identified cards aren't populated on the fixing screen, thus losing the work

# Solution
I did not touch problem a). The logic of upload_cards.ts doesn't added each part of a split card name to the nameToId map, and I am unsure if that would be useful.

For b), identified a couple minor errors in the code logic that prevented the identified cards from showing when the user is asked to fix the misidentified cards.
Issues:
1. `added.concat()` did nothing as that returns a new array but it wasn't assigned
2. Between the CSV and Text parts of bulkUpload we can have either cardID or scryfall_id respectively for the correctly identified cards, but were only mapping using scryfall_id for the UI. If added was fixed but this wasn't, you'd get a bunch of "+ Undefined" in the added block

# Testing
Added unit tests to cover the bulkUpload / updateCubeAndBlog logic in helper.js. I used Claude 3.5 AI to start, massaged with more cases and details on expectations, then used it again to consolidate and make concise.

## Before

When a card wasn't identified its name was shown, but the correctly identified cards were not populated.
![old-matched-cards-not-shown-in-ui](https://github.com/user-attachments/assets/a6bd606e-6679-431e-9093-41b0674280cf)
Then if you saved without fixing the card, nothing was saved.
![old-saving-has-no-changes](https://github.com/user-attachments/assets/751bfc38-8112-4a64-b6e7-cbe1860dea09)

If you did that again but searched for the name the search gives you "Collision // Colossus".
![old-found-missing-and-added](https://github.com/user-attachments/assets/bf524e30-3c9a-496c-8159-ffb1637b3f1c)
Then if you add that and save, you still only get the one card in the cube and all the rest of the CSV not.
![old-corrected-missing-added](https://github.com/user-attachments/assets/61e4f3af-8cbb-47b7-9ecd-49a530ef14ae)

## After
The identified cards are shown in the added section already
![new-matched-cards-showing-in-ui](https://github.com/user-attachments/assets/679dcceb-247a-4d92-ac8e-a5cb61bcb32f)

Then can searched collision giving "Collision // Colossus" and add to the list
![new-found-missing-card-and-added](https://github.com/user-attachments/assets/08261879-f48c-4d61-b185-99e6935bf261)

Then saving adds all the cards to the cube.
![new-cube-after-save](https://github.com/user-attachments/assets/4e6258fb-db98-49ea-93ba-9ef92380bf45)
