### PR TITLE
Allow ButtonLink anchors to act using standard browser behaviour.

### DIFF
--- a/src/client/components/base/Button.tsx
+++ b/src/client/components/base/Button.tsx
@@ -28,7 +28,7 @@ const ButtonLink: React.FC<ButtonLinkProps> = ({
     }
 
     setLoading(true); // Set loading state to true to prevent further clicks
-    window.location.href = href; // Navigate to the link
+    //Allow default anchor behaviour to take effect
   };
 
   return (
@@ -36,6 +36,7 @@ const ButtonLink: React.FC<ButtonLinkProps> = ({
       className={classNames(className, 'hover:cursor-pointer', { 'opacity-50 cursor-not-allowed': loading })}
       target={target}
       rel={rel}
+      href={href}
       onClick={handleClick}
     >
       {loading ? <Spinner className="position-absolute" /> : children}


### PR DESCRIPTION
eg. Ctrl-click opens in new tab.

Some of the UX can be a bit odd such as ctrl-click on Cube Analyics from the card modal, as the button becomes a spinner (until the modal is closed)

# Testing

## Before

Ctrl-click changed the current tab
![old-ctrl-click-same-tab](https://github.com/user-attachments/assets/4ed931ac-288d-4dda-aa42-4bf82ecb245b)

## After

Ctrl-click opens new tab (whatever the browser behaviour is)
![new-ctrl-click-new-tab](https://github.com/user-attachments/assets/96400225-16ee-4337-a280-d9019da8c330)

Still prevents multiple backend calls
![new-still-prevents-multiple-actions](https://github.com/user-attachments/assets/8854cc57-c0fb-416c-ae6e-ca59e26e91c2)
