### PR TITLE
Backfill dynamo model tests

### DIFF
--- a/tests/cards/carddb.test.ts
+++ b/tests/cards/carddb.test.ts
@@ -7,12 +7,15 @@ const mockCardCatalog: Catalog = {
   imagedict: {},
   cardimages: {},
   cardnames: [],
+  comboTree: {},
+  comboDict: {},
   full_names: [],
   nameToId: {},
   oracleToId: {},
   english: {},
   _carddict: {},
   indexToOracle: [],
+  oracleToIndex: {},
   metadatadict: {},
   printedCardList: [], // for card filters
 };

--- a/tests/cards/cardhistory.dynamo.test.ts
+++ b/tests/cards/cardhistory.dynamo.test.ts
@@ -1,0 +1,151 @@
+import { Period, UnhydratedCardHistory } from '../../src/datatypes/History';
+import CardHistory from '../../src/dynamo/models/cardhistory';
+
+// Mock dependencies
+jest.mock('../../src/dynamo/util');
+
+// Test helpers
+const createUnhydratedCardHistory = (overrides?: Partial<UnhydratedCardHistory>): UnhydratedCardHistory => ({
+  OTComp: 'oracle-123:day',
+  oracle: 'oracle-123',
+  date: new Date('2024-03-24').valueOf(),
+  picks: 10,
+  elo: 1201,
+  size180: undefined,
+  size360: [0, 0],
+  size450: [0, 0],
+  size540: [0, 0],
+  size720: [0, 0],
+  pauper: [0, 0],
+  peasant: [0, 0],
+  legacy: [50, 75],
+  modern: [33, 45],
+  vintage: [0, 0],
+  cubeCount: undefined,
+  total: [83, 120],
+  ...overrides,
+});
+
+const setupQueryResult = (response: any) => {
+  (mockDynamoClient.query as jest.Mock).mockResolvedValueOnce(response);
+};
+
+const verifyQueryCall = (params: any) => {
+  expect(mockDynamoClient.query).toHaveBeenCalledWith(expect.objectContaining(params));
+};
+
+// First test createClient configuration
+describe('CardHistory Model Initialization', () => {
+  it('cardhistory table created with proper configuration', async () => {
+    // Import to trigger createClient
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('../../src/dynamo/models/cardhistory');
+
+    expect(mockDynamoCreateClient).toHaveBeenCalledWith({
+      name: 'CARD_HISTORY',
+      partitionKey: 'OTComp',
+      sortKey: 'date',
+      attributes: {
+        OTComp: 'S',
+        date: 'N',
+      },
+    });
+  });
+});
+
+describe('CardHistory Model', () => {
+  const mockCardHistory = createUnhydratedCardHistory();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+  });
+
+  describe('getByOracleAndType', () => {
+    it('returns empty result when no history found', async () => {
+      setupQueryResult({ Items: [], LastEvaluatedKey: null });
+
+      const result = await CardHistory.getByOracleAndType('oracle-123', Period.DAY, 5);
+
+      expect(result).toEqual({ items: [], lastKey: null });
+      verifyQueryCall({
+        KeyConditionExpression: 'OTComp = :oracle',
+        ExpressionAttributeValues: {
+          ':oracle': 'oracle-123:day',
+        },
+        ScanIndexForward: false,
+        Limit: 5,
+      });
+    });
+
+    it('returns history items with last key', async () => {
+      const history1 = createUnhydratedCardHistory({ date: 1000 });
+      const history2 = createUnhydratedCardHistory({ date: 2000 });
+
+      setupQueryResult({
+        Items: [history1, history2],
+        LastEvaluatedKey: { key: 'lastKey' },
+      });
+
+      const result = await CardHistory.getByOracleAndType('oracle-123', Period.DAY, 10);
+
+      expect(result.items).toEqual([history1, history2]);
+      expect(result.lastKey).toEqual({ key: 'lastKey' });
+      verifyQueryCall({
+        KeyConditionExpression: 'OTComp = :oracle',
+        ExpressionAttributeValues: {
+          ':oracle': 'oracle-123:day',
+        },
+        ScanIndexForward: false,
+        Limit: 10,
+      });
+    });
+
+    it('uses default limit when limit is falsey', async () => {
+      setupQueryResult({ Items: [], LastEvaluatedKey: null });
+
+      await CardHistory.getByOracleAndType('oracle-123', Period.DAY, 0);
+
+      verifyQueryCall({
+        Limit: 100,
+      });
+    });
+
+    it('uses provided last key for pagination', async () => {
+      setupQueryResult({ Items: [], LastEvaluatedKey: null });
+
+      const lastKey = { S: 'previousPage' };
+      await CardHistory.getByOracleAndType('oracle-123', Period.DAY, 5, lastKey);
+
+      verifyQueryCall({
+        ExclusiveStartKey: lastKey,
+      });
+    });
+  });
+
+  describe('put', () => {
+    it('saves card history document', async () => {
+      await CardHistory.put(mockCardHistory);
+
+      expect(mockDynamoClient.put).toHaveBeenCalledWith(mockCardHistory);
+    });
+  });
+
+  describe('batchPut', () => {
+    it('saves multiple card history documents', async () => {
+      const histories = [createUnhydratedCardHistory({ date: 1000 }), createUnhydratedCardHistory({ date: 2000 })];
+
+      await CardHistory.batchPut(histories);
+
+      expect(mockDynamoClient.batchPut).toHaveBeenCalledWith(histories);
+    });
+  });
+
+  describe('createTable', () => {
+    it('calls client to create table', async () => {
+      await CardHistory.createTable();
+
+      expect(mockDynamoClient.createTable).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/cards/changelog.dynamo.test.ts
+++ b/tests/cards/changelog.dynamo.test.ts
@@ -1,0 +1,398 @@
+import { v4 as UUID } from 'uuid';
+
+import Card, { Changes } from '../../src/datatypes/Card';
+import ChangelogType from '../../src/datatypes/ChangeLog';
+import Changelog from '../../src/dynamo/models/changelog';
+import { getBucketName, getObject, putObject } from '../../src/dynamo/s3client';
+import { cardFromId } from '../../src/util/carddb';
+import {
+  createCard,
+  createCardDetails,
+  createChangelog,
+  createChangelogCardAdd,
+  createChangelogCardEdit,
+  createChangelogCardRemove,
+  createChangelogCardSwap,
+} from '../test-utils/data';
+
+// Mock dependencies
+
+//Mocking uuid has side-effect of making the data generators from test-utils/data use the mock too
+jest.mock('uuid');
+jest.mock('../../src/util/carddb');
+jest.mock('../../src/dynamo/s3client');
+jest.mock('../../src/dynamo/util');
+
+// Test helpers
+const createUnhydratedChangelog = (overrides?: Partial<ChangelogType>): ChangelogType => ({
+  id: 'changelog-1',
+  cube: 'cube-1',
+  date: new Date('2024-03-24').valueOf(),
+  ...overrides,
+});
+
+const setupQueryResult = (response: any) => {
+  (mockDynamoClient.query as jest.Mock).mockResolvedValueOnce(response);
+};
+
+const verifyQueryCall = (params: any) => {
+  expect(mockDynamoClient.query).toHaveBeenCalledWith(expect.objectContaining(params));
+};
+
+const createHydratedChangelog = (initialChanges: Changes, hydratedCard: Card): Changes => {
+  const mockHydratedChanges = { ...initialChanges };
+  if (mockHydratedChanges.mainboard?.adds) {
+    mockHydratedChanges.mainboard.adds[0].details = hydratedCard.details;
+  }
+  if (mockHydratedChanges.mainboard?.removes) {
+    mockHydratedChanges.mainboard.removes[0].oldCard.details = hydratedCard.details;
+  }
+
+  if (mockHydratedChanges.mainboard?.edits) {
+    mockHydratedChanges.mainboard.edits[0].oldCard.details = hydratedCard.details;
+    mockHydratedChanges.mainboard.edits[0].newCard.details = hydratedCard.details;
+  }
+
+  if (mockHydratedChanges.mainboard?.swaps) {
+    mockHydratedChanges.mainboard.swaps[0].oldCard.details = hydratedCard.details;
+    mockHydratedChanges.mainboard.swaps[0].card.details = hydratedCard.details;
+  }
+
+  return mockHydratedChanges;
+};
+
+describe('Changelog Model Initialization', () => {
+  it('creates changelog table with proper configuration', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('../../src/dynamo/models/changelog');
+
+    expect(mockDynamoCreateClient).toHaveBeenCalledWith({
+      name: 'CUBE_CHANGELOG',
+      partitionKey: 'cube',
+      sortKey: 'date',
+      attributes: {
+        cube: 'S',
+        date: 'N',
+      },
+    });
+  });
+});
+
+describe('Changelog Model', () => {
+  const mockCardDetails = createCardDetails();
+  const mockCard = createCard({ cardID: 'card-123', details: mockCardDetails });
+
+  const mockAdd = createChangelogCardAdd();
+  const mockRemove = createChangelogCardRemove();
+  const mockEdit = createChangelogCardEdit();
+  const mockSwap = createChangelogCardSwap();
+
+  const mockChanges = createChangelog({
+    adds: [mockAdd],
+    removes: [mockRemove],
+    edits: [mockEdit],
+    swaps: [mockSwap],
+  });
+  const mockStoredChangelog = createUnhydratedChangelog();
+
+  /* In the real world these would all be different cards / details, but for simplicity of tests...
+   * Extending the existing mocks so the indexes are consistent between the unhydrated and hydrated.
+   * Conditions are to appease Typescript since mainboard/adds can be undefined.
+   */
+  const mockHydratedChanges = createHydratedChangelog(mockChanges, mockCard);
+
+  const mockCardDetailsTwo = createCardDetails();
+  const mockCardTwo = createCard({ cardID: 'card-567', details: mockCardDetailsTwo });
+
+  const mockChangesTwo = { ...mockChanges };
+  const mockHydratedChangesTwo = createHydratedChangelog(mockChangesTwo, mockCardTwo);
+
+  const setupMultipleCardDetails = () => {
+    (cardFromId as jest.Mock).mockImplementation((cardID: string) => {
+      if (cardID === mockCard.cardID) {
+        return mockCard.details;
+      } else {
+        return mockCardTwo.details;
+      }
+    });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+    (UUID as jest.Mock).mockReturnValue('changelog-2');
+    (getBucketName as jest.Mock).mockReturnValue('test-bucket');
+  });
+
+  describe('getById', () => {
+    it('returns hydrated changelog', async () => {
+      (getObject as jest.Mock).mockResolvedValueOnce(mockChanges);
+      (cardFromId as jest.Mock).mockReturnValue(mockCardDetails);
+
+      const result = await Changelog.getById('cube-1', 'changelog-1');
+
+      expect(result).toEqual(mockHydratedChanges);
+      expect(getObject).toHaveBeenCalledWith('test-bucket', 'changelog/cube-1/changelog-1.json');
+    });
+
+    it('returns hydrated changelog for maybeboard', async () => {
+      const maybeboardChanges = {
+        maybeboard: mockChanges.mainboard,
+      };
+      const maybeboardHydratedChanges = {
+        maybeboard: mockHydratedChanges.mainboard,
+      };
+
+      (getObject as jest.Mock).mockResolvedValueOnce(maybeboardChanges);
+      (cardFromId as jest.Mock).mockReturnValue(mockCardDetails);
+
+      const result = await Changelog.getById('cube-1', 'changelog-1');
+
+      expect(result).toEqual(maybeboardHydratedChanges);
+      expect(getObject).toHaveBeenCalledWith('test-bucket', 'changelog/cube-1/changelog-1.json');
+    });
+
+    it('returns hydrated changelog for partial changesets', async () => {
+      const partialChanges = { ...mockChanges };
+      //If conditions to appease Typescript
+      if (partialChanges?.mainboard?.adds) {
+        delete partialChanges.mainboard.adds;
+      }
+      if (partialChanges?.mainboard?.swaps) {
+        delete partialChanges.mainboard.swaps;
+      }
+
+      const partialHydratedChanges = { ...mockHydratedChanges };
+      if (partialHydratedChanges?.mainboard?.adds) {
+        delete partialHydratedChanges.mainboard.adds;
+      }
+      if (partialHydratedChanges?.mainboard?.swaps) {
+        delete partialHydratedChanges.mainboard.swaps;
+      }
+
+      (getObject as jest.Mock).mockResolvedValueOnce(partialChanges);
+      (cardFromId as jest.Mock).mockReturnValue(mockCardDetails);
+
+      const result = await Changelog.getById('cube-1', 'changelog-1');
+
+      expect(result).toEqual(partialHydratedChanges);
+      expect(getObject).toHaveBeenCalledWith('test-bucket', 'changelog/cube-1/changelog-1.json');
+    });
+
+    it('returns raw changelog when hydration fails', async () => {
+      (getObject as jest.Mock).mockResolvedValueOnce(mockChanges);
+      (cardFromId as jest.Mock).mockImplementation(() => {
+        throw new Error('Card not found');
+      });
+
+      const result = await Changelog.getById('cube-1', 'changelog-1');
+
+      expect(result).toEqual(mockChanges);
+      expect(getObject).toHaveBeenCalledWith('test-bucket', 'changelog/cube-1/changelog-1.json');
+    });
+
+    it('returns raw changelog when there are too many cards to hydrate', async () => {
+      const largeChangelog = createChangelog({
+        adds: Array(5001).fill(mockAdd),
+        removes: Array(5000).fill(mockRemove),
+      });
+      (getObject as jest.Mock).mockResolvedValueOnce(largeChangelog);
+      (cardFromId as jest.Mock).mockReturnValue(mockCardDetails);
+
+      const result = await Changelog.getById('cube-1', 'changelog-1');
+
+      expect(result).toEqual(largeChangelog);
+      expect(getObject).toHaveBeenCalledWith('test-bucket', 'changelog/cube-1/changelog-1.json');
+      expect(cardFromId).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getByCube', () => {
+    it('returns empty result when no changelogs found', async () => {
+      setupQueryResult({ Items: [], LastEvaluatedKey: undefined });
+
+      const result = await Changelog.getByCube('cube-1', 10);
+
+      expect(result).toEqual({ items: [], lastKey: undefined });
+      verifyQueryCall({
+        KeyConditionExpression: '#p1 = :cube',
+        ExpressionAttributeValues: { ':cube': 'cube-1' },
+        ExpressionAttributeNames: { '#p1': 'cube' },
+        Limit: 10,
+        ScanIndexForward: false,
+      });
+    });
+
+    it('returns hydrated changelogs with pagination', async () => {
+      const changelogs = [
+        createUnhydratedChangelog(),
+        createUnhydratedChangelog({ id: 'changelog-2', date: 1742997330 }),
+      ];
+      setupQueryResult({
+        Items: changelogs,
+        LastEvaluatedKey: { S: 'last-key-1' },
+      });
+
+      (getObject as jest.Mock).mockResolvedValueOnce(mockChanges);
+      (getObject as jest.Mock).mockResolvedValueOnce(mockChangesTwo);
+
+      setupMultipleCardDetails();
+
+      const result = await Changelog.getByCube('cube-1', 10);
+
+      expect(result.items?.length).toBe(2);
+      expect(result.lastKey).toEqual({ S: 'last-key-1' });
+      expect(result.items?.[0]).toEqual({
+        cubeId: 'cube-1',
+        date: changelogs[0].date,
+        changelog: mockHydratedChanges,
+      });
+      expect(result.items?.[1]).toEqual({
+        cubeId: 'cube-1',
+        date: 1742997330,
+        changelog: mockHydratedChangesTwo,
+      });
+    });
+
+    it('uses default limit when input is falsey', async () => {
+      const changelogs = [createUnhydratedChangelog()];
+      setupQueryResult({
+        Items: changelogs,
+        LastEvaluatedKey: { S: 'last-key-1' },
+      });
+      (getObject as jest.Mock).mockResolvedValueOnce(mockChanges);
+
+      const result = await Changelog.getByCube('cube-1', 0);
+
+      expect(result.items?.length).toBe(1);
+      verifyQueryCall({
+        Limit: 36,
+      });
+    });
+  });
+
+  describe('put', () => {
+    it('creates new changelog entry', async () => {
+      const result = await Changelog.put(mockChanges, 'cube-1');
+
+      expect(result).toBe('changelog-2');
+      expect(putObject).toHaveBeenCalledWith(
+        'test-bucket',
+        'changelog/cube-1/changelog-2.json',
+        expect.objectContaining(mockChanges),
+      );
+      expect(mockDynamoClient.put).toHaveBeenCalledWith({
+        id: 'changelog-2',
+        cube: 'cube-1',
+        date: expect.any(Number),
+      });
+    });
+
+    it('card details are stripped before saving', async () => {
+      const result = await Changelog.put(mockHydratedChanges, 'cube-1');
+
+      expect(result).toBe('changelog-2');
+      expect(putObject).toHaveBeenCalledWith('test-bucket', 'changelog/cube-1/changelog-2.json', mockChanges);
+      expect(mockDynamoClient.put).toHaveBeenCalledWith({
+        id: 'changelog-2',
+        cube: 'cube-1',
+        date: expect.any(Number),
+      });
+    });
+  });
+
+  describe('scan', () => {
+    it('returns all changelogs with pagination', async () => {
+      (mockDynamoClient.scan as jest.Mock).mockResolvedValueOnce({
+        Items: [mockStoredChangelog],
+        LastEvaluatedKey: { S: 'last-key-1' },
+      });
+
+      const result = await Changelog.scan(10, { S: 'key-1' });
+
+      expect(result).toEqual({
+        items: [mockStoredChangelog],
+        lastKey: { S: 'last-key-1' },
+      });
+      expect(mockDynamoClient.scan).toHaveBeenCalledWith({
+        ExclusiveStartKey: { S: 'key-1' },
+        Limit: 10,
+      });
+    });
+
+    it('uses default limit when input is falsey', async () => {
+      (mockDynamoClient.scan as jest.Mock).mockResolvedValueOnce({
+        Items: [mockStoredChangelog],
+        LastEvaluatedKey: null,
+      });
+
+      const result = await Changelog.scan(0);
+
+      expect(result).toEqual({
+        items: [mockStoredChangelog],
+        lastKey: null,
+      });
+      expect(mockDynamoClient.scan).toHaveBeenCalledWith({
+        Limit: 36,
+      });
+    });
+  });
+
+  describe('batchGet', () => {
+    it('retrieves multiple hydrated changelogs', async () => {
+      const keys = [
+        { cube: 'cube-1', id: 'changelog-1' },
+        { cube: 'cube-2', id: 'changelog-2' },
+      ];
+      (getObject as jest.Mock).mockResolvedValueOnce(mockChanges);
+      (getObject as jest.Mock).mockResolvedValueOnce(mockChangesTwo);
+
+      setupMultipleCardDetails();
+
+      const result = await Changelog.batchGet(keys);
+
+      expect(result).toHaveLength(2);
+      expect(getObject).toHaveBeenCalledTimes(2);
+      keys.forEach((key, index) => {
+        expect(getObject).toHaveBeenNthCalledWith(index + 1, 'test-bucket', `changelog/${key.cube}/${key.id}.json`);
+      });
+      expect(result[0]).toEqual(mockHydratedChanges);
+      expect(result[1]).toEqual(mockHydratedChangesTwo);
+    });
+
+    it('returns raw changelogs on error', async () => {
+      const keys = [
+        { cube: 'cube-1', id: 'changelog-1' },
+        { cube: 'cube-2', id: 'changelog-2' },
+      ];
+      (getObject as jest.Mock).mockResolvedValueOnce(mockChanges);
+      (getObject as jest.Mock).mockResolvedValueOnce(mockChangesTwo);
+
+      (cardFromId as jest.Mock).mockImplementation((cardID: string) => {
+        if (cardID === mockCard.cardID) {
+          return mockCard.details;
+        } else {
+          throw new Error('Unexpected failure in hydrating');
+        }
+      });
+
+      const result = await Changelog.batchGet(keys);
+
+      expect(result).toHaveLength(2);
+      expect(getObject).toHaveBeenCalledTimes(2);
+      keys.forEach((key, index) => {
+        expect(getObject).toHaveBeenNthCalledWith(index + 1, 'test-bucket', `changelog/${key.cube}/${key.id}.json`);
+      });
+      expect(result[0]).toEqual(mockHydratedChanges);
+      expect(result[1]).toEqual(mockChangesTwo);
+    });
+  });
+
+  describe('createTable', () => {
+    it('calls client to create table', async () => {
+      await Changelog.createTable();
+
+      expect(mockDynamoClient.createTable).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/comments/dynamo.test.ts
+++ b/tests/comments/dynamo.test.ts
@@ -1,0 +1,371 @@
+import { v4 as UUID } from 'uuid';
+
+import CommentType, { UnhydratedComment } from '../../src/datatypes/Comment';
+import { CubeImage } from '../../src/datatypes/Cube';
+import Comment from '../../src/dynamo/models/comment';
+import UserModel from '../../src/dynamo/models/user';
+import { getImageData } from '../../src/util/imageutil';
+import { createUser } from '../test-utils/data';
+
+// Mock dependencies
+jest.mock('../../src/dynamo/util');
+jest.mock('../../src/dynamo/models/user');
+jest.mock('../../src/util/imageutil');
+jest.mock('uuid');
+
+// Test helpers
+const createUnhydratedComment = (overrides?: Partial<UnhydratedComment>): UnhydratedComment => ({
+  id: 'comment-1',
+  parent: 'cube-1',
+  date: new Date('2024-03-24').valueOf(),
+  type: 'cube',
+  body: 'Test comment',
+  owner: 'user-1',
+  ...overrides,
+});
+
+const setupQueryResult = (response: any) => {
+  (mockDynamoClient.query as jest.Mock).mockResolvedValueOnce(response);
+};
+
+const verifyQueryCall = (params: any) => {
+  expect(mockDynamoClient.query).toHaveBeenCalledWith(expect.objectContaining(params));
+};
+
+describe('Comment Model Initialization', () => {
+  it('creates comment table with proper configuration', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('../../src/dynamo/models/comment');
+
+    expect(mockDynamoCreateClient).toHaveBeenCalledWith({
+      name: 'COMMENTS',
+      partitionKey: 'id',
+      attributes: {
+        id: 'S',
+        date: 'N',
+        parent: 'S',
+        owner: 'S',
+      },
+      indexes: [
+        {
+          name: 'ByParent',
+          partitionKey: 'parent',
+          sortKey: 'date',
+        },
+        {
+          name: 'ByOwner',
+          partitionKey: 'owner',
+          sortKey: 'date',
+        },
+      ],
+    });
+  });
+});
+
+describe('Comment Model', () => {
+  const mockUser = createUser({
+    id: 'user-1',
+    username: 'testuser',
+    imageName: 'default-avatar',
+  });
+
+  const mockImage = {
+    id: 'image-1234',
+    imageName: 'Test Image',
+    uri: 'https://exmaple.com/test.jpg',
+    artist: 'First Last',
+  } as CubeImage;
+
+  const anonymousUserImage = {
+    id: 'image-6666',
+    imageName: 'Ambush Viper',
+    uri: 'https://exmaple.com/viper.jpg',
+    artist: 'FirstA LastA',
+  } as CubeImage;
+
+  const mockStoredComment = createUnhydratedComment();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (UUID as jest.Mock).mockReturnValue('comment-2');
+    (getImageData as jest.Mock).mockReturnValue(mockImage);
+  });
+
+  describe('getById', () => {
+    it('returns undefined when no comment found', async () => {
+      (mockDynamoClient.get as jest.Mock).mockResolvedValueOnce({ Item: undefined });
+
+      const result = await Comment.getById('comment-999');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns hydrated comment with owner', async () => {
+      (mockDynamoClient.get as jest.Mock).mockResolvedValueOnce({ Item: mockStoredComment });
+      (UserModel.getById as jest.Mock).mockResolvedValueOnce(mockUser);
+
+      const result = await Comment.getById('comment-1');
+
+      expect(result).toEqual({
+        ...mockStoredComment,
+        owner: mockUser,
+        image: mockImage,
+      });
+    });
+
+    it.each([
+      ['undefined owner', undefined],
+      ['null string owner', 'null'],
+    ])('handles anonymous comments correctly with %s', async (_, ownerValue) => {
+      const anonymousComment = createUnhydratedComment({ owner: ownerValue });
+      (mockDynamoClient.get as jest.Mock).mockResolvedValueOnce({ Item: anonymousComment });
+      (getImageData as jest.Mock).mockReturnValue(anonymousUserImage);
+
+      const result = await Comment.getById('comment-1');
+
+      expect(result).toEqual({
+        ...anonymousComment,
+        owner: {
+          id: '404',
+          username: 'Anonymous',
+        },
+        image: anonymousUserImage,
+      });
+      expect(UserModel.getById).not.toHaveBeenCalled();
+      expect(getImageData).toHaveBeenCalledWith('Ambush Viper');
+    });
+
+    it('handles comments with owner 404 as anonymous', async () => {
+      const deletedComment = createUnhydratedComment({ owner: '404' });
+      (mockDynamoClient.get as jest.Mock).mockResolvedValueOnce({ Item: deletedComment });
+      (getImageData as jest.Mock).mockReturnValue(anonymousUserImage);
+
+      const result = await Comment.getById('comment-1');
+
+      expect(result).toEqual({
+        ...deletedComment,
+        owner: {
+          id: '404',
+          username: 'Anonymous',
+        },
+        image: anonymousUserImage,
+      });
+      expect(UserModel.getById).not.toHaveBeenCalled();
+      expect(getImageData).toHaveBeenCalledWith('Ambush Viper');
+    });
+  });
+
+  describe('queryByParentAndType', () => {
+    it('returns empty array when no comments found', async () => {
+      setupQueryResult({ Items: [], LastEvaluatedKey: undefined });
+
+      const result = await Comment.queryByParentAndType('cube-1');
+
+      expect(result).toEqual({ items: [], lastKey: undefined });
+      verifyQueryCall({
+        IndexName: 'ByParent',
+        KeyConditionExpression: '#p1 = :parent',
+        ExpressionAttributeValues: { ':parent': 'cube-1' },
+        Limit: 10,
+        ScanIndexForward: false,
+      });
+    });
+
+    it('returns hydrated comments with pagination', async () => {
+      const comments = [createUnhydratedComment({ id: 'comment-1' }), createUnhydratedComment({ id: 'comment-2' })];
+      setupQueryResult({
+        Items: comments,
+        LastEvaluatedKey: { S: 'last-key-1' },
+      });
+      (UserModel.batchGet as jest.Mock).mockResolvedValueOnce([mockUser]);
+
+      const result = await Comment.queryByParentAndType('cube-1');
+
+      expect(result.items?.length).toBe(2);
+      expect(result.lastKey).toEqual({ S: 'last-key-1' });
+      result.items?.forEach((item, index) => {
+        //Obviously index and id don't align in real world
+        expect(item.id).toEqual(`comment-${index + 1}`);
+        expect(item.owner).toEqual(mockUser);
+        expect(item.image).toEqual(mockImage);
+      });
+    });
+
+    it('handles comments when no users are found', async () => {
+      const comments = [createUnhydratedComment({ id: 'comment-1' }), createUnhydratedComment({ id: 'comment-2' })];
+      setupQueryResult({
+        Items: comments,
+        LastEvaluatedKey: undefined,
+      });
+      (UserModel.batchGet as jest.Mock).mockResolvedValueOnce([]);
+      (getImageData as jest.Mock).mockReturnValue(anonymousUserImage);
+
+      const result = await Comment.queryByParentAndType('cube-1');
+
+      expect(result.items?.length).toBe(2);
+      result.items?.forEach((item) => {
+        expect(item.owner).toEqual({
+          id: '404',
+          username: 'Anonymous',
+        });
+        expect(item.image).toEqual(anonymousUserImage);
+      });
+      expect(getImageData).toHaveBeenCalledWith('Ambush Viper');
+      expect(UserModel.batchGet).toHaveBeenCalledWith(['user-1', 'user-1']);
+    });
+
+    it('uses provided lastKey for pagination', async () => {
+      setupQueryResult({ Items: [], LastEvaluatedKey: undefined });
+
+      await Comment.queryByParentAndType('cube-1', { S: 'last-key-1' });
+
+      verifyQueryCall({
+        ExclusiveStartKey: { S: 'last-key-1' },
+      });
+    });
+
+    it('handles falsey Items in response', async () => {
+      setupQueryResult({
+        Items: null,
+        LastEvaluatedKey: undefined,
+      });
+
+      const result = await Comment.queryByParentAndType('cube-1');
+
+      expect(result).toEqual({
+        items: [],
+        lastKey: undefined,
+      });
+      verifyQueryCall({
+        IndexName: 'ByParent',
+        KeyConditionExpression: '#p1 = :parent',
+        ExpressionAttributeValues: { ':parent': 'cube-1' },
+        Limit: 10,
+        ScanIndexForward: false,
+      });
+    });
+  });
+
+  describe('queryByOwner', () => {
+    it('returns empty array when no comments found', async () => {
+      setupQueryResult({ Items: [], LastEvaluatedKey: undefined });
+
+      const result = await Comment.queryByOwner('user-1');
+
+      expect(result).toEqual({ items: [], lastKey: undefined });
+      verifyQueryCall({
+        IndexName: 'ByOwner',
+        KeyConditionExpression: '#p1 = :owner',
+        ExpressionAttributeValues: { ':owner': 'user-1' },
+        ScanIndexForward: false,
+      });
+    });
+
+    it('returns hydrated comments with owner', async () => {
+      const comments = [createUnhydratedComment()];
+      setupQueryResult({ Items: comments });
+      (UserModel.batchGet as jest.Mock).mockResolvedValueOnce([mockUser]);
+
+      const result = await Comment.queryByOwner('user-1');
+
+      expect(result.items?.[0].owner).toEqual(mockUser);
+    });
+
+    it('handles comments with falsey owners as anonymous', async () => {
+      const comments = [createUnhydratedComment({ owner: undefined }), createUnhydratedComment({ owner: 'null' })];
+      setupQueryResult({ Items: comments });
+      (getImageData as jest.Mock).mockReturnValue(anonymousUserImage);
+
+      const result = await Comment.queryByOwner('user-1');
+
+      expect(result.items?.length).toBe(2);
+      result.items?.forEach((item) => {
+        expect(item.owner).toEqual({
+          id: '404',
+          username: 'Anonymous',
+        });
+        expect(item.image).toEqual(anonymousUserImage);
+      });
+      expect(UserModel.batchGet).toHaveBeenCalledWith(['null']);
+      expect(getImageData).toHaveBeenCalledWith('Ambush Viper');
+    });
+  });
+
+  describe('put', () => {
+    it('creates new comment with generated id', async () => {
+      const newComment = createUnhydratedComment({ id: undefined });
+
+      (UUID as jest.Mock).mockReturnValue('abcdefg-hijklom');
+
+      await Comment.put(newComment);
+
+      expect(UUID).toHaveBeenCalled();
+      expect(mockDynamoClient.put).toHaveBeenCalledWith({
+        ...newComment,
+        id: 'abcdefg-hijklom',
+      });
+    });
+
+    it('updates existing comment', async () => {
+      const updatedComment = { ...mockStoredComment, body: 'New text' };
+
+      await Comment.put(updatedComment);
+
+      expect(UUID).not.toHaveBeenCalled();
+      expect(mockDynamoClient.put).toHaveBeenCalledWith(updatedComment);
+    });
+
+    it('handles hydrated comments where the owner is an object', async () => {
+      const updatedComment = { ...mockStoredComment, owner: mockUser, body: 'New text' } as CommentType;
+
+      await Comment.put(updatedComment);
+
+      expect(UUID).not.toHaveBeenCalled();
+      expect(mockDynamoClient.put).toHaveBeenCalledWith({
+        ...updatedComment,
+        owner: mockUser.id,
+      });
+    });
+  });
+
+  describe('scan', () => {
+    it('scans all comments', async () => {
+      const comments = [createUnhydratedComment()];
+      (mockDynamoClient.scan as jest.Mock).mockResolvedValueOnce({
+        Items: comments,
+        LastEvaluatedKey: { S: 'last-key-1' },
+      });
+
+      const result = await Comment.scan();
+
+      expect(result).toEqual({
+        items: comments,
+        lastKey: { S: 'last-key-1' },
+      });
+      expect(mockDynamoClient.scan).toHaveBeenCalledWith({
+        ExclusiveStartKey: undefined,
+      });
+    });
+
+    it('uses lastKey for pagination', async () => {
+      (mockDynamoClient.scan as jest.Mock).mockResolvedValueOnce({
+        Items: [],
+        LastEvaluatedKey: undefined,
+      });
+
+      await Comment.scan({ S: 'last-key-1' });
+
+      expect(mockDynamoClient.scan).toHaveBeenCalledWith({
+        ExclusiveStartKey: { S: 'last-key-1' },
+      });
+    });
+  });
+
+  describe('createTable', () => {
+    it('calls client to create table', async () => {
+      await Comment.createTable();
+
+      expect(mockDynamoClient.createTable).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/cube/blog/dynamo.test.ts
+++ b/tests/cube/blog/dynamo.test.ts
@@ -1,0 +1,716 @@
+import BlogPost, { UnhydratedBlogPost } from '../../../src/datatypes/BlogPost';
+import Blog from '../../../src/dynamo/models/blog';
+import * as carddb from '../../../src/util/carddb';
+import { createBlogPost, createCard, createChangelog, createCube, createUser } from '../../test-utils/data';
+
+jest.mock('../../../src/dynamo/models/cube');
+jest.mock('../../../src/dynamo/models/changelog');
+jest.mock('../../../src/dynamo/models/user');
+jest.mock('../../../src/util/carddb');
+
+import Changelog from '../../../src/dynamo/models/changelog';
+import Cube from '../../../src/dynamo/models/cube';
+import User from '../../../src/dynamo/models/user';
+
+const createUnhydratedBlogPost = (overrides?: Partial<UnhydratedBlogPost>): UnhydratedBlogPost => {
+  return {
+    id: 'blog-post-99999',
+    ...overrides,
+  } as UnhydratedBlogPost;
+};
+
+// First test createClient configuration
+describe('Blog Model Initialization', () => {
+  it('blog table created with proper configuration', async () => {
+    // Import to trigger createClient
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('../../../src/dynamo/models/blog');
+
+    expect(mockDynamoCreateClient).toHaveBeenCalledWith({
+      name: 'BLOG',
+      partitionKey: 'id',
+      attributes: {
+        cube: 'S',
+        date: 'N',
+        id: 'S',
+        owner: 'S',
+      },
+      indexes: [
+        {
+          name: 'ByCube',
+          partitionKey: 'cube',
+          sortKey: 'date',
+        },
+        {
+          name: 'ByOwner',
+          partitionKey: 'owner',
+          sortKey: 'date',
+        },
+      ],
+    });
+  });
+});
+
+describe('Blog Model', () => {
+  const mockUser = createUser({ id: 'user-123' });
+
+  const mockCube = createCube({ id: 'cube-123', name: 'My Cube', owner: mockUser });
+
+  // const mockChangelog = undefined;
+
+  const mockStoredBlog = createUnhydratedBlogPost({
+    id: 'blog-123',
+    owner: 'user-123',
+    title: 'Test Blog',
+    body: 'Test content',
+    date: new Date('2024-03-24').valueOf(),
+    cube: 'cube-123',
+    changelist: 'changelog-id-5235',
+  });
+
+  const mockChangelog = createChangelog({
+    mainboard: {
+      adds: [createCard()],
+    },
+    maybeboard: undefined,
+  });
+
+  let mockBlog: BlogPost;
+
+  const mockNewBlog = createUnhydratedBlogPost({
+    id: undefined,
+    owner: 'user-123',
+    title: 'Test Blog',
+    body: 'Test content',
+    date: undefined,
+    cube: 'cube-123',
+    changelist: undefined,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+
+    const temp = { ...mockStoredBlog };
+    delete temp.changelist;
+
+    mockBlog = createBlogPost({
+      ...temp,
+      id: 'blog-123',
+      owner: mockUser,
+      cubeName: 'My Cube',
+      Changelog: mockChangelog,
+    });
+  });
+
+  describe('getById', () => {
+    it('returns undefined when no blog found', async () => {
+      (mockDynamoClient.get as jest.Mock).mockResolvedValueOnce({ Item: undefined });
+      const result = await Blog.getById('nonexistent');
+      expect(result).toBeUndefined();
+    });
+
+    it('returns hydrated blog with all related objects', async () => {
+      (mockDynamoClient.get as jest.Mock).mockResolvedValueOnce({ Item: mockStoredBlog });
+
+      (User.getById as jest.Mock).mockResolvedValueOnce(mockUser);
+      (Cube.getById as jest.Mock).mockResolvedValueOnce(mockCube);
+      (Changelog.getById as jest.Mock).mockResolvedValueOnce(mockChangelog);
+
+      const result = await Blog.getById(mockBlog.id);
+      expect(result).toEqual(mockBlog);
+      expect(User.getById).toHaveBeenCalledWith(mockStoredBlog.owner);
+      expect(Cube.getById).toHaveBeenCalledWith(mockStoredBlog.cube);
+      expect(Changelog.getById).toHaveBeenCalledWith(mockStoredBlog.cube, mockStoredBlog.changelist);
+    });
+
+    it('returns hydrated blog without changelog', async () => {
+      const storedBlog = { ...mockStoredBlog };
+      storedBlog.changelist = undefined;
+      const hydratedBlog = { ...mockBlog };
+      hydratedBlog.Changelog = undefined;
+
+      (mockDynamoClient.get as jest.Mock).mockResolvedValueOnce({
+        Item: storedBlog,
+      });
+
+      (User.getById as jest.Mock).mockResolvedValueOnce(mockUser);
+      (Cube.getById as jest.Mock).mockResolvedValueOnce(mockCube);
+
+      const result = await Blog.getById(storedBlog.id!);
+      expect(result).toEqual(hydratedBlog);
+      expect(User.getById).toHaveBeenCalledWith(storedBlog.owner);
+      expect(Cube.getById).toHaveBeenCalledWith(storedBlog.cube);
+      expect(Changelog.getById).not.toHaveBeenCalled();
+    });
+
+    it('returns hydrated blog when cube isnt found', async () => {
+      const storedBlog = { ...mockStoredBlog };
+      storedBlog.cube = 'cube-id-not-found';
+      const hydratedBlog = { ...mockBlog };
+      hydratedBlog.cube = storedBlog.cube;
+      hydratedBlog.cubeName = 'Unknown';
+
+      (mockDynamoClient.get as jest.Mock).mockResolvedValueOnce({
+        Item: storedBlog,
+      });
+
+      (User.getById as jest.Mock).mockResolvedValueOnce(mockUser);
+      (Cube.getById as jest.Mock).mockResolvedValueOnce(null);
+      (Changelog.getById as jest.Mock).mockResolvedValueOnce(mockChangelog);
+
+      const result = await Blog.getById(storedBlog.id!);
+      expect(result).toEqual(hydratedBlog);
+      expect(User.getById).toHaveBeenCalledWith(storedBlog.owner);
+      expect(Cube.getById).toHaveBeenCalledWith(storedBlog.cube);
+      expect(Changelog.getById).toHaveBeenCalledWith(storedBlog.cube, storedBlog.changelist);
+    });
+
+    it('returns hydrated blog with no cube details if the cube is the special "DEVBLOG"', async () => {
+      const storedBlog = { ...mockStoredBlog };
+      storedBlog.cube = 'DEVBLOG';
+      const hydratedBlog = { ...mockBlog };
+      hydratedBlog.cube = storedBlog.cube;
+      hydratedBlog.cubeName = 'Unknown';
+
+      (mockDynamoClient.get as jest.Mock).mockResolvedValueOnce({
+        Item: storedBlog,
+      });
+
+      (User.getById as jest.Mock).mockResolvedValueOnce(mockUser);
+      (Changelog.getById as jest.Mock).mockResolvedValueOnce(mockChangelog);
+
+      const result = await Blog.getById(storedBlog.id!);
+      expect(result).toEqual(hydratedBlog);
+      expect(User.getById).toHaveBeenCalledWith(storedBlog.owner);
+      expect(Cube.getById).not.toHaveBeenCalled();
+      expect(Changelog.getById).toHaveBeenCalledWith(storedBlog.cube, storedBlog.changelist);
+    });
+
+    it('defaults body to empty string if not set', async () => {
+      const storedBlog = { ...mockStoredBlog };
+      storedBlog.body = undefined;
+      const hydratedBlog = { ...mockBlog };
+      hydratedBlog.cube = storedBlog.cube;
+      hydratedBlog.cubeName = 'Unknown';
+      hydratedBlog.body = '';
+      hydratedBlog.Changelog = undefined;
+
+      (mockDynamoClient.get as jest.Mock).mockResolvedValueOnce({
+        Item: storedBlog,
+      });
+
+      (User.getById as jest.Mock).mockResolvedValueOnce(hydratedBlog.owner);
+      (Cube.getById as jest.Mock).mockResolvedValueOnce(undefined);
+      (Changelog.getById as jest.Mock).mockResolvedValueOnce(undefined);
+
+      const result = await Blog.getById(storedBlog.id!);
+      expect(result).toEqual(hydratedBlog);
+    });
+  });
+
+  describe('getUnhydrated', () => {
+    it('returns unhydrated blog', async () => {
+      (mockDynamoClient.get as jest.Mock).mockResolvedValueOnce({
+        Item: mockStoredBlog,
+      });
+
+      const result = await Blog.getUnhydrated(mockStoredBlog.id!);
+      expect(result).toEqual(mockStoredBlog);
+    });
+  });
+
+  describe('getByCube', () => {
+    it('returns empty array when no blogs found', async () => {
+      (mockDynamoClient.query as jest.Mock).mockResolvedValueOnce({ Items: [], LastEvaluatedKey: null });
+
+      const result = await Blog.getByCube(mockCube.id, 5);
+      expect(result).toEqual({ items: [], lastKey: null });
+
+      expect(mockDynamoClient.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          IndexName: 'ByCube',
+          ExpressionAttributeValues: {
+            ':cube': mockCube.id,
+          },
+          ExpressionAttributeNames: {
+            '#p1': 'cube',
+          },
+        }),
+      );
+    });
+
+    it('returns empty array Items are falsey', async () => {
+      (mockDynamoClient.query as jest.Mock).mockResolvedValueOnce({ Items: undefined, LastEvaluatedKey: null });
+
+      const result = await Blog.getByCube(mockCube.id, 5);
+      expect(result).toEqual({ items: [], lastKey: null });
+
+      expect(mockDynamoClient.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          IndexName: 'ByCube',
+          ExpressionAttributeValues: {
+            ':cube': mockCube.id,
+          },
+          ExpressionAttributeNames: {
+            '#p1': 'cube',
+          },
+        }),
+      );
+    });
+
+    it('default limit if the input is falsey', async () => {
+      (mockDynamoClient.query as jest.Mock).mockResolvedValueOnce({ Items: undefined, LastEvaluatedKey: null });
+
+      const result = await Blog.getByCube(mockCube.id, 0);
+      expect(result).toEqual({ items: [], lastKey: null });
+
+      expect(mockDynamoClient.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          IndexName: 'ByCube',
+          ExpressionAttributeValues: {
+            ':cube': mockCube.id,
+          },
+          ExpressionAttributeNames: {
+            '#p1': 'cube',
+          },
+          Limit: 36,
+        }),
+      );
+    });
+
+    it('returns hydrated blogs of the cube', async () => {
+      const blog1 = { ...mockStoredBlog, owner: 'user-1234', changelist: 'changelist-1234' };
+      const blog2 = { ...mockStoredBlog, id: 'blog-456', owner: 'user-5678', changelist: 'changelist-5678' };
+
+      const user1 = { ...mockUser, id: 'user-1234' };
+      const user2 = { ...mockUser, id: 'user-5678' };
+
+      const changelog1 = { ...mockChangelog, id: 'changelist-1234' };
+      const changelog2 = { ...mockChangelog, id: 'changelist-5678' };
+
+      (mockDynamoClient.query as jest.Mock).mockResolvedValueOnce({
+        Items: [blog1, blog2],
+        LastEvaluatedKey: { S: 'foobar' },
+      });
+
+      (User.batchGet as jest.Mock).mockResolvedValueOnce([user1, user2]);
+      (Cube.batchGet as jest.Mock).mockResolvedValueOnce([mockCube]);
+      (Changelog.batchGet as jest.Mock).mockResolvedValueOnce([changelog1, changelog2]);
+
+      const result = await Blog.getByCube(mockCube.id, 5);
+
+      expect(result.lastKey).toEqual({ S: 'foobar' });
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0]?.id).toEqual(blog1.id);
+      expect(result.items[0]?.cubeName).toEqual(mockCube.name);
+      expect(result.items[0]?.owner).toEqual(user1);
+      expect(result.items[0]?.Changelog).toEqual(changelog1);
+
+      expect(result.items[1]?.id).toEqual(blog2.id);
+      expect(result.items[1]?.cubeName).toEqual(mockCube.name);
+      expect(result.items[1]?.owner).toEqual(user2);
+      expect(result.items[1]?.Changelog).toEqual(changelog2);
+
+      expect(User.batchGet).toHaveBeenCalledWith([user1.id, user2.id]);
+      expect(Cube.batchGet).toHaveBeenCalledWith([mockCube.id, mockCube.id]);
+      expect(Changelog.batchGet).toHaveBeenCalledWith([
+        { id: changelog1.id, cube: mockCube.id },
+        { id: changelog2.id, cube: mockCube.id },
+      ]);
+
+      expect(mockDynamoClient.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          IndexName: 'ByCube',
+          ExpressionAttributeValues: {
+            ':cube': mockCube.id,
+          },
+          ExpressionAttributeNames: {
+            '#p1': 'cube',
+          },
+          Limit: 5,
+        }),
+      );
+    });
+
+    it('returns hydrated blogs of the cube, with missing related objects', async () => {
+      const blog1 = { ...mockStoredBlog, owner: 'user-66666', changelist: 'changelist-1234' };
+      const blog2 = { ...mockStoredBlog, id: 'blog-456', owner: 'user-1234', changelist: 'changelist-7457457' };
+
+      const user1 = { ...mockUser, id: 'user-1234' };
+
+      const changelog1 = { ...mockChangelog, id: 'changelist-1234' };
+
+      (mockDynamoClient.query as jest.Mock).mockResolvedValueOnce({
+        Items: [blog1, blog2],
+        LastEvaluatedKey: null,
+      });
+
+      (User.batchGet as jest.Mock).mockResolvedValueOnce([user1]);
+      (Cube.batchGet as jest.Mock).mockResolvedValueOnce([]);
+      (Changelog.batchGet as jest.Mock).mockResolvedValueOnce([changelog1]);
+
+      const result = await Blog.getByCube(mockCube.id, 77);
+
+      expect(result.lastKey).toBeNull();
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0]?.id).toEqual(blog1.id);
+      expect(result.items[0]?.cubeName).toEqual('Unknown');
+      expect(result.items[0]?.owner).toEqual(undefined);
+      expect(result.items[0]?.Changelog).toEqual(changelog1);
+
+      expect(result.items[1]?.id).toEqual(blog2.id);
+      expect(result.items[1]?.cubeName).toEqual('Unknown');
+      expect(result.items[1]?.owner).toEqual(user1);
+      expect(result.items[1]?.Changelog).toEqual(undefined);
+
+      expect(User.batchGet).toHaveBeenCalledWith(['user-66666', user1.id]);
+      expect(Cube.batchGet).toHaveBeenCalledWith([mockCube.id, mockCube.id]);
+      expect(Changelog.batchGet).toHaveBeenCalledWith([
+        { id: changelog1.id, cube: mockCube.id },
+        { id: 'changelist-7457457', cube: mockCube.id },
+      ]);
+
+      expect(mockDynamoClient.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Limit: 77,
+        }),
+      );
+    });
+  });
+
+  //getByCube and getByOwner share hydration logic so we don't need both to have full sets of conditional tests
+  describe('getByOwner', () => {
+    it('returns empty array when no blogs found', async () => {
+      (mockDynamoClient.query as jest.Mock).mockResolvedValueOnce({ Items: [], LastEvaluatedKey: null });
+
+      const result = await Blog.getByOwner(mockUser.id, 5);
+      expect(result).toEqual({ items: [], lastKey: null });
+
+      expect(mockDynamoClient.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          IndexName: 'ByOwner',
+          ExpressionAttributeValues: {
+            ':owner': mockUser.id,
+          },
+          ExpressionAttributeNames: {
+            '#p1': 'owner',
+          },
+        }),
+      );
+    });
+
+    it('returns empty array when items are falsey', async () => {
+      (mockDynamoClient.query as jest.Mock).mockResolvedValueOnce({ Items: false, LastEvaluatedKey: null });
+
+      const result = await Blog.getByOwner(mockUser.id, 5);
+      expect(result).toEqual({ items: [], lastKey: null });
+
+      expect(mockDynamoClient.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          IndexName: 'ByOwner',
+          ExpressionAttributeValues: {
+            ':owner': mockUser.id,
+          },
+          ExpressionAttributeNames: {
+            '#p1': 'owner',
+          },
+        }),
+      );
+    });
+
+    it('default limit if input is falsey', async () => {
+      (mockDynamoClient.query as jest.Mock).mockResolvedValueOnce({ Items: [], LastEvaluatedKey: null });
+
+      const result = await Blog.getByOwner(mockUser.id, 0);
+      expect(result).toEqual({ items: [], lastKey: null });
+
+      expect(mockDynamoClient.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          IndexName: 'ByOwner',
+          ExpressionAttributeValues: {
+            ':owner': mockUser.id,
+          },
+          ExpressionAttributeNames: {
+            '#p1': 'owner',
+          },
+          Limit: 36,
+        }),
+      );
+    });
+
+    it('returns all blogs for owner', async () => {
+      const blog1 = { ...mockStoredBlog, owner: 'user-1234', changelist: undefined, cube: 'cube-1234' };
+      const blog2 = { ...mockStoredBlog, id: 'blog-456', owner: 'user-1234', changelist: undefined, cube: 'cube-5678' };
+
+      const user1 = { ...mockUser, id: 'user-1234' };
+
+      const cube1 = { ...mockCube, id: 'cube-1234' };
+      const cube2 = { ...mockCube, id: 'cube-5678' };
+
+      (mockDynamoClient.query as jest.Mock).mockResolvedValueOnce({
+        Items: [blog1, blog2],
+        LastEvaluatedKey: { S: 'foobar' },
+      });
+
+      (User.batchGet as jest.Mock).mockResolvedValueOnce([user1]);
+      (Cube.batchGet as jest.Mock).mockResolvedValueOnce([cube1, cube2]);
+      (Changelog.batchGet as jest.Mock).mockResolvedValueOnce([]);
+
+      const result = await Blog.getByOwner(user1.id, 5, { S: 'keyABC' });
+
+      expect(result.lastKey).toEqual({ S: 'foobar' });
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0]?.id).toEqual(blog1.id);
+      expect(result.items[0]?.cubeName).toEqual(cube1.name);
+      expect(result.items[0]?.owner).toEqual(user1);
+      expect(result.items[0]?.Changelog).toBeUndefined();
+
+      expect(result.items[1]?.id).toEqual(blog2.id);
+      expect(result.items[1]?.cubeName).toEqual(cube2.name);
+      expect(result.items[1]?.owner).toEqual(user1);
+      expect(result.items[1]?.Changelog).toBeUndefined();
+
+      expect(User.batchGet).toHaveBeenCalledWith([user1.id, user1.id]);
+      expect(Cube.batchGet).toHaveBeenCalledWith([cube1.id, cube2.id]);
+      expect(Changelog.batchGet).toHaveBeenCalledWith([]);
+
+      expect(mockDynamoClient.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          IndexName: 'ByOwner',
+          ExpressionAttributeValues: {
+            ':owner': user1.id,
+          },
+          ExpressionAttributeNames: {
+            '#p1': 'owner',
+          },
+          ExclusiveStartKey: { S: 'keyABC' },
+        }),
+      );
+    });
+  });
+
+  describe('put', () => {
+    it('saves blog with generated id and date if none provided', async () => {
+      const id = await Blog.put(mockNewBlog);
+
+      expect(mockDynamoClient.put).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: expect.any(String),
+          owner: mockNewBlog.owner,
+          title: mockNewBlog.title,
+          body: mockNewBlog.body,
+          cube: mockNewBlog.cube,
+          date: expect.any(Number),
+          changelist: mockNewBlog.changelist,
+        }),
+      );
+      expect(typeof id).toBe('string');
+    });
+
+    it('saves blog and uses existing id and date if set', async () => {
+      const filledBlogPost = mockNewBlog;
+      filledBlogPost.id = 'blog-post-12345';
+      filledBlogPost.date = 1742855772000;
+
+      const id = await Blog.put(filledBlogPost);
+
+      expect(mockDynamoClient.put).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'blog-post-12345',
+          date: 1742855772000,
+        }),
+      );
+      expect(id).toEqual('blog-post-12345');
+    });
+
+    it('blog bodies are limited to 10000 characters', async () => {
+      const filledBlogPost = mockNewBlog;
+      filledBlogPost.body = 'x'.repeat(10050);
+
+      await Blog.put(filledBlogPost);
+
+      expect(mockDynamoClient.put).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: 'x'.repeat(10000),
+        }),
+      );
+    });
+
+    it('body defaults to undefined if falsey', async () => {
+      const filledBlogPost = mockNewBlog;
+      filledBlogPost.body = '';
+
+      await Blog.put(filledBlogPost);
+
+      expect(mockDynamoClient.put).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: undefined,
+        }),
+      );
+    });
+  });
+
+  describe('delete', () => {
+    it('deletes blog by id', async () => {
+      await Blog.delete(mockBlog.id);
+      expect(mockDynamoClient.delete).toHaveBeenCalledWith({ id: mockBlog.id });
+    });
+  });
+
+  describe('createTable', () => {
+    it('calls client to create table', async () => {
+      await Blog.createTable();
+
+      expect(mockDynamoClient.createTable).toHaveBeenCalled();
+    });
+  });
+
+  describe('batchPut', () => {
+    it('saves multiple blog posts with required fields', async () => {
+      const blogs = [
+        { ...mockNewBlog, title: 'Blog 1' },
+        { ...mockNewBlog, title: 'Blog 2', id: undefined },
+      ];
+
+      await Blog.batchPut(blogs);
+
+      expect(mockDynamoClient.batchPut).toHaveBeenCalledWith([
+        expect.objectContaining({
+          id: expect.any(String),
+          date: expect.any(Number),
+          title: 'Blog 1',
+        }),
+        expect.objectContaining({
+          id: expect.any(String),
+          date: expect.any(Number),
+          title: 'Blog 2',
+        }),
+      ]);
+    });
+
+    it('truncates long bodies in batch put', async () => {
+      const blogs = [
+        { ...mockNewBlog, body: 'x'.repeat(10500) },
+        { ...mockNewBlog, body: 'y'.repeat(9000) },
+      ];
+
+      await Blog.batchPut(blogs);
+
+      expect(mockDynamoClient.batchPut).toHaveBeenCalledWith([
+        expect.objectContaining({
+          body: 'x'.repeat(10000),
+        }),
+        expect.objectContaining({
+          body: 'y'.repeat(9000),
+        }),
+      ]);
+    });
+  });
+
+  //Hydration logic tested by other functions
+  describe('batchGet', () => {
+    it('returns empty array when no ids provided', async () => {
+      (mockDynamoClient.batchGet as jest.Mock).mockResolvedValueOnce([]);
+
+      const result = await Blog.batchGet([]);
+      expect(result).toEqual([]);
+    });
+
+    it('returns hydrated blog posts', async () => {
+      const stored1 = { ...mockStoredBlog, id: 'blog1' };
+      const stored2 = { ...mockStoredBlog, id: 'blog2' };
+
+      (User.batchGet as jest.Mock).mockResolvedValueOnce([]);
+      (Cube.batchGet as jest.Mock).mockResolvedValueOnce([]);
+      (Changelog.batchGet as jest.Mock).mockResolvedValueOnce([]);
+
+      mockDynamoClient.batchGet.mockResolvedValueOnce([stored2, stored1]);
+
+      const result = await Blog.batchGet(['blog1', 'blog2']);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]?.id).toBe('blog2');
+      expect(result[1]?.id).toBe('blog1');
+      expect(mockDynamoClient.batchGet).toHaveBeenCalledWith([stored1.id, stored2.id]);
+    });
+  });
+
+  describe('changelogToText', () => {
+    const cardAdd1 = createCard({ cardID: '1' });
+    const cardAdd2 = createCard({ cardID: '2' });
+
+    beforeEach(() => {
+      (carddb.cardFromId as jest.Mock).mockImplementation((id) => ({
+        name: `Card ${id}`,
+      }));
+    });
+
+    it('generates text for adds and removes', () => {
+      const changelog = {
+        mainboard: {
+          adds: [cardAdd1, cardAdd2],
+          removes: [
+            { index: 55, oldCard: { cardID: '3' } },
+            { index: 98, oldCard: { cardID: '4' } },
+          ],
+        },
+      };
+
+      const result = Blog.changelogToText(changelog);
+
+      expect(result).toContain('Added:\nCard 1\nCard 2\n');
+      expect(result).toContain('Removed:\nCard 3\nCard 4\n');
+    });
+
+    it('generates text for swaps and edits', () => {
+      const changelog = {
+        mainboard: {
+          swaps: [
+            { index: 55, oldCard: { cardID: '1' }, card: { cardID: '2' } },
+            { index: 98, oldCard: { cardID: '3' }, card: { cardID: '4' } },
+          ],
+          edits: [
+            { index: 23, oldCard: { cardID: '5' }, newCard: { cardID: '5', tags: ['Foobar'] } },
+            { index: 44, oldCard: { cardID: '6' }, newCard: { cardID: '88' } },
+          ],
+        },
+      };
+
+      const result = Blog.changelogToText(changelog);
+
+      expect(result).toContain('Swapped:\nCard 1 -> Card 2\nCard 3 -> Card 4\n');
+      expect(result).toContain('Edited:\nCard 5\nCard 6\n');
+    });
+
+    it('handles multiple boards', () => {
+      const changelog = {
+        mainboard: {
+          adds: [cardAdd1],
+        },
+        sideboard: {
+          removes: [{ index: 22, oldCard: { cardID: '2' } }],
+        },
+      };
+
+      const result = Blog.changelogToText(changelog);
+
+      expect(result).toContain('Mainboard:\nAdded:\nCard 1\n');
+      expect(result).toContain('Sideboard:\nRemoved:\nCard 2\n');
+    });
+
+    it('skips empty boards', () => {
+      const changelog = {
+        mainboard: {
+          adds: [cardAdd1],
+        },
+        sideboard: undefined,
+      };
+
+      const result = Blog.changelogToText(changelog);
+
+      expect(result).toContain('Mainboard:');
+      expect(result).not.toContain('Sideboard:');
+    });
+  });
+});

