### PR TITLE
Use distinct oracle ids when fetching combos, and only show the first copy of a card by oracle id in each combo UI.

### DIFF
--- a/src/client/analytics/Combos.tsx
+++ b/src/client/analytics/Combos.tsx
@@ -35,7 +35,19 @@ const ComboCard: React.FC<ComboCardProps> = ({ combo }) => {
 
   const cards = useMemo(() => {
     const oracles = combo.uses.map((use) => use.card.oracleId);
-    return cube.cards.mainboard.filter((card) => oracles.includes(cardOracleId(card)));
+    //Match the first copy of the oracle id in the cube list
+    const matchedOracles = new Set();
+    return cube.cards.mainboard.filter((card) => {
+      const oracleId = cardOracleId(card);
+      if (matchedOracles.has(oracleId)) {
+        return false;
+      }
+      const matched = oracles.includes(oracleId);
+      if (matched) {
+        matchedOracles.add(oracleId);
+      }
+      return matched;
+    });
   }, [combo, cube]);
 
   return (
@@ -141,8 +153,9 @@ const Combos: React.FC = () => {
           headers: {
             'Content-Type': 'application/json',
           },
+          //Only send unique cards to get combos
           body: JSON.stringify({
-            oracles: cards.map((card) => cardOracleId(card)),
+            oracles: [...new Set(cards.map((card) => cardOracleId(card)))],
           }),
         });
         if (!response.ok) {


### PR DESCRIPTION
As reported in Discord.

# Testing

## Before

Duplicate combos:
![old-duplicate-combos](https://github.com/user-attachments/assets/0a0e4ad0-a812-44e9-bc81-92ac2ab1e61c)

## After

Distinct combos:
![new-distinct-combos](https://github.com/user-attachments/assets/3ccdf1ea-a476-43aa-ae44-028a0ece1e47)
