### PR TITLE
Draftmancer API tests and addition of anonymous notification for the cube owner (assuming enabled)

### DIFF
--- a/src/client/components/nav/Notification.tsx
+++ b/src/client/components/nav/Notification.tsx
@@ -17,7 +17,11 @@ const Notification: React.FC<NotificationProps> = ({ notification }) => {
       <div className="hover:bg-bg-active pb-2 pt-3 px-2 deck-preview">
         <Text semibold sm>
           <Link href={`/user/notification/${notification.id}`}>{texts[0]}</Link>
-          <Link href={`/user/view/${notification.from}`}>{notification.fromUsername}</Link>
+          {notification.from ? (
+            <Link href={`/user/view/${notification.from}`}>{notification.fromUsername}</Link>
+          ) : (
+            notification.fromUsername
+          )}
           <Link href={`/user/notification/${notification.id}`}>{texts[1]}</Link>
           {' - '}
           <TimeAgo date={notification.date} />

--- a/src/datatypes/Draft.ts
+++ b/src/datatypes/Draft.ts
@@ -26,6 +26,7 @@ export type DraftState = {
   steps: DraftStep[];
 }[][];
 
+//TODO: Move to Draftmancer types
 export interface DraftmancerPick {
   booster: number[];
   pick: number;

--- a/src/datatypes/Draftmancer.ts
+++ b/src/datatypes/Draftmancer.ts
@@ -1,0 +1,32 @@
+export interface Pick {
+  booster: string[]; // oracle id
+  picks: number[]; // Indices into booster
+  burn: number[];
+}
+
+export interface Decklist {
+  main: string[]; // oracle id
+  side: string[]; // oracle id
+  lands: {
+    W: number;
+    U: number;
+    B: number;
+    R: number;
+    G: number;
+  };
+}
+
+export interface Player {
+  userName: string;
+  isBot: boolean;
+  picks: Pick[];
+  decklist: Decklist;
+}
+
+export interface PublishDraftBody {
+  cubeID: string;
+  sessionID: string;
+  timestamp: number;
+  players: Player[];
+  apiKey: string;
+}

--- a/src/datatypes/Notification.ts
+++ b/src/datatypes/Notification.ts
@@ -6,7 +6,7 @@ export enum NotificationStatus {
 export type NewNotification = {
   date: number;
   to: string;
-  from: string;
+  from?: string;
   url?: string;
   body: string;
   fromUsername?: string;

--- a/src/dynamo/models/notification.ts
+++ b/src/dynamo/models/notification.ts
@@ -26,7 +26,7 @@ const client = createClient({
   ],
 });
 
-module.exports = {
+const notification = {
   getById: async (id: string): Promise<Notification> => (await client.get(id)).Item as Notification,
   getByToAndStatus: async (
     to: string,
@@ -103,3 +103,7 @@ module.exports = {
     ),
   createTable: async (): Promise<DocumentClient.CreateTableOutput> => client.createTable(),
 };
+
+module.exports = notification;
+
+export default notification;

--- a/src/router/routes/api/draftmancer/publish.ts
+++ b/src/router/routes/api/draftmancer/publish.ts
@@ -157,7 +157,6 @@ const sendDraftNotification = async (draftId: string, drafterName: string, cube:
   await Notification.put({
     date: new Date().valueOf(),
     to: cubeOwner.id,
-    from: '',
     fromUsername: drafterName,
     url: `/cube/deck/${draftId}`,
     body: `${drafterName} drafted your cube: ${cube.name}`,

--- a/src/util/draftmancerUtil.ts
+++ b/src/util/draftmancerUtil.ts
@@ -1,0 +1,107 @@
+import { detailsToCard } from '../client/utils/cardutil';
+import { CardDetails } from '../datatypes/Card';
+import { Decklist } from '../datatypes/Draftmancer';
+import { getReasonableCardByOracle } from './carddb';
+import { deckbuild } from './draftbots';
+import { getCardDefaultRowColumn, setupPicks } from './draftutil';
+
+export const upsertCardAndGetIndex = (cards: CardDetails[], oracleId: string): number => {
+  const card = getReasonableCardByOracle(oracleId);
+  const index = cards.findIndex((c) => c.oracle_id === oracleId);
+
+  if (index === -1) {
+    cards.push(card);
+    return cards.length - 1;
+  }
+
+  return index;
+};
+
+export const formatMainboard = (decklist: Decklist, cardDetails: CardDetails[]) => {
+  const mainboard: number[][][] = setupPicks(2, 8);
+
+  for (const oracleId of decklist.main) {
+    const index = upsertCardAndGetIndex(cardDetails, oracleId);
+    const card = cardDetails[index];
+
+    //TODO: Consolidate with draftutil.getCardDefaultRowColumn
+    const isCreature = card.type.toLowerCase().includes('creature');
+    const cmc = card.cmc;
+
+    const row = isCreature ? 0 : 1;
+    const col = Math.max(0, Math.min(7, Math.floor(cmc)));
+
+    mainboard[row][col].push(index);
+  }
+  return mainboard;
+};
+
+export const formatSideboard = (decklist: Decklist, cardDetails: CardDetails[]) => {
+  const sideboard: number[][][] = setupPicks(2, 8);
+
+  for (const oracleId of decklist.side) {
+    const index = upsertCardAndGetIndex(cardDetails, oracleId);
+    const card = cardDetails[index];
+
+    const cmc = card.cmc;
+
+    const col = Math.max(0, Math.min(7, Math.floor(cmc)));
+
+    sideboard[0][col].push(index);
+  }
+  return sideboard;
+};
+
+export const buildBotDeck = (
+  pickorder: number[],
+  basics: number[],
+  cards: CardDetails[],
+): { mainboard: number[][][]; sideboard: number[][][] } => {
+  const mainboardBuilt = deckbuild(
+    pickorder.map((index) => cards[index]),
+    basics.map((index) => cards[index]),
+  ).mainboard;
+
+  const pool = pickorder.slice();
+
+  const newMainboard = [];
+
+  for (const oracle of mainboardBuilt) {
+    const poolIndex = pool.findIndex((cardindex) => cards[cardindex].oracle_id === oracle);
+    if (poolIndex === -1) {
+      // try basics
+      const basicsIndex = basics.findIndex((cardindex) => cards[cardindex].oracle_id === oracle);
+      if (basicsIndex !== -1) {
+        newMainboard.push(basics[basicsIndex]);
+      }
+    } else {
+      newMainboard.push(pool[poolIndex]);
+      pool.splice(poolIndex, 1);
+    }
+  }
+
+  // format mainboard
+  const formattedMainboard = setupPicks(2, 8);
+  const formattedSideboard = setupPicks(1, 8);
+
+  for (const index of newMainboard) {
+    const card = cards[index];
+    const { row, col } = getCardDefaultRowColumn(detailsToCard(card));
+
+    formattedMainboard[row][col].push(index);
+  }
+
+  for (const index of pool) {
+    if (!basics.includes(index)) {
+      const card = cards[index];
+      const { col } = getCardDefaultRowColumn(detailsToCard(card));
+
+      formattedSideboard[0][col].push(index);
+    }
+  }
+
+  return {
+    mainboard: formattedMainboard,
+    sideboard: formattedSideboard,
+  };
+};

--- a/tests/draftmancer/api.test.ts
+++ b/tests/draftmancer/api.test.ts
@@ -1,12 +1,20 @@
 import express, { Application } from 'express';
-import { PublishDraftBody, routes } from 'src/router/routes/api/draftmancer/publish';
-import { getReasonableCardByOracle } from 'src/util/carddb';
 import request from 'supertest';
 
+import Card from '../../src/datatypes/Card';
+import CubeType from '../../src/datatypes/Cube';
+import { DraftmancerPick } from '../../src/datatypes/Draft';
+import { Player, PublishDraftBody } from '../../src/datatypes/Draftmancer';
+import type DraftSeatType from '../../src/datatypes/DraftSeat';
 import Cube from '../../src/dynamo/models/cube';
 import Draft from '../../src/dynamo/models/draft';
+import { handler, routes, validatePublishDraftBody } from '../../src/router/routes/api/draftmancer/publish';
 import { RequestHandler } from '../../src/types/express';
-import { createCardDetails, createCube } from '../test-utils/data';
+import { cardFromId } from '../../src/util/carddb';
+import { buildBotDeck, formatMainboard, formatSideboard, getPicksFromPlayer } from '../../src/util/draftmancerUtil';
+import * as draftutil from '../../src/util/draftutil';
+import { createBasicsIds, createCard, createCardDetails, createCube } from '../test-utils/data';
+import { call, middleware } from '../test-utils/transport';
 
 jest.mock('../../src/util/draftbots', () => ({
   deckbuild: jest.fn(),
@@ -16,53 +24,76 @@ jest.mock('../../src/dynamo/models/cube', () => ({
   getById: jest.fn(),
 }));
 
+jest.mock('../../src/dynamo/models/draft', () => ({
+  put: jest.fn(),
+}));
+
 jest.mock('../../src/util/carddb', () => ({
-  getReasonableCardByOracle: jest.fn(),
+  cardFromId: jest.fn(),
 }));
 
 jest.mock('../../src/dynamo/models/draft', () => ({
   put: jest.fn(),
 }));
 
-describe('Publish', () => {
-  let app: Application;
+jest.mock('../../src/util/draftmancerUtil', () => ({
+  buildBotDeck: jest.fn(),
+  formatMainboard: jest.fn(),
+  formatSideboard: jest.fn(),
+  getPicksFromPlayer: jest.fn(),
+  upsertCardAndGetIndex: jest.fn(),
+}));
 
-  beforeAll(async () => {
-    app = express();
-    app.use(express.json());
-    //Need to type as our RequestHandler or Typescript gets angry
-    app.post('/api/draftmancer/publish', ...(routes[0].handler as RequestHandler[]));
+//Not mocking cardutil because those functions are pretty simple
+//Not mocking draftutil.setupPicks as simple
 
-    process.env.DRAFTMANCER_API_KEY = 'api-key';
-  });
+type DraftSeatPicks = Pick<DraftSeatType, 'pickorder' | 'mainboard' | 'sideboard' | 'trashorder'> & {
+  draftmancerPicks: DraftmancerPick[];
+};
 
-  it('requires a valid api key', async () => {
-    let response = await request(app)
-      .post('/api/draftmancer/publish')
-      .send(createRequest({ apiKey: '' }));
-    expect(response.status).toBe(400);
-
-    response = await request(app)
-      .post('/api/draftmancer/publish')
-      .send(createRequest({ apiKey: 'invalid api key' }));
-    expect(response.status).toBe(401);
-  });
-
-  it('should accept a valid request without bots', async () => {
-    const cube = createCube({ id: 'my-cube' });
-
-    (Cube.getById as jest.Mock).mockResolvedValue(cube);
-    (getReasonableCardByOracle as jest.Mock).mockReturnValue(createCardDetails());
-    (Draft.put as jest.Mock).mockResolvedValue('uuid');
-
-    const response = await request(app)
-      .post('/api/draftmancer/publish')
-      .send(createRequest({ cubeID: cube.id }));
-
-    expect(response.status).toBe(200);
-    expect(Cube.getById).toHaveBeenCalledWith(cube.id);
-    expect(Draft.put).toHaveBeenCalled();
-  });
+// Helper function to create player data
+const createPlayerData = (cardIdPrefix: string, overrides?: Partial<Player>) => ({
+  userName: 'test-user',
+  isBot: false,
+  picks: [
+    {
+      booster: [
+        `cardid-${cardIdPrefix}1234`,
+        `cardid-${cardIdPrefix}1253`,
+        `cardid-${cardIdPrefix}1123`,
+        `cardid-${cardIdPrefix}1475`,
+      ],
+      picks: [1],
+      burn: [],
+    },
+    {
+      booster: [`cardid-${cardIdPrefix}2313`, `cardid-${cardIdPrefix}2211`, `cardid-${cardIdPrefix}2234`],
+      picks: [2],
+      burn: [],
+    },
+    {
+      booster: [`cardid-${cardIdPrefix}3525`, `cardid-${cardIdPrefix}3526`],
+      picks: [0],
+      burn: [],
+    },
+    {
+      booster: [`cardid-${cardIdPrefix}4113`],
+      picks: [0],
+      burn: [],
+    },
+  ],
+  decklist: {
+    main: [`cardid-${cardIdPrefix}1253`, `cardid-${cardIdPrefix}2234`, `cardid-${cardIdPrefix}4113`],
+    side: [`cardid-${cardIdPrefix}3525`],
+    lands: {
+      W: 2,
+      U: 3,
+      B: 5,
+      R: 7,
+      G: 1,
+    },
+  },
+  ...overrides,
 });
 
 const createRequest = (overrides?: Partial<PublishDraftBody>): PublishDraftBody => {
@@ -108,3 +139,457 @@ const createRequest = (overrides?: Partial<PublishDraftBody>): PublishDraftBody 
     ...overrides,
   };
 };
+
+const createPlayerDraftPicks = (startingCardId: number) => {
+  return [
+    {
+      booster: [startingCardId, startingCardId + 1, startingCardId + 2, startingCardId + 3],
+      pick: 1,
+    },
+    {
+      booster: [startingCardId + 4, startingCardId + 5, startingCardId + 6],
+      pick: 2,
+    },
+    {
+      booster: [startingCardId + 7, startingCardId + 8],
+      pick: 0,
+    },
+    {
+      booster: [startingCardId + 9],
+      pick: 0,
+    },
+  ];
+};
+
+const createDraftSeatPicks = (
+  startingCardId: number,
+  mainboardCards: Array<{ column: number; row: number; cardIds: number[] }>,
+  sideboardCards: Array<{ column: number; row: number; cardIds: number[] }> = [],
+): DraftSeatPicks => {
+  const mainboard = draftutil.setupPicks(2, 8);
+  const sideboard = draftutil.setupPicks(1, 8);
+
+  mainboardCards.forEach(({ column, row, cardIds }) => {
+    mainboard[column][row].push(...cardIds);
+  });
+
+  sideboardCards.forEach(({ column, row, cardIds }) => {
+    sideboard[column][row].push(...cardIds);
+  });
+
+  return {
+    mainboard,
+    sideboard,
+    pickorder: [1, 2, 0, 0],
+    trashorder: [],
+    draftmancerPicks: createPlayerDraftPicks(startingCardId),
+  };
+};
+
+describe('Publish', () => {
+  let app: Application;
+
+  beforeAll(async () => {
+    app = express();
+    app.use(express.json());
+    //Need to type as our RequestHandler or Typescript gets angry
+    app.post('/api/draftmancer/publish', ...(routes[0].handler as RequestHandler[]));
+
+    process.env.DRAFTMANCER_API_KEY = 'api-key';
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockCards: Map<string, Card> = new Map();
+
+  const mockCube = createCube({ id: 'test-cube', basics: createBasicsIds() });
+
+  // Helper function to setup common test dependencies
+  const setupTestDependencies = () => {
+    const cardDetails = createCardDetails();
+
+    (Cube.getById as jest.Mock).mockResolvedValue(mockCube);
+
+    (cardFromId as jest.Mock).mockImplementation((cardID: string) => {
+      if (!mockCards.has(cardID)) {
+        const details = createCard({
+          cardID: cardID,
+        });
+        mockCards.set(cardID, details);
+      }
+      return mockCards.get(cardID);
+    });
+    (Draft.put as jest.Mock).mockResolvedValue('test-draft-id');
+
+    return { cube: mockCube, cardDetails };
+  };
+
+  // Helper function to verify high level draft details
+  const verifyDraftCreation = (cube: CubeType) => {
+    expect(Draft.put).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Draftmancer Draft',
+        cube: cube.id,
+        complete: true,
+        cubeOwner: cube.owner,
+        InitialState: undefined,
+        seed: undefined,
+        basics: [0, 1, 2, 3, 4],
+        type: 'd',
+        owner: undefined,
+        date: expect.any(Number),
+        DraftmancerLog: expect.objectContaining({
+          sessionID: 'sessionID',
+        }),
+      }),
+    );
+  };
+
+  const validateHumanDraftSeat = (seat: Record<string, any>, seatInfo: DraftSeatPicks) => {
+    expect(seat).toEqual(
+      expect.objectContaining({
+        description: 'This deck was drafted on Draftmancer by human1',
+        owner: undefined,
+        bot: false,
+      }),
+    );
+    validateCommonDraftSeat(seat, seatInfo);
+  };
+
+  const validateBotDraftSeat = (seat: Record<string, any>, seatInfo: DraftSeatPicks) => {
+    expect(seat).toEqual(
+      expect.objectContaining({
+        description: 'This deck was drafted by a bot on Draftmancer',
+        owner: undefined,
+        bot: true,
+      }),
+    );
+    validateCommonDraftSeat(seat, seatInfo);
+  };
+
+  const validateCommonDraftSeat = (seat: Record<string, any>, seatInfo: DraftSeatPicks) => {
+    const { pickorder, mainboard, sideboard, trashorder } = seatInfo;
+    expect(seat).toEqual(
+      expect.objectContaining({
+        pickorder,
+        mainboard,
+        sideboard,
+        trashorder,
+        name: '',
+        owner: undefined,
+      }),
+    );
+  };
+
+  it('should handle human players correctly', async () => {
+    const { cube } = setupTestDependencies();
+
+    // Player 1 setup
+    const playerOneDraftSeat = createDraftSeatPicks(6, [
+      { column: 0, row: 1, cardIds: [9, 8] },
+      { column: 0, row: 2, cardIds: [11] },
+    ]);
+
+    (getPicksFromPlayer as jest.Mock).mockReturnValueOnce(playerOneDraftSeat);
+    (formatMainboard as jest.Mock).mockReturnValueOnce(playerOneDraftSeat.mainboard);
+    (formatSideboard as jest.Mock).mockReturnValueOnce(playerOneDraftSeat.sideboard);
+
+    // Player 2 setup
+    const playerTwoDraftSeat = createDraftSeatPicks(
+      16,
+      [
+        { column: 0, row: 6, cardIds: [17] },
+        { column: 0, row: 7, cardIds: [22] },
+        { column: 1, row: 0, cardIds: [23] },
+        { column: 1, row: 5, cardIds: [25] },
+      ],
+      [
+        { column: 0, row: 0, cardIds: [6] },
+        { column: 0, row: 3, cardIds: [17] },
+      ],
+    );
+
+    (getPicksFromPlayer as jest.Mock).mockReturnValueOnce(playerTwoDraftSeat);
+    (formatMainboard as jest.Mock).mockReturnValueOnce(playerTwoDraftSeat.mainboard);
+    (formatSideboard as jest.Mock).mockReturnValueOnce(playerTwoDraftSeat.sideboard);
+
+    const response = await call(handler)
+      .withBody(
+        createRequest({
+          cubeID: cube.id,
+          players: [
+            createPlayerData('1', { userName: 'human1', isBot: false }),
+            createPlayerData('2', { userName: 'human2', isBot: false }),
+          ],
+        }),
+      )
+      .send();
+
+    expect(response.status).toBe(200);
+
+    const putCall = (Draft.put as jest.Mock).mock.calls[0][0];
+    expect(putCall.seats.every((seat: any) => seat.bot === false)).toBeTruthy();
+    expect(putCall.seats.every((seat: any) => seat.description.includes('drafted on Draftmancer by'))).toBeTruthy();
+
+    expect(putCall.DraftmancerLog.players[0]).toEqual(playerOneDraftSeat.draftmancerPicks);
+    expect(putCall.DraftmancerLog.players[1]).toEqual(playerTwoDraftSeat.draftmancerPicks);
+
+    verifyDraftCreation(cube);
+  });
+
+  it('should handle bot players correctly', async () => {
+    const { cube } = setupTestDependencies();
+
+    // Player 1 setup
+    const playerOneDraftSeat = createDraftSeatPicks(6, [
+      { column: 0, row: 1, cardIds: [9, 8] },
+      { column: 0, row: 2, cardIds: [11] },
+    ]);
+
+    (getPicksFromPlayer as jest.Mock).mockReturnValueOnce(playerOneDraftSeat);
+    (formatMainboard as jest.Mock).mockReturnValueOnce(playerOneDraftSeat.mainboard);
+    (formatSideboard as jest.Mock).mockReturnValueOnce(playerOneDraftSeat.sideboard);
+
+    // Player 2 (bot) setup
+    const playerTwoDraftSeat = createDraftSeatPicks(
+      16,
+      [
+        { column: 0, row: 6, cardIds: [17] },
+        { column: 0, row: 7, cardIds: [22] },
+        { column: 1, row: 0, cardIds: [23] },
+        { column: 1, row: 5, cardIds: [25] },
+      ],
+      [
+        { column: 0, row: 0, cardIds: [6] },
+        { column: 0, row: 3, cardIds: [17] },
+      ],
+    );
+
+    (getPicksFromPlayer as jest.Mock).mockReturnValueOnce(playerTwoDraftSeat);
+    (buildBotDeck as jest.Mock).mockReturnValueOnce({
+      mainboard: playerTwoDraftSeat.mainboard,
+      sideboard: playerTwoDraftSeat.sideboard,
+    });
+
+    const response = await call(handler)
+      .withBody(
+        createRequest({
+          cubeID: cube.id,
+          players: [
+            createPlayerData('1', { userName: 'human1', isBot: false }),
+            createPlayerData('2', { userName: 'bot2', isBot: true }),
+          ],
+        }),
+      )
+      .send();
+
+    expect(response.status).toBe(200);
+
+    const putCall = (Draft.put as jest.Mock).mock.calls[0][0];
+    validateHumanDraftSeat(putCall.seats[0], playerOneDraftSeat);
+    validateBotDraftSeat(putCall.seats[1], playerTwoDraftSeat);
+
+    expect(putCall.DraftmancerLog.players[0]).toEqual(playerOneDraftSeat.draftmancerPicks);
+    expect(putCall.DraftmancerLog.players[1]).toEqual(playerTwoDraftSeat.draftmancerPicks);
+
+    verifyDraftCreation(cube);
+  });
+
+  it('should handle database errors gracefully', async () => {
+    const error = new Error('Database error');
+    (Cube.getById as jest.Mock).mockRejectedValue(error);
+
+    const response = await request(app).post('/api/draftmancer/publish').send(createRequest());
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({
+      error: 'Error publishing draft',
+    });
+  });
+
+  it('should handle missing cube gracefully', async () => {
+    (Cube.getById as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).post('/api/draftmancer/publish').send(createRequest());
+
+    expect(response.status).toBe(500);
+  });
+
+  it('requires a valid api key', async () => {
+    let response = await request(app)
+      .post('/api/draftmancer/publish')
+      .send(createRequest({ apiKey: '' }));
+    expect(response.status).toBe(400);
+
+    response = await request(app)
+      .post('/api/draftmancer/publish')
+      .send(createRequest({ apiKey: 'invalid api key' }));
+    expect(response.status).toBe(401);
+  });
+});
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+describe('validatePublishDraftBody', () => {
+  const assertPassingValidation = async (body: any) => {
+    const res = await middleware(validatePublishDraftBody).withBody(body).send();
+    expect(res.nextCalled).toBeTruthy();
+  };
+
+  const assertFailingValidation = async (body: any) => {
+    const res = await middleware(validatePublishDraftBody).withBody(body).send();
+    expect(res.status).toEqual(400);
+    expect(res.nextCalled).toBeFalsy();
+  };
+
+  const validBody = {
+    cubeID: 'test-cube-id',
+    sessionID: 'test-session-id',
+    timestamp: 1234567890,
+    players: [
+      {
+        userName: 'testUser',
+        isBot: false,
+        picks: [
+          {
+            booster: ['123e4567-e89b-12d3-a456-426614174000'],
+            picks: [1, 2],
+            burn: [0],
+          },
+        ],
+        decklist: {
+          main: ['123e4567-e89b-12d3-a456-426614174000'],
+          side: ['223e4567-e89b-12d3-a456-426614174000'],
+          lands: {
+            W: 4,
+            U: 4,
+            B: 4,
+            R: 4,
+            G: 4,
+          },
+        },
+      },
+    ],
+    apiKey: 'test-api-key',
+  };
+
+  it('should pass with valid body data', async () => {
+    await assertPassingValidation(validBody);
+  });
+
+  it('should fail without cubeID', async () => {
+    const { cubeID, ...bodyWithoutCubeId } = validBody;
+    await assertFailingValidation(bodyWithoutCubeId);
+  });
+
+  it('should fail without sessionID', async () => {
+    const { sessionID, ...bodyWithoutSessionId } = validBody;
+    await assertFailingValidation(bodyWithoutSessionId);
+  });
+
+  it('should fail without timestamp', async () => {
+    const { timestamp, ...bodyWithoutTimestamp } = validBody;
+    await assertFailingValidation(bodyWithoutTimestamp);
+  });
+
+  it('should fail without players array', async () => {
+    const { players, ...bodyWithoutPlayers } = validBody;
+    await assertFailingValidation(bodyWithoutPlayers);
+  });
+
+  it('should fail with invalid player data', async () => {
+    const invalidBody = {
+      ...validBody,
+      players: [
+        {
+          userName: 'testUser',
+          // missing isBot
+          picks: validBody.players[0].picks,
+          decklist: validBody.players[0].decklist,
+        },
+      ],
+    };
+    await assertFailingValidation(invalidBody);
+  });
+
+  it('should fail with invalid picks structure', async () => {
+    const invalidBody = {
+      ...validBody,
+      players: [
+        {
+          ...validBody.players[0],
+          picks: [
+            {
+              booster: 'not-an-array',
+              picks: [1],
+              burn: [],
+            },
+          ],
+        },
+      ],
+    };
+    await assertFailingValidation(invalidBody);
+  });
+
+  it('should fail with invalid decklist structure', async () => {
+    const invalidBody = {
+      ...validBody,
+      players: [
+        {
+          ...validBody.players[0],
+          decklist: {
+            main: ['valid-id'],
+            side: ['valid-id'],
+            lands: {
+              W: 4,
+              U: 4,
+              // missing other colors
+            },
+          },
+        },
+      ],
+    };
+    await assertFailingValidation(invalidBody);
+  });
+
+  it('should fail with invalid UUID in card lists', async () => {
+    const invalidBody = {
+      ...validBody,
+      players: [
+        {
+          ...validBody.players[0],
+          picks: [
+            {
+              booster: ['not-a-uuid'],
+              picks: [1],
+              burn: [],
+            },
+          ],
+        },
+      ],
+    };
+    await assertFailingValidation(invalidBody);
+  });
+
+  it('should fail without apiKey', async () => {
+    const { apiKey, ...bodyWithoutApiKey } = validBody;
+    await assertFailingValidation(bodyWithoutApiKey);
+  });
+
+  it('should allow multiple players', async () => {
+    const bodyWithMultiplePlayers = {
+      ...validBody,
+      players: [validBody.players[0], { ...validBody.players[0], userName: 'testUser2' }],
+    };
+    await assertPassingValidation(bodyWithMultiplePlayers);
+  });
+
+  it('should validate bot players the same as human players', async () => {
+    const bodyWithBot = {
+      ...validBody,
+      players: [{ ...validBody.players[0], isBot: true }],
+    };
+    await assertPassingValidation(bodyWithBot);
+  });
+});

--- a/tests/draftmancer/api.test.ts
+++ b/tests/draftmancer/api.test.ts
@@ -348,7 +348,6 @@ describe('Publish', () => {
       expect.objectContaining({
         date: expect.any(Number),
         to: cube.owner.id,
-        from: '',
         fromUsername: 'human1',
         url: '/cube/deck/test-draft-id',
         body: `human1 drafted your cube: ${cube.name}`,
@@ -480,7 +479,6 @@ describe('Publish', () => {
       expect.objectContaining({
         date: expect.any(Number),
         to: cube.owner.id,
-        from: '',
         fromUsername: 'human1',
         url: '/cube/deck/test-draft-id',
         body: `human1 drafted your cube: ${cube.name}`,

--- a/tests/draftmancer/draftmancerUtil.test.ts
+++ b/tests/draftmancer/draftmancerUtil.test.ts
@@ -1,0 +1,229 @@
+import Card, { CardDetails } from '../../src/datatypes/Card';
+import { Decklist } from '../../src/datatypes/Draftmancer';
+import { getReasonableCardByOracle } from '../../src/util/carddb';
+import { deckbuild } from '../../src/util/draftbots';
+import { buildBotDeck, formatMainboard, formatSideboard, upsertCardAndGetIndex } from '../../src/util/draftmancerUtil';
+import { getCardDefaultRowColumn } from '../../src/util/draftutil';
+import { createCardDetails } from '../test-utils/data';
+
+jest.mock('../../src/util/carddb', () => ({
+  getReasonableCardByOracle: jest.fn(),
+}));
+
+jest.mock('../../src/util/draftbots', () => ({
+  deckbuild: jest.fn(),
+}));
+
+//Not mocking cardutil.detailsToCard or draftutil.setupPicks as they are simple
+
+jest.mock('../../src/util/draftutil', () => ({
+  ...jest.requireActual('../../src/util/draftutil'),
+  getCardDefaultRowColumn: jest.fn(),
+}));
+
+describe('upsertCardAndGetIndex', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('adds new card to end of cards array and returns index', () => {
+    const cards: CardDetails[] = [];
+    cards.push(createCardDetails({ oracle_id: 'existing id' }));
+    const oracleId = 'test-oracle-id';
+    const mockCard = createCardDetails({ oracle_id: oracleId });
+
+    (getReasonableCardByOracle as jest.Mock).mockReturnValue(mockCard);
+
+    const result = upsertCardAndGetIndex(cards, oracleId);
+
+    expect(result).toBe(1);
+    expect(cards).toHaveLength(2);
+    expect(cards[1]).toBe(mockCard);
+  });
+
+  it('returns existing card index without adding duplicate', () => {
+    const oracleId = 'test-oracle-id';
+    const existingCard = createCardDetails({ oracle_id: oracleId });
+    const otherCard = createCardDetails({ oracle_id: 'other-id' });
+    const cards = [existingCard, otherCard];
+
+    const result = upsertCardAndGetIndex(cards, oracleId);
+
+    expect(result).toBe(0);
+    expect(cards).toHaveLength(2);
+  });
+});
+
+describe('formatMainboard', () => {
+  it('formats creature cards correctly', () => {
+    const cards: CardDetails[] = [];
+    const decklist: Decklist = {
+      main: ['creature-id'],
+      side: [],
+      lands: { W: 0, U: 0, B: 0, R: 0, G: 0 },
+    };
+
+    const creatureCard = createCardDetails({
+      oracle_id: 'creature-id',
+      type: 'Creature',
+      cmc: 2,
+    });
+
+    (getReasonableCardByOracle as jest.Mock).mockReturnValue(creatureCard);
+
+    const result = formatMainboard(decklist, cards);
+
+    // Creature should be in row 0, column 2 (based on CMC)
+    expect(result[0][2]).toContain(0);
+    expect(result[1][2]).toHaveLength(0);
+  });
+
+  it('formats non-creature cards correctly', () => {
+    const cards: CardDetails[] = [];
+    const decklist: Decklist = {
+      main: ['instant-id'],
+      side: [],
+      lands: { W: 0, U: 0, B: 0, R: 0, G: 0 },
+    };
+
+    const instantCard = createCardDetails({
+      oracle_id: 'instant-id',
+      type: 'Instant',
+      cmc: 3,
+    });
+
+    (getReasonableCardByOracle as jest.Mock).mockReturnValue(instantCard);
+
+    const result = formatMainboard(decklist, cards);
+
+    // Non-creature should be in row 1, column 3 (based on CMC)
+    expect(result[0][3]).toHaveLength(0);
+    expect(result[1][3]).toContain(0);
+  });
+
+  it('handles high CMC cards by capping column at 7', () => {
+    const cards: CardDetails[] = [];
+    const decklist: Decklist = {
+      main: ['high-cmc-id'],
+      side: [],
+      lands: { W: 0, U: 0, B: 0, R: 0, G: 0 },
+    };
+
+    const highCMCCard = createCardDetails({
+      oracle_id: 'high-cmc-id',
+      type: 'Creature',
+      cmc: 15,
+    });
+
+    (getReasonableCardByOracle as jest.Mock).mockReturnValue(highCMCCard);
+
+    const result = formatMainboard(decklist, cards);
+
+    expect(result[0][7]).toContain(0);
+  });
+});
+
+describe('formatSideboard', () => {
+  it('formats sideboard cards by CMC', () => {
+    const cards: CardDetails[] = [];
+    const decklist: Decklist = {
+      main: [],
+      side: ['side-card-id'],
+      lands: { W: 0, U: 0, B: 0, R: 0, G: 0 },
+    };
+
+    const sideCard = createCardDetails({
+      oracle_id: 'side-card-id',
+      cmc: 2,
+    });
+
+    (getReasonableCardByOracle as jest.Mock).mockReturnValue(sideCard);
+
+    const result = formatSideboard(decklist, cards);
+
+    expect(result[0][2]).toContain(0);
+  });
+
+  it('caps sideboard card CMC at column 7', () => {
+    const cards: CardDetails[] = [];
+    const decklist: Decklist = {
+      main: [],
+      side: ['high-cmc-id'],
+      lands: { W: 0, U: 0, B: 0, R: 0, G: 0 },
+    };
+
+    const highCMCCard = createCardDetails({
+      oracle_id: 'high-cmc-id',
+      cmc: 10,
+    });
+
+    (getReasonableCardByOracle as jest.Mock).mockReturnValue(highCMCCard);
+
+    const result = formatSideboard(decklist, cards);
+
+    expect(result[0][7]).toContain(0);
+  });
+});
+
+describe('buildBotDeck', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (getCardDefaultRowColumn as jest.Mock).mockImplementation((card: Card) => {
+      if (card.details?.oracle_id.toLowerCase().includes('basic')) {
+        return { row: 1, col: 0 };
+      } else {
+        const row = card.details?.type.toLowerCase().includes('creature') ? 0 : 1;
+        return { row, col: card.cmc };
+      }
+    });
+  });
+
+  it('builds deck with correct mainboard and sideboard', () => {
+    const pickorder = [0, 1, 3];
+    const basics = [2, 4];
+    const cards = [
+      createCardDetails({ oracle_id: 'card-1', type: 'Creature', cmc: 2 }),
+      createCardDetails({ oracle_id: 'card-2', type: 'Instant', cmc: 3 }),
+      createCardDetails({ oracle_id: 'basic-1', type: 'Basic Land' }),
+      createCardDetails({ oracle_id: 'card-3', type: 'Creature', cmc: 4 }),
+      createCardDetails({ oracle_id: 'basic-2', type: 'Basic Land' }),
+    ];
+
+    (deckbuild as jest.Mock).mockReturnValue({
+      mainboard: ['card-1', 'card-2', 'basic-1'],
+    });
+
+    const result = buildBotDeck(pickorder, basics, cards);
+
+    expect(deckbuild).toHaveBeenCalledWith([cards[0], cards[1], cards[3]], [cards[2], cards[4]]);
+
+    // Verify mainboard formatting
+    expect(result.mainboard[0][2]).toContain(0); // creature in row 0
+    expect(result.mainboard[1][3]).toContain(1); // instant in row 1
+    expect(result.mainboard[1][0]).toContain(2); // basic land in row 1, col 0
+
+    // Verify remaining card went to sideboard
+    expect(result.sideboard[0][4]).toContain(3); // card-3 in sideboard
+  });
+
+  it('handles missing cards gracefully', () => {
+    const pickorder = [0];
+    const basics = [1];
+    const cards = [
+      createCardDetails({ oracle_id: 'card-1', type: 'Creature', cmc: 2 }),
+      createCardDetails({ oracle_id: 'basic-1', type: 'Basic Land' }),
+    ];
+
+    (deckbuild as jest.Mock).mockReturnValue({
+      mainboard: ['missing-card'],
+    });
+
+    const result = buildBotDeck(pickorder, basics, cards);
+
+    // Should have empty mainboard since card wasn't found
+    expect(result.mainboard.flat(2)).toHaveLength(0);
+    // Original card should be in sideboard
+    expect(result.sideboard[0][2]).toContain(0);
+  });
+});

--- a/tests/test-utils/data.ts
+++ b/tests/test-utils/data.ts
@@ -165,6 +165,20 @@ export const createDraftSeat = (isBot: boolean, overrides?: Partial<DraftSeat>):
   } as DraftSeat;
 };
 
+export const createBasicsSet = (): Card[] => {
+  return [
+    createCardFromDetails({ type: 'Land', name: 'Island' }),
+    createCardFromDetails({ type: 'Land', name: 'Forest' }),
+    createCardFromDetails({ type: 'Land', name: 'Plains' }),
+    createCardFromDetails({ type: 'Land', name: 'Mountain' }),
+    createCardFromDetails({ type: 'Land', name: 'Swamp' }),
+  ];
+};
+
+export const createBasicsIds = (): string[] => {
+  return createBasicsSet().map((c) => c.cardID);
+};
+
 /**
  * Two seats, 3 packs, 30 cards total (5 cards per pack)
  */
@@ -172,13 +186,7 @@ export const createCompletedSoloDraft = (overrides?: Partial<Draft>): Draft => {
   // Create 30 unique cards
   const cards = Array.from({ length: 30 }, () => createCard());
   //Add 5 basics
-  const basics = [
-    createCardFromDetails({ type: 'Land', name: 'Island' }),
-    createCardFromDetails({ type: 'Land', name: 'Forest' }),
-    createCardFromDetails({ type: 'Land', name: 'Plains' }),
-    createCardFromDetails({ type: 'Land', name: 'Mountain' }),
-    createCardFromDetails({ type: 'Land', name: 'Swamp' }),
-  ];
+  const basics = createBasicsSet();
 
   const standardPickSteps: DraftStep[] = [];
   for (let i = 0; i < 5; i++) {


### PR DESCRIPTION
# Changes
1. Refactoring of logic from publish.ts to new draftmancerUtils and type file, in order to simplify unit testing
2. Complete test coverage of both
3. Make from optional in Notification to support anonymous notifications, not from an existing CubeCobra user
4. Related to that, adjust the Notifications history UI so that if from isn't set then it does not link

# Challenges
Even working with Copilot to help create the tests, it was a struggle to get the test data into a reasonable form such that it could be used for multiple tests.

# Testing
1. Ensuring all tests pass
2. Using curl to send a test draftmancer API body (shared by Dekkaru in discord on an old bug related to drafting) and validate the draft is saved sucessfully, and viewable in the UI

## After

Draft notification to the cube owner
![new-notification-without-user-link-from-draftmancer](https://github.com/user-attachments/assets/18cf38d1-d100-4e6a-93c4-86d129078bcf)

Draft created by importing from curl:
![image](https://github.com/user-attachments/assets/8b00dec9-6747-4121-9998-96911610a061)

