### PR TITLE
Sort Price usd foil fallback

### DIFF
--- a/src/client/utils/Sort.ts
+++ b/src/client/utils/Sort.ts
@@ -748,7 +748,7 @@ export function cardGetLabels(card: Card, sort: string, showOther = false): stri
       ret = ['No Price Available'];
     }
   } else if (sort === 'Price USD Foil') {
-    const price = card.details?.prices.usd_foil;
+    const price = card.details?.prices.usd_foil ?? card.details?.prices.usd_etched ?? card.details?.prices.usd;
     if (price) {
       ret = [getPriceBucket(price, '$')];
     } else {

--- a/tests/cards/sort.test.ts
+++ b/tests/cards/sort.test.ts
@@ -319,7 +319,103 @@ describe('Grouping by Price USD', () => {
     expect(labels).toEqual(['$50 - $74.99']);
   });
 
+  it('Foil fallback has precedence over etched', async () => {
+    const card = createCard({
+      details: createCardDetails({
+        name: 'Card 1',
+        prices: {
+          usd_foil: 123.11,
+          usd_etched: 66.6,
+        },
+      }),
+    });
+
+    const labels = cardGetLabels(card, SORT, true);
+
+    expect(labels).toEqual(['>= $100']);
+  });
+
   it('No USD price available for grouping', async () => {
+    const card = createCard({
+      details: createCardDetails({
+        name: 'Card 1',
+        prices: {
+          eur: 23.11,
+        },
+      }),
+    });
+
+    const labels = cardGetLabels(card, SORT, true);
+
+    expect(labels).toEqual(['No Price Available']);
+  });
+});
+
+describe('Grouping by Price USD Foil', () => {
+  const SORT = 'Price USD Foil';
+
+  it('Has USD foil price for grouping', async () => {
+    const card = createCard({
+      details: createCardDetails({
+        name: 'Card 1',
+        prices: {
+          usd_foil: 4.23,
+        },
+      }),
+    });
+
+    const labels = cardGetLabels(card, SORT, true);
+
+    expect(labels).toEqual(['$4 - $4.99']);
+  });
+
+  it('Has USD price for grouping, with regular fallback', async () => {
+    const card = createCard({
+      details: createCardDetails({
+        name: 'Card 1',
+        prices: {
+          usd: 23.11,
+        },
+      }),
+    });
+
+    const labels = cardGetLabels(card, SORT, true);
+
+    expect(labels).toEqual(['$20 - $24.99']);
+  });
+
+  it('Has USD foil price for grouping, with etched fallback', async () => {
+    const card = createCard({
+      details: createCardDetails({
+        name: 'Card 1',
+        prices: {
+          usd_etched: 66.6,
+        },
+      }),
+    });
+
+    const labels = cardGetLabels(card, SORT, true);
+
+    expect(labels).toEqual(['$50 - $74.99']);
+  });
+
+  it('Etched fallback has precedence over usd', async () => {
+    const card = createCard({
+      details: createCardDetails({
+        name: 'Card 1',
+        prices: {
+          usd_etched: 99.2,
+          usd: 33.1,
+        },
+      }),
+    });
+
+    const labels = cardGetLabels(card, SORT, true);
+
+    expect(labels).toEqual(['$75 - $99.99']);
+  });
+
+  it('No USD foil price available for grouping', async () => {
     const card = createCard({
       details: createCardDetails({
         name: 'Card 1',


### PR DESCRIPTION
As reported on Discord, when sorting by Foil USD price cards with only Etched versions or don't yet have a foil price (newest set pre-release cards) get bucketed into "No price available". Months ago we added to the USD price sorting fallbacks to etched and foil prices, so makes sense to do the reverse.