### PR TITLE
Default cardNotes to empty string instead of null to fix filtering error.

### DIFF
--- a/src/client/utils/cardutil.ts
+++ b/src/client/utils/cardutil.ts
@@ -232,7 +232,7 @@ export const cardImageUrl = (card: Card): string =>
 
 export const cardImageBackUrl = (card: Card): string => card.imgBackUrl ?? card.details?.image_flip ?? '';
 
-export const cardNotes = (card: Card): string | null => card.notes ?? null;
+export const cardNotes = (card: Card): string => card.notes ?? '';
 
 /*
  * Helper to convert the old color category types into current Type. Existing cards may have their colorCategory


### PR DESCRIPTION
I believe this would only occur for very old cubes where cards were created before notes was a default field.

Reproduced the discord reported notes filtering error using https://cubecobra.com/cube/list/dekkaruvintage though I am not 100% it is the same error. In that cube only 127 of the cards don't have a notes field, such as Sword of the Meek. Because the cardNotes default was null, the stringOperation in FuncOperations.js would try to do null.toLowerCase() which errored. That is the only usage of the cardNotes function I found.