### PR TITLE
Fixing a few errors in the Record feature

### DIFF
--- a/src/client/components/modals/AssignTrophiesModal.tsx
+++ b/src/client/components/modals/AssignTrophiesModal.tsx
@@ -15,7 +15,11 @@ interface AssignTrophiesModalProps {
 
 const AssignTrophiesModal: React.FC<AssignTrophiesModalProps> = ({ isOpen, setOpen, record }) => {
   const formRef = createRef<HTMLFormElement>();
-  const [trophyState, setTrophyState] = useState<Record['trophy']>(record.trophy || []);
+
+  //Player renames can cause divergence from trophy winner names, remove any trophy winners that aren't in the player list
+  const playerNames = new Set(record.players.map((p) => p.name));
+  const filteredTrophyNames = record.trophy.filter((name) => playerNames.has(name));
+  const [trophyState, setTrophyState] = useState<Record['trophy']>(filteredTrophyNames || []);
 
   return (
     <Modal isOpen={isOpen} setOpen={setOpen} xl>

--- a/src/client/records/RecordDecks.tsx
+++ b/src/client/records/RecordDecks.tsx
@@ -72,7 +72,7 @@ const RecordDecks: React.FC<RecordDecksProps> = ({ record, draft }) => {
               value: `${index}`,
               label: player.name,
             }))
-            .filter((option) => draft.seats[parseInt(option.value, 10)].mainboard?.flat(3).length > 0)}
+            .filter((option) => draft.seats[parseInt(option.value, 10)]?.mainboard?.flat(3).length > 0)}
         />
         <DeckCard
           seat={draft.seats[selectedUserIndex]}

--- a/src/client/records/TrophyArchive.tsx
+++ b/src/client/records/TrophyArchive.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useContext, useMemo, useState } from 'react';
 
+import { QuestionIcon } from '@primer/octicons-react';
+
 import { CardBody } from 'components/base/Card';
 import FormatttedDate from 'components/base/FormatttedDate';
 import { Flexbox } from 'components/base/Layout';
@@ -7,6 +9,7 @@ import Link from 'components/base/Link';
 import Pagination from 'components/base/Pagination';
 import Table from 'components/base/Table';
 import Text from 'components/base/Text';
+import Tooltip from 'components/base/Tooltip';
 import { CSRFContext } from 'contexts/CSRFContext';
 import Record from 'datatypes/Record';
 
