### PR TITLE
Fix drafts not finishing or ending in a weird state, related to pending picks and failing bot predictions

### DIFF
--- a/src/client/pages/CubeDraftPage.tsx
+++ b/src/client/pages/CubeDraftPage.tsx
@@ -13,6 +13,7 @@ import Cube from 'datatypes/Cube';
 import Draft from 'datatypes/Draft';
 import DraftLocation, { addCard, location, removeCard } from 'drafting/DraftLocation';
 import { locations } from 'drafting/DraftLocation';
+import useAlerts, { Alerts } from 'hooks/UseAlerts';
 import useLocalStorage from 'hooks/useLocalStorage';
 import CubeLayout from 'layouts/CubeLayout';
 import MainLayout from 'layouts/MainLayout';
@@ -79,6 +80,8 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
   const [userPicksInOrder, setUserPicksInOrder] = useLocalStorage<number[]>(`picks-${draft.id}`, []); // Tracks the pick sequencing, managed separately from the mainboard/sideboard state
   const [pendingPick, setPendingPick] = useState<number | null>(null); // Add state to track the pending pick made during predictionsLoading
 
+  const { alerts, addAlert } = useAlerts();
+
   // Draft Status
   // These are used to track the status of the draft itself, including loading, errors, etc.
   const [draftStatus, setDraftStatus] = useState<DraftStatus>({
@@ -138,9 +141,10 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error('endDraft error caught:', err);
+      addAlert('danger', 'Error finishing draft, please reach out to the Discord');
       setDraftStatus((prev) => ({ ...prev, loading: false, draftCompleted: false }));
     }
-  }, [csrfFetch, draft.id, mainboard, userPicksInOrder, sideboard, state, setDraftStatus, trashboard]);
+  }, [csrfFetch, draft.id, mainboard, userPicksInOrder, sideboard, state, setDraftStatus, trashboard, addAlert]);
 
   const getPredictions = useCallback(
     async (request: { state: any; packCards: { index: number; oracle_id: string }[] }) => {
@@ -725,6 +729,7 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
     <MainLayout loginCallback={loginCallback}>
       <DisplayContextProvider cubeID={cube.id}>
         <CubeLayout cube={cube} activeLink="playtest">
+          <Alerts alerts={alerts} />
           <DndContext onDragEnd={onMoveCard} onDragStart={() => setDragStartTime(Date.now())}>
             <div className="relative">
               {/* Only show the pack if there are actually cards to show */}


### PR DESCRIPTION
This took lots of exploration and collaboration in discord to pinpoint the problem. The reported issue is drafts not finishing, stuck on the draft screen.

# Problem

When the drafter has made a pending pick (eg they pick before the bot predictions are ready) and then the bot predictions API request failed (most likely due to 10 second client timeout), the pending pick proceeded to the pick logic. However the predictions in state were for the previous packs and thus the predicted oracle ids don't map to the current packs. That results in using index -1 of the pack to get the card's overall index in the randomized draft pool, which is undefined in JS. Then when the new state is saved into localstorage that becomes null during the JSON stringification.

Then finally when the draft finishes, the server side validation rejects the request immediately because it expects all picks to be numbers not null. The console would have an error, but the drafter wouldn't know.

# Solutions
Mitigations applied:
1. Don't proceed with pending pick in its useEffect if there are prediction errors or retries in process
2. If the predicted oracle ID cannot be mapped in the pack, randomly choose the index
3. If the finish API request fails, display an Alert about the failure and redirect them to Discord

# Testing

To reproduce the issue consistently I had temporary testing code which passed query string error=1 to the batch prediction endpoint is a window property was set. When that was set, the backend paused for a couple seconds and then returned a 500 error.

Sorry these are long gifs, wasn't sure how else to make the problem/fixes obvious.

## Before

A pending pick is made and then the predictions fail. The pending pick is applied, but then the bot seats have null in their picks array due to the prediction mismatch.
![pending-pick-then-bot-predictions-fail-cause-invalid-picks](https://github.com/user-attachments/assets/4627b347-6e24-4072-b2a4-94782f106fd8)

## After

Showing how each mitigation works independently of the others (as if only that mitigation was applied).

The updated logic in the useEffect for pending pick prevents the pending pick from being applied until the predictions are fixed and good. After good predictions are loaded, the pick applies and the picks state is good as seen in localstorage.
![new-pending-pick-then-bot-predictions-fail-waits-until-valid-predictions](https://github.com/user-attachments/assets/9699bf07-37e3-40c3-a8ee-e0120b1b796c)

The pending pick applies even when the bot predictions failed (and thus are old). The console logs show how the logic fell back to random picking due to the oracle id mismatch. The picks state is good as seen in localstorage.
![new-prediction-oracle-fails-to-find-defaults-to-random](https://github.com/user-attachments/assets/71643c9a-530c-4e88-bfe7-ee23b9b4994f)

If the draft state has bad nulls in it and you finish the draft, it shows the failure as an alert.
![new-finish-failure-message](https://github.com/user-attachments/assets/731bf194-1616-4d5b-b5ff-1a53b95b19d4)
