### PR TITLE
Backfilling tests on the Content dynamo model, which identified a bug

### DIFF
--- a/src/dynamo/models/content.ts
+++ b/src/dynamo/models/content.ts
@@ -262,7 +262,7 @@ const content = {
         await putBody(document.id, body);
       }),
     );
-    client.batchPut(docs);
+    client.batchPut(docs.map((doc) => doc.document));
   },
   batchDelete: async (keys: DocumentClient.Key[]): Promise<void> => {
     return client.batchDelete(keys);

--- a/tests/content/dynamo.test.ts
+++ b/tests/content/dynamo.test.ts
@@ -467,16 +467,7 @@ describe('Content Model', () => {
       expect(putObject).toHaveBeenCalledWith(TEST_BUCKET, 'content/video-123.json', 'video body');
       expect(putObject).toHaveBeenCalledWith(TEST_BUCKET, 'content/podcast-456.json', 'podcast body');
 
-      expect(mockDynamoClient.batchPut).toHaveBeenCalledWith([
-        {
-          document: expectedVideoDocument,
-          body: 'video body',
-        },
-        {
-          document: expectedPodcastDocument,
-          body: 'podcast body',
-        },
-      ]);
+      expect(mockDynamoClient.batchPut).toHaveBeenCalledWith([expectedVideoDocument, expectedPodcastDocument]);
     });
   });
 

