### PR TITLE
Add User auto blog setting, which determines whether "Create blog post" is checked or not by default (and defaults to false)

### DIFF
--- a/src/client/components/EditCollapse.tsx
+++ b/src/client/components/EditCollapse.tsx
@@ -1,5 +1,7 @@
 import React, { Dispatch, SetStateAction, useCallback, useContext, useRef, useState } from 'react';
 
+import { QuestionIcon } from '@primer/octicons-react';
+
 import { BoardType } from '../../datatypes/Card';
 import { CardDetails } from '../../datatypes/Card';
 import { CSRFContext } from '../contexts/CSRFContext';
@@ -14,6 +16,7 @@ import Collapse from './base/Collapse';
 import Input from './base/Input';
 import { Col, Flexbox, Row } from './base/Layout';
 import Select from './base/Select';
+import Tooltip from './base/Tooltip';
 import Changelist from './Changelist';
 import LoadingButton from './LoadingButton';
 import TextEntry from './TextEntry';
@@ -283,6 +286,9 @@ const EditCollapse: React.FC<EditCollapseProps> = ({ isOpen }) => {
           />
           <Checkbox label="Use Maybeboard" checked={showMaybeboard} setChecked={toggleShowMaybeboard} />
           <Checkbox label="Create Blog Post" checked={useBlog} setChecked={(value) => setUseBlog(value)} />
+          <Tooltip text="The last checked status for 'Create Blog Post' will be remembered per Cube. The default can be set in your display preferences now.">
+            <QuestionIcon size={16} />
+          </Tooltip>
         </Flexbox>
         <Collapse
           isOpen={

--- a/src/client/components/EditCollapse.tsx
+++ b/src/client/components/EditCollapse.tsx
@@ -45,6 +45,7 @@ export const getCard = async (
       if (setAlerts) {
         setAlerts((alerts: UncontrolledAlertProps[]) => [...alerts, { color: 'danger', message }]);
       } else {
+        // eslint-disable-next-line no-console -- Debugging
         console.error(message);
       }
       return null;
@@ -56,6 +57,7 @@ export const getCard = async (
       if (setAlerts) {
         setAlerts((alerts: UncontrolledAlertProps[]) => [...alerts, { color: 'danger', message }]);
       } else {
+        // eslint-disable-next-line no-console -- Debugging
         console.error(message);
       }
       return null;
@@ -120,6 +122,7 @@ const EditCollapse: React.FC<EditCollapseProps> = ({ isOpen }) => {
           addRef.current.focus();
         }
       } catch (e) {
+        // eslint-disable-next-line no-console -- Debugging
         console.error(e);
       }
     },
@@ -177,6 +180,7 @@ const EditCollapse: React.FC<EditCollapseProps> = ({ isOpen }) => {
           focus.current.focus();
         }
       } catch (e) {
+        // eslint-disable-next-line no-console -- Debugging
         console.error(e);
       }
     },

