### PR TITLE
#2689 - Support showing card back image in the page with markdown

### DIFF
--- a/src/client/components/Markdown.tsx
+++ b/src/client/components/Markdown.tsx
@@ -149,11 +149,19 @@ interface RenderCardImageProps {
   id: string;
   dfc?: boolean;
   inParagraph?: boolean;
+  showBackImage?: boolean;
 }
 const renderCardImage: React.FC<RenderCardImageProps> = (node) => {
   const idURL = encodeURIComponent(node.id);
   const details: Partial<CardDetails> = { image_normal: `/tool/cardimage/${idURL}` };
-  if (node.dfc) details.image_flip = `/tool/cardimageflip/${idURL}`;
+  if (node.dfc) {
+    details.image_flip = `/tool/cardimageflip/${idURL}`;
+    if (node.showBackImage) {
+      //Swap the front and back images for the display, which affects the inline image and the autocard hover
+      [details.image_normal, details.image_flip] = [details.image_flip, details.image_normal];
+    }
+  }
+
   const tag = node.inParagraph ? 'span' : 'div';
   return (
     <div className="w-1/2 lg:w-1/4 p-2 markdown-card-image">

--- a/src/client/markdown/cardlink/index.js
+++ b/src/client/markdown/cardlink/index.js
@@ -17,6 +17,12 @@ function oncard(node, index, parent) {
     node.dfc = true;
   }
 
+  if (node.value[0] === '/') {
+    // A second slash means we want to show the back side on the page
+    node.value = node.value.substring(1);
+    node.showBackImage = true;
+  }
+
   if (node.value[0] === '!' && node.type !== 'cardimage') {
     // Check for exclamation point again in case we began with "/!"
     node.value = node.value.substring(1);
@@ -42,7 +48,13 @@ function oncard(node, index, parent) {
   }
 
   node.data.hName = node.type;
-  node.data.hProperties = { name: node.name, id: node.id, dfc: node.dfc, inParagraph: node.inParagraph };
+  node.data.hProperties = {
+    name: node.name,
+    id: node.id,
+    dfc: node.dfc,
+    inParagraph: node.inParagraph,
+    showBackImage: node.showBackImage,
+  };
 }
 
 function cardlinks() {

--- a/src/client/pages/MarkdownPage.tsx
+++ b/src/client/pages/MarkdownPage.tsx
@@ -184,6 +184,28 @@ const MarkdownPage: React.FC<MarkdownProps> = ({ loginCallback }) => (
             </Col>
           </Row>
           <br />
+          <p>For DFCs, you can show the back side on the page using an additional /.</p>
+          <Row>
+            <Col xs={12} sm={6}>
+              <Card>
+                <CardHeader>Source</CardHeader>
+                <CardBody>
+                  <p>
+                    <code>[[!//Delver of Secrets]]</code>
+                  </p>
+                </CardBody>
+              </Card>
+            </Col>
+            <Col xs={12} sm={6}>
+              <Card>
+                <CardHeader>Result</CardHeader>
+                <CardBody>
+                  <Markdown markdown="[[!//Delver of Secrets]]" />
+                </CardBody>
+              </Card>
+            </Col>
+          </Row>
+          <br />
           <p>
             If you want to display card images alongside each other in a row, you'll need to wrap those card images with
             double angle brackets. This feature is not available for blog posts. Take the following example:

--- a/src/client/pages/MarkdownPage.tsx
+++ b/src/client/pages/MarkdownPage.tsx
@@ -16,7 +16,7 @@ interface MarkdownProps {
   loginCallback?: string;
 }
 
-const MarkdownPage: React.FC<MarkdownProps> = ({ loginCallback }) => (
+const MarkdownPage: React.FC<MarkdownProps> = ({ loginCallback = '/' }) => (
   <MainLayout loginCallback={loginCallback}>
     <Banner />
     <DynamicFlash />
@@ -827,10 +827,6 @@ const MarkdownPage: React.FC<MarkdownProps> = ({ loginCallback }) => (
 
 MarkdownPage.propTypes = {
   loginCallback: PropTypes.string,
-};
-
-MarkdownPage.defaultProps = {
-  loginCallback: '/',
 };
 
 export default RenderToRoot(MarkdownPage);


### PR DESCRIPTION
Implements #2689

# Testing

![new-markdown-card-backside](https://github.com/user-attachments/assets/4abf4ef6-4d8e-46f8-8e32-1d8244ba1987)

Of course it doesn't work so well when the card doesn't have a backside

![image](https://github.com/user-attachments/assets/ba797bc5-6ab0-419e-bd03-b94189e1d69a)