### PR TITLE
Remove auth check on search more items to prevent indefinite loading state

### DIFF
--- a/src/client/components/cube/CubeSearchController.tsx
+++ b/src/client/components/cube/CubeSearchController.tsx
@@ -41,7 +41,12 @@ const CubeSearchController: React.FC<CubeSearchControllerProps> = ({
       </Text>
       <Row xs={12}>
         <Col xs={12} sm={3}>
-          <Input placeholder="Search cubes..." value={queryText} onChange={(event) => setQuery(event.target.value)} />
+          <Input
+            placeholder="Search cubes..."
+            value={queryText}
+            onEnter={() => go(queryText, searchOrder, searchAscending)}
+            onChange={(event) => setQuery(event.target.value)}
+          />
         </Col>
         <Col xs={6} sm={3}>
           <Select

--- a/src/routes/search_routes.js
+++ b/src/routes/search_routes.js
@@ -7,7 +7,6 @@ const CubeHash = require('../dynamo/models/cubeHash');
 const { PrintingPreference } = require('../datatypes/Card');
 
 const { render } = require('../util/render');
-const { ensureAuth } = require('./middleware');
 const { isCubeListed } = require('../util/cubefn');
 
 const router = express.Router();
@@ -362,7 +361,7 @@ router.get('/search', async (req, res) => {
   });
 });
 
-router.post('/getmoresearchitems', ensureAuth, async (req, res) => {
+router.post('/getmoresearchitems', async (req, res) => {
   const { lastKey, query, order, ascending } = req.body;
 
   const result = await searchCubes(query, order, lastKey, ascending, req.user);


### PR DESCRIPTION
As reported in Discord, logged out user gets stuck paging through the cubes search results once it needs to fetch more from the server. The response is a 302 redirect to login due to the auth check on the endpoint, which is unnecessary given the search page is already showing information from the same source.

Secondly I made the search input field trigger the search when you press enter. I've gotten "stuck" myself a few times by writing my search and then hitting enter, and waiting for something to change that won't until I click the search button.

# Testing

## Before

![old-search-more-triggers-login-redirect](https://github.com/user-attachments/assets/1095f944-1633-4e4c-b4bc-e0f6d2fe626b)

## After

![new-search-more-works-not-logged-in](https://github.com/user-attachments/assets/a4824563-74d0-4991-af55-434608a73810)
