### PR TITLE
Implement Set release date ordering

### DIFF
--- a/src/client/utils/Sort.ts
+++ b/src/client/utils/Sort.ts
@@ -17,6 +17,7 @@ import {
   cardRarity,
   cardReleaseDate,
   cardSet,
+  cardSetIndex,
   cardStatus,
   cardTix,
   cardType,
@@ -188,6 +189,7 @@ export const SORTS: string[] = [
   'MTGO TIX',
   'Rarity',
   'Set',
+  'Set (Release Date)',
   'Shards / Wedges',
   'Status',
   'Subtype',
@@ -423,6 +425,25 @@ export function getLabelsRaw(cube: Card[] | null, sort: string, showOther: boole
       }
     }
     ret = sets.sort();
+  } else if (sort === 'Set (Release Date)') {
+    //Use a map to prevent duplicates when we want both set and setIndex later.
+    //Sets treat each object as unique even if the contents are the same
+    const sets = new Map<string, { set: string; setIndex: number }>();
+    for (const card of cube || []) {
+      const set = cardSet(card).toUpperCase();
+      const setIndex = cardSetIndex(card);
+      //Encode set and set index into string for uniqueness
+      const key = `${set}-${setIndex}`;
+      if (!sets.has(key)) {
+        sets.set(key, {
+          set,
+          setIndex,
+        });
+      }
+    }
+
+    //Sort based on setIndex and then return the set codes in that order
+    ret = [...sets.values()].sort((a, b) => a.setIndex - b.setIndex).map((a) => a.set);
   } else if (sort === 'Artist') {
     const artists: string[] = [];
     for (const card of cube || []) {
@@ -657,7 +678,7 @@ export function cardGetLabels(card: Card, sort: string, showOther = false): stri
     }
   } else if (sort === 'Color Count') {
     ret = [cardColorIdentity(card).length.toFixed(0)];
-  } else if (sort === 'Set') {
+  } else if (sort === 'Set' || sort === 'Set (Release Date)') {
     ret = [cardSet(card).toUpperCase()];
   } else if (sort === 'Rarity') {
     const rarity = cardRarity(card);

--- a/src/client/utils/cardutil.ts
+++ b/src/client/utils/cardutil.ts
@@ -151,6 +151,7 @@ export const CardDetails = (card: Card): CardDetailsType =>
     oracle_id: '',
     name: 'Invalid Card',
     set: '',
+    setIndex: -1,
     collector_number: '',
     released_at: '',
     promo: false,
@@ -363,6 +364,8 @@ export const cardIsFullArt = (card: Card): boolean => card.details?.full_art ?? 
 export const cardCost = (card: Card): string[] => card.details?.parsed_cost ?? [];
 
 export const cardSet = (card: Card): string => card.details?.set ?? '';
+
+export const cardSetIndex = (card: Card): number => card.details?.setIndex ?? -1;
 
 export const cardSetName = (card: Card): string => card.details?.set_name ?? '';
 

--- a/src/datatypes/Card.ts
+++ b/src/datatypes/Card.ts
@@ -20,6 +20,7 @@ export interface CardDetails {
   oracle_id: string;
   name: string;
   set: string;
+  setIndex: number; //Index of the set code when all sets are sorted by release date. eg. Alpha = 0, M10 = 12. -1 means unknown
   collector_number: string;
   released_at: string;
   promo: boolean;

--- a/src/jobs/utils/update_cards.ts
+++ b/src/jobs/utils/update_cards.ts
@@ -88,6 +88,31 @@ export interface ScryfallCard {
   }[];
 }
 
+//See https://scryfall.com/docs/api/sets/all and https://scryfall.com/docs/api/sets
+export interface ScryfallSet {
+  object: 'set';
+  id: string;
+  code: string;
+  name: string;
+  set_type: string;
+  uri: string;
+  scryfall_uri: string;
+  search_uri: string;
+  released_at?: string; //YYYY-MM-DD format
+  card_count: number;
+  parent_set_code?: string;
+  digital: boolean;
+  nonfoil_only: boolean;
+  foil_only: boolean;
+  icon_svg_uri: string;
+  mtgo_code?: string;
+  arena_code?: string;
+  tcgplayer_id?: number;
+  block_code?: string;
+  block?: string;
+  printed_size?: number;
+}
+
 export function convertName(card: ScryfallCard, preflipped: boolean) {
   let str = card.name;
 

--- a/src/util/carddb.ts
+++ b/src/util/carddb.ts
@@ -14,6 +14,7 @@ export function getPlaceholderCard(scryfall_id: string): CardDetails {
     isToken: false,
     finishes: [],
     set: '',
+    setIndex: -1,
     collector_number: '',
     promo: false,
     reprint: false,

--- a/tests/cards/sort.test.ts
+++ b/tests/cards/sort.test.ts
@@ -1,6 +1,6 @@
-import { cardGetLabels, getLabelsRaw, sortForDownload } from '../../src/client/utils/Sort';
+import { cardGetLabels, getLabelsRaw, sortForDownload, sortGroupsOrdered } from '../../src/client/utils/Sort';
 import Card from '../../src/datatypes/Card';
-import { createCard, createCardDetails } from '../test-utils/data';
+import { createCard, createCardDetails, createCardFromDetails } from '../test-utils/data';
 
 const mapToCardNames = (sorted: Card[]) => {
   return sorted.map((c) => c.details?.name);
@@ -746,5 +746,147 @@ describe('Grouping by type', () => {
     const labels = cardGetLabels(card, SORT, true);
 
     expect(labels).toEqual(['Land']);
+  });
+});
+
+describe('Grouping by Set (Release Date)', () => {
+  const SORT = 'Set (Release Date)';
+
+  const assertGroupOrdering = (groups: [string, Card[]][], expectedSetOrder: string[]) => {
+    const setNames = groups.map((g) => g[0]);
+    expect(setNames).toEqual(expectedSetOrder);
+  };
+
+  const assertCardOrdering = (groups: [string, Card[]][], expectedCardsOrder: string[]) => {
+    const cards = groups.map((g) => g[1]);
+    expect(cards.flatMap((g) => g.map((c) => c.details?.name))).toEqual(expectedCardsOrder);
+  };
+
+  //setIndex defines the release date ordering
+  it('Cards grouped by the set release date', async () => {
+    const cards = [
+      createCardFromDetails({
+        name: 'Card 1',
+        set: 'LEA',
+        setIndex: 0,
+      }),
+      createCardFromDetails({
+        name: 'Card 2',
+        set: 'LEB',
+        setIndex: 1,
+      }),
+      createCardFromDetails({
+        name: 'Card 3',
+        set: 'TDM',
+        setIndex: 999,
+      }),
+      createCardFromDetails({
+        name: 'Card 4',
+        set: 'M15',
+        setIndex: 60,
+      }),
+      createCardFromDetails({
+        name: 'Card 5',
+        set: 'TDM',
+        setIndex: 999,
+      }),
+      createCardFromDetails({
+        name: 'Card 6',
+        set: 'ARB',
+        setIndex: 53,
+      }),
+    ];
+
+    const groups = sortGroupsOrdered(cards, SORT, true);
+    assertGroupOrdering(groups, ['LEA', 'LEB', 'ARB', 'M15', 'TDM']);
+    assertCardOrdering(groups, ['Card 1', 'Card 2', 'Card 6', 'Card 4', 'Card 3', 'Card 5']);
+  });
+
+  it('Negative indices are fine', async () => {
+    const cards = [
+      createCardFromDetails({
+        name: 'Card 2',
+        set: 'BLB',
+        setIndex: 800,
+      }),
+      createCardFromDetails({
+        name: 'Card 3',
+        set: 'RNA',
+        setIndex: 700,
+      }),
+      createCardFromDetails({
+        name: 'Card 4',
+        set: 'MSK',
+        setIndex: 60,
+      }),
+      createCardFromDetails({
+        name: 'Card 5',
+        set: 'MRD',
+        setIndex: 999,
+      }),
+      createCardFromDetails({
+        name: 'Card infinity',
+        set: 'RGPHD',
+        setIndex: -1,
+      }),
+    ];
+
+    const groups = sortGroupsOrdered(cards, SORT, true);
+    assertGroupOrdering(groups, ['RGPHD', 'MSK', 'RNA', 'BLB', 'MRD']);
+    assertCardOrdering(groups, ['Card infinity', 'Card 4', 'Card 3', 'Card 2', 'Card 5']);
+  });
+});
+
+//The ordering here is by set code alphanumeric
+describe('Grouping by Set', () => {
+  const SORT = 'Set';
+
+  const assertGroupOrdering = (groups: [string, Card[]][], expectedSetOrder: string[]) => {
+    const setNames = groups.map((g) => g[0]);
+    expect(setNames).toEqual(expectedSetOrder);
+  };
+
+  const assertCardOrdering = (groups: [string, Card[]][], expectedCardsOrder: string[]) => {
+    const cards = groups.map((g) => g[1]);
+    expect(cards.flatMap((g) => g.map((c) => c.details?.name))).toEqual(expectedCardsOrder);
+  };
+
+  it('Cards grouped by the set code', async () => {
+    const cards = [
+      createCardFromDetails({
+        name: 'Card 1',
+        set: 'LEA',
+        setIndex: 0,
+      }),
+      createCardFromDetails({
+        name: 'Card 2',
+        set: 'LEB',
+        setIndex: 1,
+      }),
+      createCardFromDetails({
+        name: 'Card 3',
+        set: 'TDM',
+        setIndex: 999,
+      }),
+      createCardFromDetails({
+        name: 'Card 4',
+        set: 'M15',
+        setIndex: 60,
+      }),
+      createCardFromDetails({
+        name: 'Card 5',
+        set: 'TDM',
+        setIndex: 999,
+      }),
+      createCardFromDetails({
+        name: 'Card 6',
+        set: 'ARB',
+        setIndex: 53,
+      }),
+    ];
+
+    const groups = sortGroupsOrdered(cards, SORT, true);
+    assertGroupOrdering(groups, ['ARB', 'LEA', 'LEB', 'M15', 'TDM']);
+    assertCardOrdering(groups, ['Card 6', 'Card 1', 'Card 2', 'Card 4', 'Card 3', 'Card 5']);
   });
 });

--- a/tests/test-utils/data.ts
+++ b/tests/test-utils/data.ts
@@ -73,6 +73,7 @@ export const createCardDetails = (overrides?: Partial<CardDetails>): CardDetails
   scryfall_id: uuidv4(),
   oracle_id: uuidv4(),
   set: generateRandomString(ALPHANUMERIC, 3).toLowerCase(),
+  setIndex: 0,
   collector_number: '123',
   released_at: '',
   promo: false,


### PR DESCRIPTION
# Details

Originally I had update_cards create an ordered list of set codes ordered by release date with the intent I'd use that in Sort.ts to order. But then I realised that list of 1000 set codes would be pulled into the bundles on the frontend, which is not ideal as each time a new set is added it would result in the commons bundle changing, forcing re-downloads.

So I landed on adding setIndex to the card details, where the index maps to the set's release date in ascending order. Eg. Alpha = 0, Beta = 1, TDM = 9 hundred something

# Question
In terms of rollout, is it OK that setIndex is not marked as possibly undefined? I am unsure if the card dictionaries are updated before the code goes out, or if those are paired together

# Testing

Set grouping
![new-set-grouping](https://github.com/user-attachments/assets/3d4e9f47-a681-44f5-bd20-5f1553360b49)

Set (Release date) grouping
![new-set-release-date-grouping](https://github.com/user-attachments/assets/466e768a-ee1b-49c2-a2c4-9747f8cc45c8)
