### PR TITLE
Draft failure error logging and card Cmc improvements

### DIFF
--- a/src/client/utils/cardutil.ts
+++ b/src/client/utils/cardutil.ts
@@ -185,11 +185,17 @@ export const CardDetails = (card: Card): CardDetailsType =>
   };
 
 export const cardCmc = (card: Card): number => {
-  if (card.cmc) {
+  //cmc could be zero so we must check if it is set more specifically
+  if (card.cmc !== undefined && card.cmc !== null) {
     // if it's a string
     if (typeof card.cmc === 'string') {
       // if it includes a dot, parse as float, otherwise parse as int
-      return card.cmc.includes('.') ? parseFloat(card.cmc) : parseInt(card.cmc);
+      const parsed = card.cmc.includes('.') ? parseFloat(card.cmc) : parseInt(card.cmc);
+      // if parsed is NaN, fall back to details.cmc
+      if (Number.isNaN(parsed)) {
+        return card.details?.cmc ?? 0;
+      }
+      return parsed;
     }
     return card.cmc;
   }

--- a/src/router/routes/draft/finish.ts
+++ b/src/router/routes/draft/finish.ts
@@ -168,8 +168,7 @@ export const handler = async (req: Request, res: Response) => {
       success: true,
     });
   } catch (err) {
-    // eslint-disable-next-line no-console
-    console.error('Error finishing draft', err);
+    req.logger.error('Error finishing draft', err);
     return res.status(500).json({ error: 'Error finishing draft' });
   }
 };

--- a/src/routes/cube/helper.js
+++ b/src/routes/cube/helper.js
@@ -187,7 +187,7 @@ function writeCard(res, card, maybe) {
   if (!card.type_line) {
     card.type_line = cardFromId(card.cardID).type;
   }
-  const { name, rarity, colorcategory, cmc } = cardFromId(card.cardID);
+  const { name, rarity, colorcategory } = cardFromId(card.cardID);
   let { imgUrl, imgBackUrl } = card;
   if (imgUrl) {
     imgUrl = `"${imgUrl}"`;
@@ -204,7 +204,7 @@ function writeCard(res, card, maybe) {
   const colorCategory = cardutil.convertFromLegacyCardColorCategory(card.colorCategory);
 
   res.write(`"${name.replaceAll(/"/g, '""')}",`);
-  res.write(`${card.cmc || cmc},`);
+  res.write(`${cardutil.cardCmc(card)},`);
   res.write(`"${card.type_line.replace('—', '-')}",`);
   res.write(`${colorColors.join('')},`);
   res.write(`"${cardFromId(card.cardID).set}",`);

--- a/tests/draft/finish/api.test.ts
+++ b/tests/draft/finish/api.test.ts
@@ -514,7 +514,7 @@ describe('Finish Draft', () => {
     expect(res.body).toEqual({
       error: 'Error finishing draft',
     });
-    expect(consoleErrorSpy).toHaveBeenCalledWith('Error finishing draft', error);
+    expect(res.rawRequest.logger.error).toHaveBeenCalledWith('Error finishing draft', error);
   });
 });
 

--- a/tests/test-utils/transport.ts
+++ b/tests/test-utils/transport.ts
@@ -104,7 +104,13 @@ class CallBuilder {
     return this;
   }
 
-  async send(): Promise<{ status: number; body: any; nextCalled: boolean; rawResponse: Response }> {
+  async send(): Promise<{
+    status: number;
+    body: any;
+    nextCalled: boolean;
+    rawResponse: MockResponse;
+    rawRequest: Request;
+  }> {
     if (this.user) {
       this.request = { user: createUser(this.user), ...this.request };
     }
@@ -124,7 +130,7 @@ class CallBuilder {
 
     await this.handler(req, res, next);
 
-    return { status: res.statusCode, body: res.responseBody, nextCalled, rawResponse: res };
+    return { status: res.statusCode, body: res.responseBody, nextCalled, rawResponse: res, rawRequest: req };
   }
 }
 

--- a/tests/utils/utils.test.ts
+++ b/tests/utils/utils.test.ts
@@ -1,5 +1,6 @@
-import { normalizeName } from '../../src/client/utils/cardutil';
+import { cardCmc, normalizeName } from '../../src/client/utils/cardutil';
 import util from '../../src/util/util';
+import { createCard, createCardDetails, createCardFromDetails } from '../test-utils/data';
 
 // ...existing code...
 
@@ -387,5 +388,66 @@ describe('turnToTree', () => {
 
     const result = util.turnToTree(normalizedNames);
     expect(result).toEqual(expectedTree);
+  });
+});
+
+describe('cardCmc', () => {
+  it('returns cmc from card details', () => {
+    const card = createCardFromDetails({
+      cmc: 3,
+    });
+    expect(cardCmc(card)).toBe(3);
+  });
+
+  it('returns cmc from card override', () => {
+    const card = createCard({
+      cmc: 11,
+    });
+    expect(cardCmc(card)).toBe(11);
+  });
+
+  it('returns 0 if no details exist', () => {
+    const card = createCard({
+      details: undefined,
+    });
+    expect(cardCmc(card)).toBe(0);
+  });
+
+  it('handles string decimal cmc values', () => {
+    const card = createCard({
+      cmc: '3.5',
+    });
+    expect(cardCmc(card)).toBe(3.5);
+  });
+
+  it('handles string number cmc values', () => {
+    const card = createCard({
+      cmc: '15',
+    });
+    expect(cardCmc(card)).toBe(15);
+  });
+
+  it('handles string zero cmc values', () => {
+    const card = createCard({
+      cmc: '0',
+    });
+    expect(cardCmc(card)).toBe(0);
+  });
+
+  it('handles 0 cmc', () => {
+    const card = createCard({
+      cmc: 0,
+    });
+    expect(cardCmc(card)).toBe(0);
+  });
+
+  it('defaults to details cmc if card cmc is not parseable', () => {
+    const card = createCard({
+      details: createCardDetails({
+        cmc: 4,
+      }),
+    });
+    card.cmc = 'not a number' as any;
+    expect(cardCmc(card)).toBe(4);
   });
 });


### PR DESCRIPTION
1. Log to Cloudwatch on draft finish errors
2. Improve cardCmc method so that invalid string overrides aren't used, falls back to details cmc
3. Update CSV export to use cardCmc - though ironically that would have prevented me from exporting to my local and discovering the issue
4. Add cardCmc unit tests

I also played around with making the card CMC field in cardModal a number input, but it would trigger pending changes even if you entered non-numbers and I didn't have time to figure it out.