--- a/src/client/components/user/UserThemeForm.tsx
+++ b/src/client/components/user/UserThemeForm.tsx
@@ -14,11 +14,18 @@ const UserThemeForm: React.FC = () => {
   const [selectedTheme, setSelectedTheme] = useState(user?.theme || 'default');
   const [defaultPrinting, setDefaultPrinting] = useState(user?.defaultPrinting || DefaultPrintingPreference);
   const [gridTightness, setGridTightness] = useState(user?.gridTightness || DefaultGridTightnessPreference);
+  const [autoBlog, setAutoblog] = useState(typeof user?.autoBlog !== 'undefined' ? user.autoBlog : false);
   const [hideFeaturedCubes, setHideFeaturedCubes] = useState(user?.hideFeatured || false);
   const formRef = React.useRef<HTMLFormElement>(null);
   const formData = useMemo(
-    () => ({ theme: selectedTheme, hideFeatured: `${hideFeaturedCubes}`, defaultPrinting, gridTightness }),
-    [selectedTheme, hideFeaturedCubes, defaultPrinting, gridTightness],
+    () => ({
+      theme: selectedTheme,
+      hideFeatured: `${hideFeaturedCubes}`,
+      defaultPrinting,
+      gridTightness,
+      autoBlog: `${autoBlog}`,
+    }),
+    [selectedTheme, hideFeaturedCubes, defaultPrinting, gridTightness, autoBlog],
   );
 
   return (
@@ -53,6 +60,11 @@ const UserThemeForm: React.FC = () => {
           ]}
         />
         <Checkbox label="Hide featured cubes" checked={hideFeaturedCubes} setChecked={setHideFeaturedCubes} />
+        <Checkbox
+          label="Check 'Create Blog posts' for cube change by default"
+          checked={autoBlog}
+          setChecked={setAutoblog}
+        />
         <Button block color="accent" onClick={() => formRef.current?.submit()}>
           Update
         </Button>

--- a/src/client/contexts/CubeContext.tsx
+++ b/src/client/contexts/CubeContext.tsx
@@ -240,7 +240,10 @@ export function CubeContextProvider({
   const [sortTertiary, setSortTertiary] = useQueryParam('s3', defaultSorts[2]);
   const [sortQuaternary, setSortQuaternary] = useQueryParam('s4', defaultSorts[3]);
   const [filterResult, setFilterResult] = useState({});
-  const [useBlog, setUseBlog] = useLocalStorage<boolean>(`${cube.id}-useBlog`, true);
+  const [useBlog, setUseBlog] = useLocalStorage<boolean>(
+    `${cube.id}-useBlog`,
+    typeof user?.autoBlog !== 'undefined' ? user.autoBlog : false,
+  );
 
   const allTags = useMemo(() => {
     const tags = new Set<string>();

--- a/src/datatypes/User.ts
+++ b/src/datatypes/User.ts
@@ -29,4 +29,8 @@ export default interface User {
   notifications?: Notification[];
   defaultPrinting?: PrintingPreference;
   gridTightness?: GridTightnessPreference;
+  /* If true the "create blog post" action will be enabled when editing a cube.
+   * Cube's local storage setting takes precedence
+   */
+  autoBlog?: boolean;
 }

--- a/src/dynamo/models/user.js
+++ b/src/dynamo/models/user.js
@@ -76,6 +76,9 @@ const hydrate = (user) => {
   if (!user.gridTightness) {
     user.gridTightness = DefaultGridTightnessPreference;
   }
+  if (typeof user.autoBlog === 'undefined') {
+    user.autoBlog = false;
+  }
 
   return user;
 };

--- a/src/routes/users_routes.js
+++ b/src/routes/users_routes.js
@@ -358,6 +358,7 @@ router.post(
         dateCreated: new Date().valueOf(),
         defaultPrinting: DefaultPrintingPreference,
         gridTightness: DefaultGridTightnessPreference,
+        autoBlog: false,
       };
 
       const salt = await bcrypt.genSalt(10);
@@ -745,9 +746,10 @@ router.post('/changedisplay', ensureAuth, async (req, res) => {
     }
 
     user.theme = req.body.theme;
-    user.hideFeatured = req.body.hideFeatured === 'on';
+    user.hideFeatured = req.body.hideFeatured === 'true';
     user.defaultPrinting = req.body.defaultPrinting;
     user.gridTightness = req.body.gridTightness;
+    user.autoBlog = req.body.autoBlog === 'true';
 
     await User.update(user);
 

--- a/src/util/render.js
+++ b/src/util/render.js
@@ -55,6 +55,7 @@ const render = (req, res, page, reactProps = {}, options = {}) => {
         notifications: notifications.items,
         defaultPrinting: req.user.defaultPrinting,
         gridTightness: req.user.gridTightness,
+        autoBlog: req.user.autoBlog,
       };
     }
 


### PR DESCRIPTION
From Discord feature request https://discord.com/channels/592787488523943937/1349131518055944242/1349131518055944242 though this only covers:

> req 1: setting handled at the account level
> req 2: setting off by default

of the 3 requested parts.

Happy to hear feedback on the wording around the setting/tooltips or even the property name.

This has a dependency on https://github.com/dekkerglen/CubeCobra/pull/2665 so depending on which of the two is merged first, the other will need small updates.

# Testing

## After
Auto blog setting configurable in display settings.
![new-create-blog-post-user-setting](https://github.com/user-attachments/assets/1c6ec655-6ac2-4aac-9b68-efee1a895778)

New tooltip beside the "Create Blog Post" in the editing cube section.
![new-tooltip-for-create-blog-post](https://github.com/user-attachments/assets/35de8e90-47d6-4937-8f62-7dbc788d71a6)

Just as before, the last checked status of "Create Blog Post" is stored in local storage.
![create-blog-checked-in-localstorage](https://github.com/user-attachments/assets/1a8f9509-48a3-4a28-bc3e-4ef0fc9b2f32)

When auto blog is off for the user, can see that it is used when the local storage value is gone.
![new-default-blog-posts-off-and-setting-used](https://github.com/user-attachments/assets/c2b8c3bf-386e-49c8-956e-56235b661329)

When auto blog is on for the user, the same thing occurs.
![new-default-blog-posts-on-and-setting-used](https://github.com/user-attachments/assets/27fe4b11-2503-4b8a-9dc7-3cb48832fd7b)
