### PR TITLE
User profile editing, populate the about field

### DIFF
--- a/src/client/components/user/UserProfile.tsx
+++ b/src/client/components/user/UserProfile.tsx
@@ -36,17 +36,18 @@ const UserProfile: React.FC = () => {
       setImageDict(json.dict);
     };
     getData();
-  }, []);
+  }, [csrfFetch]);
 
   const changeImage = useCallback(
     (img: string) => {
       setImagename(img);
+      // eslint-disable-next-line no-console -- Debugging
       console.log(imageDict[img.toLowerCase()]);
       if (imageDict[img.toLowerCase()]) {
         setImage(imageDict[img.toLowerCase()]);
       }
     },
-    [imageDict, user?.image],
+    [imageDict],
   );
 
   const formData = useMemo(

--- a/src/client/components/user/UserProfile.tsx
+++ b/src/client/components/user/UserProfile.tsx
@@ -16,7 +16,7 @@ import Image from 'datatypes/Image';
 const UserProfile: React.FC = () => {
   const { csrfFetch } = useContext(CSRFContext);
   const user = useContext(UserContext);
-  const [markdown, setMarkdown] = useState('');
+  const [markdown, setMarkdown] = useState(user?.about || '');
   const [username, setUsername] = useState(user?.username);
   const [email, setEmail] = useState(user?.email);
   const formRef = React.useRef<HTMLFormElement>(null);


### PR DESCRIPTION
Reported in Discord

# Testing

## Before

Have "about" me filled out
![profile-about](https://github.com/user-attachments/assets/cb5cbc6a-1ae3-437e-9d5b-c4230dce20fe)

But when you try to edit your profile it doesn't appear in the editor
![old-about-me-doesnt-show](https://github.com/user-attachments/assets/29971938-ee4d-42fe-8e42-f6ba7e669fd4)

## After

About me shows in the editor
![new-profile-about-edit](https://github.com/user-attachments/assets/0c6b0580-4732-4f87-93ab-ea11d0fc38dd)
