### PR TITLE
Increase draft end timeout

### DIFF
--- a/src/client/contexts/CSRFContext.tsx
+++ b/src/client/contexts/CSRFContext.tsx
@@ -1,8 +1,10 @@
 import React, { createContext, useCallback } from 'react';
 
+type ExtendedRequestInit = RequestInit & { timeout?: number };
+
 interface CSRFContext {
   csrfToken: string;
-  csrfFetch: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
+  csrfFetch: (input: RequestInfo, init?: ExtendedRequestInit) => Promise<Response>;
   callApi: (route: RequestInfo, body: any) => Promise<Response>;
 }
 
@@ -21,10 +23,7 @@ interface CSRFContextProviderProps {
   csrfToken: string;
 }
 
-async function fetchWithTimeout(
-  resource: RequestInfo,
-  options: RequestInit & { timeout?: number } = {},
-): Promise<Response> {
+async function fetchWithTimeout(resource: RequestInfo, options: ExtendedRequestInit = {}): Promise<Response> {
   const { timeout = 10000 } = options;
 
   const controller = new AbortController();
@@ -39,7 +38,7 @@ async function fetchWithTimeout(
 
 export const CSRFContextProvider: React.FC<CSRFContextProviderProps> = ({ children, csrfToken }) => {
   const csrfFetch = useCallback(
-    async (resource: RequestInfo, init?: RequestInit) => {
+    async (resource: RequestInfo, init?: ExtendedRequestInit) => {
       if (init) {
         init.credentials = init.credentials || 'same-origin';
       }

--- a/src/client/pages/CubeDraftPage.tsx
+++ b/src/client/pages/CubeDraftPage.tsx
@@ -126,6 +126,7 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
           mainboard,
           sideboard,
         }),
+        timeout: 60 * 1000, //Match server-side timeout
       });
 
       // Force error if status is not 2xx range


### PR DESCRIPTION
Based on bug reports about drafts failing to end, sometimes with the draft not finished recording and others when the UI doesn't transition to the deck building but you can see the draft in the playtest history. At least in the latter case the most logical explanation is the frontend fetch timeout of 10 seconds is hit, but the server finishes the draft within its 60 second timeout.

# Testing

## After

Temporarily made each bot deck build take 5 seconds and with 7 bots server will take 35+ seconds to finish. But with the increased frontend timeout the draft finishes and transitions to the deck building UI.
![new-higher-cube-draft-frontend-timeout](https://github.com/user-attachments/assets/10c36077-8f70-40db-9fa4-7e5b0c5240c3)