@@ -56,7 +59,12 @@ const TrophyArchive: React.FC<TrophyArchiveProps> = ({ records, lastKey }) => {
 
     for (const item of itemPage) {
       for (const trophy of item.trophy) {
-        const player = item.players.find((p) => p.name === trophy) || { name: trophy, userId: '' };
+        let player = item.players.find((p) => p.name === trophy) || { name: trophy, userId: '' };
+
+        const playerIndex = item.players.findIndex((p) => p.name === trophy);
+        if (playerIndex === -1) {
+          player = { name: trophy, userId: '' };
+        }
 
         result.push({
           Player: player.userId ? (
@@ -74,9 +82,18 @@ const TrophyArchive: React.FC<TrophyArchiveProps> = ({ records, lastKey }) => {
             </Link>
           ),
           '': item.draft ? (
-            <Link href={`/cube/deck/${item.draft}?seat=${item.players.indexOf(player)}`}>
-              <Text sm>View Deck</Text>
-            </Link>
+            playerIndex !== -1 ? (
+              <Link href={`/cube/deck/${item.draft}?seat=${item.players.indexOf(player)}`}>
+                <Text sm>View Deck</Text>
+              </Link>
+            ) : (
+              <>
+                <Text sm>Unable to find trophy winners deck</Text>&nbsp;
+                <Tooltip text="Please ensure the Player names are aligned with the Trophy winner names.">
+                  <QuestionIcon size={16} />
+                </Tooltip>
+              </>
+            )
           ) : (
             <Text sm>No draft available</Text>
           ),

--- a/src/client/records/WinrateAnalytics.tsx
+++ b/src/client/records/WinrateAnalytics.tsx
@@ -56,10 +56,10 @@ const WinrateAnalytics: React.FC<WinrateAnalyticsProps> = ({ analyticsData }) =>
         },
         decks: decks,
         matchCount: matchWins + matchLosses + matchDraws,
-        winRate: matchWins / (matchWins + matchLosses + matchDraws),
-        drawRate: matchDraws / (matchWins + matchLosses + matchDraws),
+        winRate: matchWins / (matchWins + matchLosses + matchDraws) || 0,
+        drawRate: matchDraws / (matchWins + matchLosses + matchDraws) || 0,
         gameCount: gameWins + gameLosses,
-        gameWinRate: gameWins / (gameWins + gameLosses + gameDraws),
+        gameWinRate: gameWins / (gameWins + gameLosses + gameDraws) || 0,
         trophyCount: trophies,
         trophyRate: trophies / decks,
       }));

--- a/src/router/routes/cube/records/edit/trophy.ts
+++ b/src/router/routes/cube/records/edit/trophy.ts
@@ -26,7 +26,7 @@ export const editTrophyHandler = async (req: Request, res: Response) => {
       return redirect(req, res, '/404');
     }
 
-    const trophy = JSON.parse(req.body.trophy);
+    const trophy: string[] = JSON.parse(req.body.trophy);
     if (!Array.isArray(trophy) || trophy.length === 0) {
       req.flash('danger', 'Trophy must be a non-empty array');
       return redirect(req, res, `/cube/record/${req.params.id}?tab=2`);
@@ -34,15 +34,20 @@ export const editTrophyHandler = async (req: Request, res: Response) => {
 
     // Ensure trophy is an array of valid user names from the list of players
     const validPlayers = ['Unknown Player', ...record.players.map((p) => p.name)];
+    let updatedTrophies = trophy;
     for (const player of trophy) {
-      if (typeof player !== 'string' || !validPlayers.includes(player)) {
+      if (typeof player !== 'string') {
         req.flash('danger', `Invalid player name in trophy: ${player}`);
         return redirect(req, res, `/cube/record/${req.params.id}?tab=2`);
+      }
+      //The trophy names may contain old player names which we will strip, rather than aborting the action
+      if (!validPlayers.includes(player)) {
+        updatedTrophies = updatedTrophies.filter((name) => name !== player);
       }
     }
 
     // Update the record with the new trophy
-    record.trophy = trophy;
+    record.trophy = updatedTrophies;
 
     await Record.put(record);
 


### PR DESCRIPTION
# Fixes

1. UI error caused by linking to seat -1. Caused by the Trophy winner name not aligning with the player names
2. UI error caused by adding a new seat after creating the draft decks

# Testing

## Before

### Trophy error

Setup
1. Create record with players
2. Assign a trophy to a player
3. Edit the player list so the trophy winner name no longer exists
4. Go to the Trophy archive page
5. Click the "View deck" for the trophy winner

UI error about mainboard
![image](https://github.com/user-attachments/assets/aa7ab83a-14e7-4254-866a-2b55f66fbfd4)

Can see from the HTML the seat is -1 because the trophy winners name wasn't found in the array of player names, so array findIndex gives -1
![image](https://github.com/user-attachments/assets/80edce67-adeb-4a4a-abf5-7d25f1f3cd92)

### Added seats error

1. Create a record with N players
2. Add a deck to at least one player
3. Add another player to the draft
4. Page errors

3 seats
![image](https://github.com/user-attachments/assets/de2f7311-0a8f-4cae-9ef6-b881cb0e9bda)

Clicking into the record
![image](https://github.com/user-attachments/assets/e3178bf9-6e4a-44c5-9a6a-f4cbbd74b9a0)


## After

### Trophy error

Does not link to an invalid seat. Instead gives error and tooltip about fixing the misalignment
![image](https://github.com/user-attachments/assets/f15e1410-e745-47d6-9512-35ad3723a200)

### Added seats error

Seats
![image](https://github.com/user-attachments/assets/d68b5097-9102-4cb0-9b3e-a3089978a94d)

Decks dropdown only shows the seats with drafts
![image](https://github.com/user-attachments/assets/05ed4346-b09a-473c-a666-d372235cc097)