--- a/tests/cube/blog/dynamo.test.ts
+++ b/tests/cube/blog/dynamo.test.ts
@@ -1,7 +1,16 @@
 import BlogPost, { UnhydratedBlogPost } from '../../../src/datatypes/BlogPost';
 import Blog from '../../../src/dynamo/models/blog';
 import * as carddb from '../../../src/util/carddb';
-import { createBlogPost, createCard, createChangelog, createCube, createUser } from '../../test-utils/data';
+import {
+  createBlogPost,
+  createChangelog,
+  createChangelogCardAdd,
+  createChangelogCardEdit,
+  createChangelogCardRemove,
+  createChangelogCardSwap,
+  createCube,
+  createUser,
+} from '../../test-utils/data';
 
 // Mock dependencies
 jest.mock('../../../src/dynamo/models/cube');
@@ -80,10 +89,7 @@ describe('Blog Model Initialization', () => {
 describe('Blog Model', () => {
   const mockUser = createUser({ id: 'user-123' });
   const mockCube = createCube({ id: 'cube-123', name: 'My Cube', owner: mockUser });
-  const mockChangelog = createChangelog({
-    mainboard: { adds: [createCard()] },
-    maybeboard: undefined,
-  });
+  const mockChangelog = createChangelog({ adds: [createChangelogCardAdd()] }, undefined);
 
   const mockStoredBlog = createUnhydratedBlogPost({
     id: 'blog-123',
@@ -631,8 +637,8 @@ describe('Blog Model', () => {
   });
 
   describe('changelogToText', () => {
-    const cardAdd1 = createCard({ cardID: '1' });
-    const cardAdd2 = createCard({ cardID: '2' });
+    const cardAdd1 = createChangelogCardAdd({ cardID: '1' });
+    const cardAdd2 = createChangelogCardAdd({ cardID: '2' });
 
     beforeEach(() => {
       (carddb.cardFromId as jest.Mock).mockImplementation((id) => ({
@@ -645,8 +651,8 @@ describe('Blog Model', () => {
         mainboard: {
           adds: [cardAdd1, cardAdd2],
           removes: [
-            { index: 55, oldCard: { cardID: '3' } },
-            { index: 98, oldCard: { cardID: '4' } },
+            createChangelogCardRemove({ index: 55, oldCard: { cardID: '3' } }),
+            createChangelogCardRemove({ index: 98, oldCard: { cardID: '4' } }),
           ],
         },
       };
@@ -661,12 +667,16 @@ describe('Blog Model', () => {
       const changelog = {
         mainboard: {
           swaps: [
-            { index: 55, oldCard: { cardID: '1' }, card: { cardID: '2' } },
-            { index: 98, oldCard: { cardID: '3' }, card: { cardID: '4' } },
+            createChangelogCardSwap({ index: 55, oldCard: { cardID: '1' }, card: { cardID: '2' } }),
+            createChangelogCardSwap({ index: 98, oldCard: { cardID: '3' }, card: { cardID: '4' } }),
           ],
           edits: [
-            { index: 23, oldCard: { cardID: '5' }, newCard: { cardID: '5', tags: ['Foobar'] } },
-            { index: 44, oldCard: { cardID: '6' }, newCard: { cardID: '88' } },
+            createChangelogCardEdit({
+              index: 23,
+              oldCard: { cardID: '5' },
+              newCard: { cardID: '5', tags: ['Foobar'] },
+            }),
+            createChangelogCardEdit({ index: 44, oldCard: { cardID: '6' }, newCard: { cardID: '88' } }),
           ],
         },
       };
@@ -683,7 +693,7 @@ describe('Blog Model', () => {
           adds: [cardAdd1],
         },
         sideboard: {
-          removes: [{ index: 22, oldCard: { cardID: '2' } }],
+          removes: [createChangelogCardRemove({ index: 22, oldCard: { cardID: '2' } })],
         },
       };
 

--- a/tests/user/dynamo.test.ts
+++ b/tests/user/dynamo.test.ts
@@ -60,6 +60,7 @@ describe('User Model', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.resetAllMocks();
 
     (imageutil.getImageData as jest.Mock).mockReturnValue(mockImage);
 
@@ -593,7 +594,7 @@ describe('User Model', () => {
   });
 
   describe('createTable', () => {
-    it('calls client to crate table', async () => {
+    it('calls client to create table', async () => {
       await User.createTable();
 
       expect(mockDynamoClient.createTable).toHaveBeenCalled();


### PR DESCRIPTION
# Changes

Been sitting on this for a while

1. Improve clarity of the Blog return types so items is always defined, but could be empty. Better matches human expectations than getting back an array or undefined
2. Add tests on card history, comments, blog, and changelog
3. Fixed recent test failures from the Combos page