--- a/tests/content/dynamo.test.ts
+++ b/tests/content/dynamo.test.ts
@@ -1,0 +1,540 @@
+import { v4 as UUID } from 'uuid';
+
+import HydratedContentType, { ContentStatus, ContentType, UnhydratedContent } from '../../src/datatypes/Content';
+import Content from '../../src/dynamo/models/content';
+import User from '../../src/dynamo/models/user';
+import { getBucketName, getObject, putObject } from '../../src/dynamo/s3client';
+import { getImageData } from '../../src/util/imageutil';
+import {
+  createArticle,
+  createCardImage,
+  createEpisode,
+  createPodcast,
+  createUser,
+  createVideo,
+} from '../test-utils/data';
+
+// Mock dependencies
+jest.mock('../../src/dynamo/util');
+jest.mock('../../src/dynamo/models/user');
+jest.mock('../../src/util/imageutil');
+jest.mock('../../src/dynamo/s3client');
+jest.mock('uuid');
+
+// Test helpers
+const createUnhydratedContent = (type: ContentType, overrides?: Partial<UnhydratedContent>): UnhydratedContent => ({
+  id: 'content-1',
+  type: type,
+  typeStatusComp: `${type}:${ContentStatus.PUBLISHED}`,
+  typeOwnerComp: `${type}:user-1`,
+  status: ContentStatus.PUBLISHED,
+  date: new Date('2024-03-24').valueOf(),
+  title: 'Test Content',
+  owner: 'user-1',
+  imageName: 'image-1.jpg',
+  short: 'Short description',
+  ...overrides,
+});
+
+const mockUser = createUser({ id: 'user-1', username: 'testuser' });
+
+const setupQueryResult = (response: any) => {
+  (mockDynamoClient.query as jest.Mock).mockResolvedValueOnce(response);
+};
+
+const verifyQueryCall = (params: any) => {
+  expect(mockDynamoClient.query).toHaveBeenCalledWith(expect.objectContaining(params));
+};
+
+const getExpectedDocumentSaved = (content: HydratedContentType, overrides?: Partial<HydratedContentType>): any => {
+  const expectedDocument: Record<string, any> = { ...content, ...overrides };
+  delete expectedDocument.body;
+  delete expectedDocument.image;
+  expectedDocument.owner = expectedDocument.owner.id;
+  return expectedDocument;
+};
+
+describe('Content Model Initialization', () => {
+  it('creates content table with proper configuration', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('../../src/dynamo/models/content');
+
+    expect(mockDynamoCreateClient).toHaveBeenCalledWith({
+      name: 'CONTENT',
+      partitionKey: 'id',
+      attributes: {
+        id: 'S',
+        date: 'N',
+        status: 'S',
+        typeStatusComp: 'S',
+        typeOwnerComp: 'S',
+      },
+      indexes: [
+        {
+          partitionKey: 'status',
+          sortKey: 'date',
+          name: 'ByStatus',
+        },
+        {
+          partitionKey: 'typeOwnerComp',
+          sortKey: 'date',
+          name: 'ByTypeOwnerComp',
+        },
+        {
+          partitionKey: 'typeStatusComp',
+          sortKey: 'date',
+          name: 'ByTypeStatusComp',
+        },
+      ],
+    });
+  });
+});
+
+describe('Content Model', () => {
+  const mockImage = createCardImage({ id: 'image-1', uri: 'test.jpg' });
+  const mockStoredContent = createUnhydratedContent(ContentType.ARTICLE);
+  const TEST_BUCKET = 'test-bucket';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+    (UUID as jest.Mock).mockReturnValue('content-2');
+    (getImageData as jest.Mock).mockReturnValue(mockImage);
+    (getBucketName as jest.Mock).mockReturnValue(TEST_BUCKET);
+  });
+
+  describe('getById', () => {
+    it('returns undefined when no content found', async () => {
+      (mockDynamoClient.get as jest.Mock).mockResolvedValueOnce({ Item: undefined });
+
+      const result = await Content.getById('content-999');
+
+      expect(getObject).not.toHaveBeenCalled();
+      expect(result).toBeUndefined();
+    });
+
+    const hasImageCases = [
+      { descriptor: 'Article', type: ContentType.ARTICLE },
+      { descriptor: 'Video', type: ContentType.VIDEO },
+    ];
+
+    it.each(hasImageCases)('returns hydrated content with owner and image ($descriptor)', async ({ type }) => {
+      const storedContent = createUnhydratedContent(type);
+
+      (mockDynamoClient.get as jest.Mock).mockResolvedValueOnce({ Item: storedContent });
+      (User.getById as jest.Mock).mockResolvedValueOnce(mockUser);
+      (getObject as jest.Mock).mockResolvedValueOnce('Test body content');
+
+      const result = await Content.getById('content-1');
+
+      expect(getObject).toHaveBeenCalledWith(TEST_BUCKET, `content/${storedContent.id}.json`);
+      expect(result).toEqual({
+        ...storedContent,
+        owner: mockUser,
+        image: mockImage,
+        body: 'Test body content',
+      });
+    });
+
+    const doesNotHaveImageCases = [
+      { descriptor: 'Episode', type: ContentType.EPISODE },
+      { descriptor: 'Podcast', type: ContentType.PODCAST },
+    ];
+
+    it.each(doesNotHaveImageCases)('returns hydrated content with only owner ($descriptor)', async ({ type }) => {
+      const storedContent = createUnhydratedContent(type);
+
+      (mockDynamoClient.get as jest.Mock).mockResolvedValueOnce({ Item: storedContent });
+      (User.getById as jest.Mock).mockResolvedValueOnce(mockUser);
+      (getObject as jest.Mock).mockResolvedValueOnce('Test body content');
+
+      const result = await Content.getById('content-1');
+
+      expect(getObject).toHaveBeenCalledWith(TEST_BUCKET, `content/${storedContent.id}.json`);
+      expect(result).toEqual({
+        ...storedContent,
+        owner: mockUser,
+        body: 'Test body content',
+      });
+    });
+
+    it('handles content with no body', async () => {
+      (mockDynamoClient.get as jest.Mock).mockResolvedValueOnce({ Item: mockStoredContent });
+      (User.getById as jest.Mock).mockResolvedValueOnce(mockUser);
+      (getObject as jest.Mock).mockRejectedValueOnce(new Error('Not found'));
+
+      const result = await Content.getById('content-1');
+
+      expect(result).toEqual({
+        ...mockStoredContent,
+        owner: mockUser,
+        image: mockImage,
+      });
+    });
+
+    it('handles content with empty owner or image', async () => {
+      const storedContent = { ...mockStoredContent };
+      storedContent.owner = '';
+      storedContent.imageName = '';
+
+      (mockDynamoClient.get as jest.Mock).mockResolvedValueOnce({ Item: storedContent });
+      (getObject as jest.Mock).mockResolvedValueOnce('Test body content');
+
+      const result = await Content.getById('content-1');
+
+      expect(User.getById).not.toHaveBeenCalled();
+      expect(getImageData).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        ...storedContent,
+        body: 'Test body content',
+        owner: undefined,
+        image: undefined,
+      });
+    });
+  });
+
+  describe('getByStatus', () => {
+    it('returns empty result when no content found', async () => {
+      setupQueryResult({ Items: [], LastEvaluatedKey: undefined });
+
+      const result = await Content.getByStatus('published');
+
+      expect(result).toEqual({ items: [], lastKey: undefined });
+      verifyQueryCall({
+        IndexName: 'ByStatus',
+        KeyConditionExpression: '#p1 = :status',
+        ExpressionAttributeValues: { ':status': 'published' },
+        ScanIndexForward: false,
+      });
+    });
+
+    it('returns hydrated content, but that doesnt include bodies', async () => {
+      const mockStoredContentTwo = createUnhydratedContent(ContentType.VIDEO, { id: 'content-555', owner: 'user-434' });
+      const mockUserTwo = createUser({ id: 'user-434' });
+      const mockImageTwo = createCardImage({ imageName: 'foobaz' });
+
+      (getImageData as jest.Mock).mockReturnValueOnce(mockImage);
+      (getImageData as jest.Mock).mockReturnValueOnce(mockImageTwo);
+
+      const contents = [mockStoredContent, mockStoredContentTwo];
+      setupQueryResult({
+        Items: contents,
+        LastEvaluatedKey: { S: 'last-key-1' },
+      });
+      (User.batchGet as jest.Mock).mockResolvedValueOnce([mockUser, mockUserTwo]);
+
+      const result = await Content.getByStatus('published');
+
+      expect(result.items?.length).toBe(2);
+      expect(result.lastKey).toEqual({ S: 'last-key-1' });
+      expect(result.items?.[0]).toEqual({
+        ...mockStoredContent,
+        owner: mockUser,
+        image: mockImage,
+      });
+      expect(result.items?.[1]).toEqual({
+        ...mockStoredContentTwo,
+        owner: mockUserTwo,
+        image: mockImageTwo,
+      });
+      expect(getObject).toHaveBeenCalledTimes(0);
+      expect(User.batchGet).toHaveBeenCalledWith([mockUser.id, mockUserTwo.id]);
+    });
+
+    it('handles content with empty owner or image', async () => {
+      const mockStoredContentOne = { ...mockStoredContent };
+      mockStoredContentOne.imageName = '';
+
+      const mockStoredContentTwo = createUnhydratedContent(ContentType.ARTICLE, { id: 'content-555', owner: '' });
+      const mockImageTwo = createCardImage({ imageName: 'foobaz' });
+
+      (getImageData as jest.Mock).mockReturnValueOnce(mockImageTwo);
+
+      const contents = [mockStoredContentOne, mockStoredContentTwo];
+      setupQueryResult({
+        Items: contents,
+        LastEvaluatedKey: { S: 'last-key-1' },
+      });
+      (User.batchGet as jest.Mock).mockResolvedValueOnce([mockUser]);
+
+      const result = await Content.getByStatus('published');
+
+      expect(result.items?.length).toBe(2);
+      expect(result.lastKey).toEqual({ S: 'last-key-1' });
+      expect(result.items?.[0]).toEqual({
+        ...mockStoredContentOne,
+        owner: mockUser,
+        image: undefined,
+      });
+      expect(result.items?.[1]).toEqual({
+        ...mockStoredContentTwo,
+        owner: undefined,
+        image: mockImageTwo,
+      });
+      expect(getObject).toHaveBeenCalledTimes(0);
+      //Empty string is apparently not falsely enough to be filtered
+      expect(User.batchGet).toHaveBeenCalledWith([mockUser.id, '']);
+    });
+  });
+
+  //Hydration logic already tested by getByStatus
+  describe('getByTypeAndStatus', () => {
+    it('any string for status is allowed', async () => {
+      setupQueryResult({ Items: [], LastEvaluatedKey: undefined });
+
+      const result = await Content.getByTypeAndStatus(ContentType.PODCAST, 'foobar');
+
+      expect(result).toEqual({ items: [], lastKey: undefined });
+      verifyQueryCall({
+        IndexName: 'ByTypeStatusComp',
+        KeyConditionExpression: '#p1 = :stcomp',
+        ExpressionAttributeValues: { ':stcomp': `${ContentType.PODCAST}:foobar` },
+        ScanIndexForward: false,
+      });
+    });
+
+    it('with status from enum', async () => {
+      setupQueryResult({ Items: [mockStoredContent], LastEvaluatedKey: { S: 'last-key-1' } });
+      (User.batchGet as jest.Mock).mockResolvedValueOnce([mockUser]);
+
+      const result = await Content.getByTypeAndStatus(ContentType.PODCAST, ContentStatus.IN_REVIEW);
+
+      expect(result.items?.length).toBe(1);
+      expect(result.lastKey).toEqual({ S: 'last-key-1' });
+      expect(result.items?.[0]).toEqual({
+        ...mockStoredContent,
+        owner: mockUser,
+        image: mockImage,
+      });
+      verifyQueryCall({
+        IndexName: 'ByTypeStatusComp',
+        KeyConditionExpression: '#p1 = :stcomp',
+        ExpressionAttributeValues: { ':stcomp': `${ContentType.PODCAST}:${ContentStatus.IN_REVIEW}` },
+        ScanIndexForward: false,
+      });
+    });
+  });
+
+  describe('getByTypeAndOwner', () => {
+    it('returns hydrated items', async () => {
+      setupQueryResult({ Items: [mockStoredContent], LastEvaluatedKey: { S: 'last-key-55' } });
+      (User.batchGet as jest.Mock).mockResolvedValueOnce([mockUser]);
+
+      const result = await Content.getByTypeAndOwner(ContentType.VIDEO, 'user-123445');
+
+      expect(result.items?.length).toBe(1);
+      expect(result.lastKey).toEqual({ S: 'last-key-55' });
+      expect(result.items?.[0]).toEqual({
+        ...mockStoredContent,
+        owner: mockUser,
+        image: mockImage,
+      });
+      verifyQueryCall({
+        IndexName: 'ByTypeOwnerComp',
+        KeyConditionExpression: '#p1 = :tocomp',
+        ExpressionAttributeValues: { ':tocomp': `${ContentType.VIDEO}:user-123445` },
+        ScanIndexForward: false,
+      });
+    });
+
+    it('starts the query from the input lastKey', async () => {
+      setupQueryResult({ Items: [], LastEvaluatedKey: null });
+      (User.batchGet as jest.Mock).mockResolvedValueOnce([mockUser]);
+
+      const result = await Content.getByTypeAndOwner(ContentType.VIDEO, 'user-123445', { S: 'keyabc' });
+
+      expect(result.items?.length).toBe(0);
+      expect(result.lastKey).toBeNull();
+      verifyQueryCall({
+        IndexName: 'ByTypeOwnerComp',
+        KeyConditionExpression: '#p1 = :tocomp',
+        ExpressionAttributeValues: { ':tocomp': `${ContentType.VIDEO}:user-123445` },
+        ScanIndexForward: false,
+        ExclusiveStartKey: { S: 'keyabc' },
+      });
+    });
+  });
+
+  describe('put', () => {
+    it('creates new content with generated id', async () => {
+      const newContent = createVideo({ id: undefined });
+      const expectedBody = newContent.body;
+
+      const expectedDocument = getExpectedDocumentSaved(newContent, { id: 'content-2' });
+
+      await Content.put(newContent, ContentType.VIDEO);
+
+      expect(UUID).toHaveBeenCalled();
+      expect(putObject).toHaveBeenCalledWith(TEST_BUCKET, 'content/content-2.json', expectedBody);
+      expect(mockDynamoClient.put).toHaveBeenCalledWith(expectedDocument);
+    });
+
+    const stringImageCases = [
+      { descriptor: 'Episode', type: ContentType.EPISODE },
+      { descriptor: 'Podcast', type: ContentType.PODCAST },
+    ];
+
+    it.each(stringImageCases)(
+      'image is preserved when it is a string not an object ($descriptor)',
+      async ({ type }) => {
+        const createFunction = type === ContentType.EPISODE ? createEpisode : createPodcast;
+
+        const newContent = createFunction({ id: 'abcdefg-346436' });
+        const expectedBody = newContent.body;
+
+        const expectedDocument = getExpectedDocumentSaved(newContent, { id: 'abcdefg-346436' });
+        expectedDocument.image = newContent.image;
+
+        await Content.put(newContent, type);
+
+        expect(putObject).toHaveBeenCalledWith(TEST_BUCKET, 'content/abcdefg-346436.json', expectedBody);
+        expect(mockDynamoClient.put).toHaveBeenCalledWith(expectedDocument);
+      },
+    );
+
+    const objectImageCases = [
+      { descriptor: 'Article', type: ContentType.ARTICLE },
+      { descriptor: 'Video', type: ContentType.VIDEO },
+    ];
+
+    it.each(objectImageCases)('image is stripped when it is an object ($descriptor)', async ({ type }) => {
+      const createFunction = type === ContentType.ARTICLE ? createArticle : createVideo;
+
+      const newContent = createFunction({ id: 'abcdefg-346436' });
+      const expectedBody = newContent.body;
+
+      const expectedDocument = getExpectedDocumentSaved(newContent, { id: 'abcdefg-346436' });
+
+      await Content.put(newContent, type);
+
+      expect(putObject).toHaveBeenCalledWith(TEST_BUCKET, 'content/abcdefg-346436.json', expectedBody);
+      expect(mockDynamoClient.put).toHaveBeenCalledWith(expectedDocument);
+    });
+
+    it('handles empty body', async () => {
+      const newContent = createArticle({ body: '' });
+
+      const expectedDocument = getExpectedDocumentSaved(newContent);
+
+      await Content.put(newContent, ContentType.ARTICLE);
+
+      expect(putObject).not.toHaveBeenCalled();
+      expect(mockDynamoClient.put).toHaveBeenCalledWith(expectedDocument);
+    });
+
+    it('handles owner being a string not an User object', async () => {
+      const newContent = createPodcast({
+        body: '',
+        //@ts-expect-error -- Owner can be a string if working with unhydrated Content (such as from scan)
+        owner: 'user-123456',
+        typeOwnerComp: `${ContentType.PODCAST}:user-123456`,
+      });
+
+      const expectedDocument: Record<string, any> = { ...newContent };
+      delete expectedDocument.body;
+
+      await Content.put(newContent, ContentType.PODCAST);
+
+      expect(putObject).not.toHaveBeenCalled();
+      expect(mockDynamoClient.put).toHaveBeenCalledWith(expectedDocument);
+    });
+
+    it('throws error when updating without id', async () => {
+      const invalidContent = createVideo({ id: undefined });
+
+      await expect(Content.update(invalidContent)).rejects.toThrow('Invalid document: No partition key provided');
+    });
+  });
+
+  describe('batchPut', () => {
+    it('handles multiple content types', async () => {
+      const video = createVideo({
+        id: 'video-123',
+        body: 'video body',
+      });
+      const podcast = createPodcast({
+        id: 'podcast-456',
+        body: 'podcast body',
+      });
+
+      const expectedVideoDocument = getExpectedDocumentSaved(video);
+      const expectedPodcastDocument = getExpectedDocumentSaved(podcast);
+      expectedPodcastDocument.image = podcast.image; // Podcast preserves string image
+
+      await Content.batchPut([video, podcast]);
+
+      expect(putObject).toHaveBeenCalledTimes(2);
+      expect(putObject).toHaveBeenCalledWith(TEST_BUCKET, 'content/video-123.json', 'video body');
+      expect(putObject).toHaveBeenCalledWith(TEST_BUCKET, 'content/podcast-456.json', 'podcast body');
+
+      expect(mockDynamoClient.batchPut).toHaveBeenCalledWith([
+        {
+          document: expectedVideoDocument,
+          body: 'video body',
+        },
+        {
+          document: expectedPodcastDocument,
+          body: 'podcast body',
+        },
+      ]);
+    });
+  });
+
+  //Same logic as put for what is written to dynamo vs S3
+  describe('update', () => {
+    it('updates existing content', async () => {
+      const existingContent = createEpisode({ id: 'article-abcdefg', short: 'New short descr' });
+      const expectedBody = existingContent.body;
+
+      const expectedDocument = getExpectedDocumentSaved(existingContent);
+      expectedDocument.image = existingContent.image;
+
+      await Content.update(existingContent);
+
+      expect(UUID).not.toHaveBeenCalled();
+      expect(putObject).toHaveBeenCalledWith(TEST_BUCKET, 'content/article-abcdefg.json', expectedBody);
+      expect(mockDynamoClient.put).toHaveBeenCalledWith(expectedDocument);
+    });
+  });
+
+  describe('batchDelete', () => {
+    it('deletes multiple content items', async () => {
+      const keys = [{ id: 'content-1' }, { id: 'content-2' }];
+
+      await Content.batchDelete(keys);
+
+      expect(mockDynamoClient.batchDelete).toHaveBeenCalledWith(keys);
+    });
+  });
+
+  describe('scan', () => {
+    it('returns unhydrated content with pagination', async () => {
+      (mockDynamoClient.scan as jest.Mock).mockResolvedValueOnce({
+        Items: [mockStoredContent],
+        LastEvaluatedKey: { S: 'last-key-1' },
+      });
+
+      const result = await Content.scan({ S: 'start-key-1' });
+
+      expect(result).toEqual({
+        items: [mockStoredContent],
+        lastKey: { S: 'last-key-1' },
+      });
+      expect(mockDynamoClient.scan).toHaveBeenCalledWith({
+        ExclusiveStartKey: { S: 'start-key-1' },
+      });
+    });
+  });
+
+  describe('createTable', () => {
+    it('delegates to client createTable', async () => {
+      const expectedResponse = { TableName: 'CONTENT' };
+      (mockDynamoClient.createTable as jest.Mock).mockResolvedValueOnce(expectedResponse);
+
+      const result = await Content.createTable();
+
+      expect(result).toEqual(expectedResponse);
+      expect(mockDynamoClient.createTable).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/test-utils/data.ts
+++ b/tests/test-utils/data.ts
@@ -1,4 +1,6 @@
-import { v4 as uuidv4 } from 'uuid';
+//Ensure we use the real uuid rather than any mocked version if it is relevant to a test
+const uuid = jest.requireActual('uuid');
+const uuidv4 = uuid.v4;
 
 import { BASIC_LAND_MANA_MAPPING } from '../../src/client/utils/cardutil';
 import BlogPost from '../../src/datatypes/BlogPost';

--- a/tests/test-utils/data.ts
+++ b/tests/test-utils/data.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { BASIC_LAND_MANA_MAPPING } from '../../src/client/utils/cardutil';
 import BlogPost from '../../src/datatypes/BlogPost';
-import Card, { BasicLand, CardDetails } from '../../src/datatypes/Card';
+import Card, { BasicLand, CardDetails, Changes } from '../../src/datatypes/Card';
 import Cube, { CubeImage } from '../../src/datatypes/Cube';
 import Draft, { DraftStep } from '../../src/datatypes/Draft';
 import DraftSeat from '../../src/datatypes/DraftSeat';
@@ -235,4 +235,11 @@ export const createCompletedSoloDraft = (overrides?: Partial<Draft>): Draft => {
     complete: false,
     ...overrides,
   } as Draft;
+};
+
+export const createChangelog = (overrides?: Partial<Changes>): Changes => {
+  return {
+    version: 1,
+    ...overrides,
+  } as Changes;
 };

--- a/tests/test-utils/data.ts
+++ b/tests/test-utils/data.ts
@@ -2,7 +2,15 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { BASIC_LAND_MANA_MAPPING } from '../../src/client/utils/cardutil';
 import BlogPost from '../../src/datatypes/BlogPost';
-import Card, { BasicLand, CardDetails, Changes } from '../../src/datatypes/Card';
+import Card, {
+  BasicLand,
+  BoardChanges,
+  CardDetails,
+  Changes,
+  CubeCardEdit,
+  CubeCardRemove,
+  CubeCardSwap,
+} from '../../src/datatypes/Card';
 import Cube, { CubeImage } from '../../src/datatypes/Cube';
 import Draft, { DraftStep } from '../../src/datatypes/Draft';
 import DraftSeat from '../../src/datatypes/DraftSeat';
@@ -18,14 +26,25 @@ export const generateRandomString = (alphabet: string, minLength: number, maxLen
   return Array.from({ length }, () => alphabet.charAt(Math.floor(Math.random() * alphabet.length))).join('');
 };
 
+export const generateRandomNumber = (minLength: number, maxLength?: number): number => {
+  return Number.parseInt(generateRandomString(NUMBERS, minLength, maxLength));
+};
+
 /**
  * Create a Card for testing by providing sane defaults but allow for overriding
  *
  * @param overrides
  */
 export const createCard = (overrides?: Partial<Card>): Card => ({
+  index: generateRandomNumber(1, 3),
   cardID: uuidv4(),
   details: createCardDetails(),
+  ...overrides,
+});
+
+export const createCardWithoutDetails = (overrides?: Partial<Omit<Card, 'details'>>): Card => ({
+  index: generateRandomNumber(1, 3),
+  cardID: uuidv4(),
   ...overrides,
 });
 
@@ -237,9 +256,45 @@ export const createCompletedSoloDraft = (overrides?: Partial<Draft>): Draft => {
   } as Draft;
 };
 
-export const createChangelog = (overrides?: Partial<Changes>): Changes => {
+export const createChangelog = (mainboard?: BoardChanges, maybeboard?: BoardChanges, version: number = 1): Changes => {
+  const changes: Changes = {};
+
+  //All fields can be missing (though logically at least one should be set)
+  if (version) {
+    changes.version = version;
+  }
+  if (mainboard) {
+    changes.mainboard = mainboard;
+  }
+  if (maybeboard) {
+    changes.maybeboard = maybeboard;
+  }
+
+  return changes;
+};
+
+export const createChangelogCardAdd = (overrides?: Partial<Card>): Card => {
+  return { ...createCardWithoutDetails(), ...overrides } as Card;
+};
+
+export const createChangelogCardRemove = (overrides?: Partial<CubeCardRemove>): CubeCardRemove => {
+  return { index: generateRandomNumber(1, 3), oldCard: createCardWithoutDetails(), ...overrides } as CubeCardRemove;
+};
+
+export const createChangelogCardEdit = (overrides?: Partial<CubeCardEdit>): CubeCardEdit => {
   return {
-    version: 1,
+    index: generateRandomNumber(1, 3),
+    oldCard: createCardWithoutDetails(),
+    newCard: createCardWithoutDetails(),
     ...overrides,
-  } as Changes;
+  } as CubeCardEdit;
+};
+
+export const createChangelogCardSwap = (overrides?: Partial<CubeCardSwap>): CubeCardSwap => {
+  return {
+    index: generateRandomNumber(1, 3),
+    oldCard: createCardWithoutDetails(),
+    card: createCardWithoutDetails(),
+    ...overrides,
+  } as CubeCardSwap;
 };

--- a/tests/test-utils/data.ts
+++ b/tests/test-utils/data.ts
@@ -3,6 +3,7 @@ const uuid = jest.requireActual('uuid');
 const uuidv4 = uuid.v4;
 
 import { BASIC_LAND_MANA_MAPPING } from '../../src/client/utils/cardutil';
+import Article from '../../src/datatypes/Article';
 import BlogPost from '../../src/datatypes/BlogPost';
 import Card, {
   BasicLand,
@@ -13,10 +14,15 @@ import Card, {
   CubeCardRemove,
   CubeCardSwap,
 } from '../../src/datatypes/Card';
+import Content, { ContentStatus, ContentType } from '../../src/datatypes/Content';
 import Cube, { CubeImage } from '../../src/datatypes/Cube';
 import Draft, { DraftStep } from '../../src/datatypes/Draft';
 import DraftSeat from '../../src/datatypes/DraftSeat';
+import Episode from '../../src/datatypes/Episode';
+import Image from '../../src/datatypes/Image';
+import Podcast from '../../src/datatypes/Podcast';
 import User from '../../src/datatypes/User';
+import Video from '../../src/datatypes/Video';
 
 const LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 const NUMBERS = '0123456789';
@@ -299,4 +305,71 @@ export const createChangelogCardSwap = (overrides?: Partial<CubeCardSwap>): Cube
     card: createCardWithoutDetails(),
     ...overrides,
   } as CubeCardSwap;
+};
+
+export const createCardImage = (overrides?: Partial<Image>): Image => {
+  return {
+    uri: `/content/images/${uuidv4()}.png`,
+    artist: `${generateRandomString(LETTERS, 3, 10)} ${generateRandomString(LETTERS, 5, 15)}`,
+    id: uuidv4(),
+    imageName: `${generateRandomString(LETTERS, 5, 10)} ${generateRandomString(LETTERS, 5, 15)}`,
+    ...overrides,
+  } as Image;
+};
+
+const createContent = (type: ContentType, overrides?: Partial<Content>): Content => {
+  const status = overrides?.status || ContentStatus.PUBLISHED;
+  const user = overrides?.owner || createUser();
+  const userId = user.id;
+
+  return {
+    id: uuidv4(),
+    type,
+    typeStatusComp: `${type}:${status}`,
+    typeOwnerComp: `${type}:${userId}`,
+    status: status,
+    date: new Date('2024-03-24').valueOf(),
+    body: generateRandomString(LETTERS, 10, 20),
+    owner: user,
+    short: generateRandomString(LETTERS, 5, 10),
+    username: 'user-1',
+    ...overrides,
+  } as Content;
+};
+
+export const createArticle = (overrides?: Partial<Article>): Article => {
+  return createContent(ContentType.ARTICLE, {
+    imageName: 'Stock Up',
+    image: createCardImage({ imageName: 'Stock Up' }),
+    ...overrides,
+  }) as Article;
+};
+
+export const createEpisode = (overrides?: Partial<Episode>): Episode => {
+  return createContent(ContentType.EPISODE, {
+    podcastName: 'This is a podcast',
+    image: 'https://example.com/podcast.png',
+    podcast: 'https://example.com/podcast.rss',
+    podcastGuid: uuidv4(),
+    ...overrides,
+  }) as Episode;
+};
+
+export const createPodcast = (overrides?: Partial<Podcast>): Podcast => {
+  return createContent(ContentType.PODCAST, {
+    image: 'https://example.com/podcast.png',
+    title: 'This is a podcast',
+    url: 'https://example.com/podcast.rss',
+    description: 'The best cubers around',
+    ...overrides,
+  }) as Podcast;
+};
+
+export const createVideo = (overrides?: Partial<Video>): Video => {
+  return createContent(ContentType.VIDEO, {
+    imageName: 'Stock Up',
+    image: createCardImage({ imageName: 'Stock Up' }),
+    url: 'https://youtube.example.com/video/abcdefg',
+    ...overrides,
+  }) as Video;
 };


### PR DESCRIPTION
1. Adding tests to backfill
2. Identified bug with Content.batchPut where the temporary object is written instead of the desired document - this only executes when a podcast updates its image and then it updates all episodes to the same image. eg not often