### PR TITLE
Upgrade Typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cubecobra",
-  "version": "1.1.23",
+  "version": "1.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cubecobra",
-      "version": "1.1.23",
+      "version": "1.2.6",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
@@ -24709,9 +24709,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
-      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13203,9 +13203,9 @@ typescript-eslint@^8.0.0:
     "@typescript-eslint/utils" "8.7.0"
 
 typescript@*, typescript@^5.5.4, typescript@>=2.7, typescript@>=4.2.0, "typescript@>=4.3 <6":
-  version "5.6.2"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz"
-  integrity sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==
+  version "5.8.3"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz"
+  integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
 
 uc.micro@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
Locally I've been using TypeScript 5.8.2 without issues.

Fingers crossed that the Typescript Go compiler becomes production ready soon and we can use it, as I've heard and seen 10x speedups