### PR TITLE
Redirect with error message when the package is not found.

### DIFF
--- a/src/routes/packages.js
+++ b/src/routes/packages.js
@@ -234,8 +234,15 @@ router.get('/remove/:id', ensureRole('Admin'), async (req, res) => {
 });
 
 router.get('/:id', async (req, res) => {
+  const pack = await Package.getById(req.params.id);
+
+  if (!pack) {
+    req.flash('danger', `Package not found`);
+    return redirect(req, res, '/packages');
+  }
+
   return render(req, res, 'PackagePage', {
-    pack: await Package.getById(req.params.id),
+    pack,
   });
 });
 


### PR DESCRIPTION
# Testing

## Before
![old-page-error-due-to-undefined-package](https://github.com/user-attachments/assets/bb06285a-879f-4dfe-a28e-eb2fd31fc058)

## After

![new-redirect-error](https://github.com/user-attachments/assets/48191fbd-dbaf-4208-802a-82b038117c6e)
