### PR TITLE
Fix blog post redirection on edit/delete if the cube is deleted

### DIFF
--- a/src/router/routes/cube/blog.ts
+++ b/src/router/routes/cube/blog.ts
@@ -177,7 +177,7 @@ export const deleteBlogHandler = async (req: Request, res: Response) => {
     if (!user) {
       req.flash('danger', 'Please login to delete a blog post.');
 
-      return redirect(req, res, `/cube/blog/${encodeURIComponent(id)}`);
+      return redirect(req, res, `/cube/blog/blogpost/${encodeURIComponent(id)}`);
     }
 
     const blog = await Blog.getById(id);

--- a/src/router/routes/cube/blog.ts
+++ b/src/router/routes/cube/blog.ts
@@ -22,7 +22,8 @@ const getRedirectUrl = async (cubeId: string): Promise<string> => {
 
 const getRedirectUrlForCube = async (cube: CubeType): Promise<string> => {
   if (cube) {
-    return `/cube/blog/${encodeURIComponent(cube.id)}`;
+    const id = cube.shortId || cube.id;
+    return `/cube/blog/${encodeURIComponent(id)}`;
   } else {
     return '/dashboard';
   }

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -309,6 +309,33 @@ function getBaseUrl() {
   return (process.env?.HTTP_ONLY === 'true' ? 'http://' : 'https://') + process.env.DOMAIN;
 }
 
+/*
+ * Returns the root relative path, based on the referrer header. Since referrer header can be manipulated,
+ * we only return a non-null value if it is not to another domain
+ */
+const getSafeReferrer = (req /* Request */) => {
+  const referrer = req.header('Referrer') || null;
+
+  if (referrer === null) {
+    return null;
+  }
+
+  //Use our domain as the base in case the referrer is relative somehow
+  const url = URL.parse(referrer, getBaseUrl());
+  if (!url) {
+    return null;
+  }
+
+  //Because of us setting the base in the parsing, we can ensure the host isn't another site.
+  //Is OK with www. version of the site
+  if (!(url.host === process.env.DOMAIN || url.host === `www.${process.env.DOMAIN}`)) {
+    return null;
+  }
+
+  //Only if its a valid URL and isn't to some other website, then return the pathname (so no query string etc)
+  return url.pathname;
+};
+
 module.exports = {
   shuffle(array, seed) {
     if (!seed) {
@@ -351,4 +378,5 @@ module.exports = {
   mapNonNull,
   validateEmail,
   getBaseUrl,
+  getSafeReferrer,
 };

--- a/tests/cube/blog/api.test.ts
+++ b/tests/cube/blog/api.test.ts
@@ -328,7 +328,7 @@ describe('Delete a Blog Post', () => {
     await call(deleteBlogHandler).withFlash(flashMock).withParams({ id: 'blog-id' }).send();
 
     expect(flashMock).toHaveBeenCalledWith('danger', 'Please login to delete a blog post.');
-    expect(util.redirect).toHaveBeenCalledWith(expect.anything(), expect.anything(), '/cube/blog/blog-id');
+    expect(util.redirect).toHaveBeenCalledWith(expect.anything(), expect.anything(), '/cube/blog/blogpost/blog-id');
   });
 
   it(`should return a 404 if blog post doesn't exists`, async () => {

--- a/tests/cube/blog/api.test.ts
+++ b/tests/cube/blog/api.test.ts
@@ -53,6 +53,8 @@ describe('Create Blog Post', () => {
   });
 
   it('should fail if the blog title is too short', async () => {
+    const cube = createCube({ id: 'cube-id' });
+    (Cube.getById as jest.Mock).mockResolvedValue(cube);
     await call(createBlogHandler).withFlash(flashMock).withParams({ id: 'cube-id' }).withBody({ title: 'Hi' }).send();
 
     expect(util.redirect).toHaveBeenCalledWith(expect.anything(), expect.anything(), '/cube/blog/cube-id');
@@ -188,6 +190,8 @@ describe('Edit Blog Post', () => {
   });
 
   it('should 404 when trying to edit a missing blog post', async () => {
+    const cube = createCube({ id: 'cube-id' });
+    (Cube.getById as jest.Mock).mockResolvedValue(cube);
     (Blog.getUnhydrated as jest.Mock).mockResolvedValue(undefined);
 
     await call(createBlogHandler)
@@ -201,6 +205,8 @@ describe('Edit Blog Post', () => {
   });
 
   it('should update a blog post', async () => {
+    const cube = createCube({ id: 'cube-id' });
+    (Cube.getById as jest.Mock).mockResolvedValue(cube);
     const user = createUser();
     const blog = createBlogPost({ owner: user, title: 'My blog title' });
 
@@ -353,6 +359,8 @@ describe('Delete a Blog Post', () => {
   });
 
   it('should delete a blog and return to the cube', async () => {
+    const cube = createCube({ id: 'cube-id' });
+    (Cube.getById as jest.Mock).mockResolvedValue(cube);
     const owner = createUser({ id: 'blogger' });
     const blog = createBlogPost({ owner, cube: 'cube-id' });
 
@@ -365,6 +373,7 @@ describe('Delete a Blog Post', () => {
     expect(util.redirect).toHaveBeenCalledWith(expect.anything(), expect.anything(), '/cube/blog/cube-id');
   });
 
+  //Blog posts can outlive the cube they belong to
   it('should redirect to dashboard when deleting a blog post for non-existent cube', async () => {
     const owner = createUser({ id: 'blogger' });
     const blog = createBlogPost({ owner, cube: 'non-existent-cube' });

--- a/tests/utils/utils.test.ts
+++ b/tests/utils/utils.test.ts
@@ -1,6 +1,105 @@
 import { normalizeName } from '../../src/client/utils/cardutil';
 import util from '../../src/util/util';
 
+// ...existing code...
+
+describe('getSafeReferrer', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
+    process.env.DOMAIN = 'cubecobra.com';
+    process.env.HTTP_ONLY = 'false';
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+  });
+
+  it('returns null when no referrer header exists', () => {
+    const req = {
+      header: jest.fn().mockReturnValue(null),
+    };
+
+    const result = util.getSafeReferrer(req);
+    expect(result).toBeNull();
+    expect(req.header).toHaveBeenCalledWith('Referrer');
+  });
+
+  it('returns null for external domain referrer', () => {
+    const req = {
+      header: jest.fn().mockReturnValue('https://example.com/some/path'),
+    };
+
+    const result = util.getSafeReferrer(req);
+    expect(result).toBeNull();
+  });
+
+  it('returns pathname for valid internal referrer', () => {
+    const req = {
+      header: jest.fn().mockReturnValue('https://cubecobra.com/cube/view/123'),
+    };
+
+    const result = util.getSafeReferrer(req);
+    expect(result).toBe('/cube/view/123');
+  });
+
+  it('handles non-root relative urls', () => {
+    const req = {
+      header: jest.fn().mockReturnValue('not-a-url'),
+    };
+
+    const result = util.getSafeReferrer(req);
+    expect(result).toBe('/not-a-url');
+  });
+
+  it('allows the www subdomain of the app', () => {
+    const req = {
+      header: jest.fn().mockReturnValue('https://www.cubecobra.com/cube/view/123'),
+    };
+
+    const result = util.getSafeReferrer(req);
+    expect(result).toBe('/cube/view/123');
+  });
+
+  it('ignores query parameters and hash', () => {
+    const req = {
+      header: jest.fn().mockReturnValue('https://cubecobra.com/cube/view/123?sort=name#top'),
+    };
+
+    const result = util.getSafeReferrer(req);
+    expect(result).toBe('/cube/view/123');
+  });
+
+  it('handles relative URLs correctly', () => {
+    const req = {
+      header: jest.fn().mockReturnValue('/cube/view/123'),
+    };
+
+    const result = util.getSafeReferrer(req);
+    expect(result).toBe('/cube/view/123');
+  });
+
+  it('handles path manipulation urls', () => {
+    const req = {
+      header: jest.fn().mockReturnValue('../cube/../blog/view/123'),
+    };
+
+    const result = util.getSafeReferrer(req);
+    expect(result).toBe('/blog/view/123');
+  });
+
+  it('returns null for different subdomain and relative paths', () => {
+    const req = {
+      header: jest.fn().mockReturnValue('https://example.com/../blog/view/123'),
+    };
+
+    const result = util.getSafeReferrer(req);
+    expect(result).toBeNull();
+  });
+});
+
 describe('turnToTree', () => {
   //Fix the seed for consistency in tests
   const SHUFFLE_SEED = '1742131471000';


### PR DESCRIPTION
# Problem

The user's blog shows blog posts from cubes that are deleted. You cannot go to the post itself (it will 404) but it shows the buttons to edit or delete. Those buttons work, except that they will redirect you to the cube's blog page which will then 404. You see the successful edit/delete but also an error saying the blog post wasn't found.

# Solution
The initial solution was to check if the cube exists or not when deciding where to redirect to, and if the cube doesn't exist anymore redirect to /dashboard so the user can still see the successful action flash.

Then I decided to improve the UX more to return the user to the page they were at when taking the action if possible, else go to /dashboard if the cube doesn't exist. Blog posts can be seen in the following places:
1. The cube's blog
2. The user's blog
3. The blog post itself - Extra check that the post wasn't deleted, as cannot return you to it once it is gone

# Questions/concerns
1. Overall the redirecting back to the page you can from could be more complicated than it is worth
2. The cube blog post view doesn't have any button/link back to the cube blog, which could make navigation annoying
3. Should we allow blog posts that belong to deleted cubes to be accessible on their blog post page? They can be edited and deleted from the user blog already

# Testing

## Before

### Happy cases
Successfully deleting a blog post from the user's blog redirects to the cube blog page:
![old-delete-blog-from-user-blog-redirects-to-cube-blog](https://github.com/user-attachments/assets/56c3e738-329e-44c4-8d50-3f27af1d5dc5)

Successfully deleting a blog post from itself redirects to the cube blog page:
![old-delete-blog-from-itself-redirects-to-cube-blog](https://github.com/user-attachments/assets/ca83dc18-22f7-4770-b226-b233f2ff775b)

Successfully deleting a blog post from the cube blog page, redirects to the same:
![old-delete-blog-redirects-to-cube-blog](https://github.com/user-attachments/assets/41f8c6b8-8521-4b41-86c4-97f16a94fd02)

Successfully editing a blog post from itself redirects to the cube blog page:
![old-edit-blog-from-itself-redirects-to-cube-blog](https://github.com/user-attachments/assets/0011222a-2f93-4056-8b03-b30ef2fa6742)

Successfully editing a blog post from the user's blog redirects to the cube blog page:
![old-edit-blog-from-user-blog-redirects-to-cube-blog](https://github.com/user-attachments/assets/f57e69bb-a1d5-464a-8d3f-68c92e0c3eab)

Successfully editing a blog post from the cube blog page, redirects to the same:
![old-edit-blog-from-cube-blog](https://github.com/user-attachments/assets/37a88bad-1cb5-417f-b5d1-253b6e2d7a90)

### Edge cases

Deleting a blog of a deleted cube gives you both success and fail:
![old-delete-blog-in-deleted-cube-error-page2](https://github.com/user-attachments/assets/91e2f3f6-3d9f-43e9-87fe-5c50f50fc475)

## After

### Happy paths

Creating a blog post from the cube blog:
![new-create-blog-post](https://github.com/user-attachments/assets/3983a92e-831a-4cdf-a70e-0870162edc93)

Editing a blog post from itself returns you there:
![new-edit-blog-post-from-itself](https://github.com/user-attachments/assets/c2452348-0dab-4355-a37a-d7098f59440a)

Editing a blog post from the user blog returns you there:
![new-edit-blog-post-from-user-blog](https://github.com/user-attachments/assets/c71fe3d3-6b0a-4e8a-bd9a-6157d39ab7a8)

Editing a blog post from the cube blog returns you there:
![new-edit-blog-post-from-cube-blog](https://github.com/user-attachments/assets/7fea889c-e6c8-4ad2-b75e-95b45f833c22)

Deleting a blog post from the user blog returns you there:
![new-delete-blog-post-from-user-blog](https://github.com/user-attachments/assets/50e5ee2b-b177-45a2-a080-3c085af63fe3)

Deleting a blog post from the user blog, when the cube is deleted, returns you there:
![new-delete-blog-post-from-user-blog-when-cube-is-deleted](https://github.com/user-attachments/assets/885874a5-e3f4-4971-9af8-5fb142799dd8)

Deleting a blog post from the cube blog returns you there:
![new-delete-blog-post-from-cube-blog](https://github.com/user-attachments/assets/3fe54c39-eb86-4b6e-8cbe-cb35bbd306d6)

### Edge cases

#### Deleting blog post from itself

Redirects to the cube blog, if the cube still exists:
![new-delete-blog-post-from-itself-redirects-to-cube-blog](https://github.com/user-attachments/assets/98fff4f3-6709-437e-b924-1d152291ed30)

#### Cube no longer exists

Editing a blog post of a deleted cube from user blog, redirects back to user blog. Also shows that you cannot go to the blog post itself because the cube is deleted.
![new-edit-blog-post-when-cube-is-deleted-from-user-blog](https://github.com/user-attachments/assets/1d1f8a38-5664-4390-84d4-b205e58390f7)

Deleting a blog post of a deleted cube, from the cube blog, redirects to dashboard:
![new-delete-blog-post-when-cube-is-deleted](https://github.com/user-attachments/assets/7bdfb683-d870-4fe6-8467-ea48b8afae04)

Editing a blog post of a deleted cube, from the cube blog, redirects to dashboard:
![new-edit-blog-post-when-cube-is-deleted](https://github.com/user-attachments/assets/fbc647fa-f351-4c5b-9833-0969c2bfdb34)

#### Referrer that doesn't belong to cubecobra

Setup:
![new-override-referer-to-evil](https://github.com/user-attachments/assets/930b5eac-b91d-4c3c-9960-e6422f0fe30e)
![new-evil-referer-used](https://github.com/user-attachments/assets/de98b094-6095-44b6-a42f-be7298df7fa6)

From the user's blog, the redirect goes to the cube blog because it exists and because the referrer wasn't trusted:
![new-edit-blog-in-user-blog-redirects-to-cube-when-evil-referer](https://github.com/user-attachments/assets/9d3a2e1d-c040-4bc4-976c-342b9f83c817)

From the user's blog, the redirect goes to the dashboard because the cube doesn't exist and because the referrer wasn't trusted:
![new-edit-blog-in-user-blog-redirects-to-dashboard-when-evil-referer-and-cube-is-gone](https://github.com/user-attachments/assets/3dd9e38d-86f4-48ad-8285-3818cbf9a543)
