### PR TITLE
Fix Match schema issues preventing importing a draft into an existing record

### DIFF
--- a/src/router/routes/cube/records/create.ts
+++ b/src/router/routes/cube/records/create.ts
@@ -99,9 +99,9 @@ const recordSchema = Joi.object({
   matches: Joi.array()
     .items(
       Joi.object({
-        player1: Joi.string().required(), // Player 1's name or ID
-        player2: Joi.string().required(), // Player 2's name or ID
-        result: Joi.string().valid('win', 'loss', 'draw').required(), // Match result
+        p1: Joi.string().required(), // Player 1 ID
+        p2: Joi.string().required(), // Player 2 ID
+        results: Joi.array().items(Joi.number().required()).length(3).required(), // Results for each player
       }),
     )
     .optional(), // Matches array is optional

--- a/src/router/routes/cube/records/import.ts
+++ b/src/router/routes/cube/records/import.ts
@@ -58,9 +58,9 @@ const recordSchema = Joi.object({
   matches: Joi.array()
     .items(
       Joi.object({
-        player1: Joi.string().required(), // Player 1's name or ID
-        player2: Joi.string().required(), // Player 2's name or ID
-        result: Joi.string().valid('win', 'loss', 'draw').required(), // Match result
+        p1: Joi.string().required(), // Player 1 ID
+        p2: Joi.string().required(), // Player 2 ID
+        results: Joi.array().items(Joi.number().required()).length(3).required(), // Results for each player
       }),
     )
     .optional(), // Matches array is optional

--- a/src/router/routes/cube/records/import.ts
+++ b/src/router/routes/cube/records/import.ts
@@ -57,13 +57,18 @@ const recordSchema = Joi.object({
     .optional(), // At least one player is optional
   matches: Joi.array()
     .items(
+      //This object represents a round
       Joi.object({
-        p1: Joi.string().required(), // Player 1 ID
-        p2: Joi.string().required(), // Player 2 ID
-        results: Joi.array().items(Joi.number().required()).length(3).required(), // Results for each player
+        matches: Joi.array().items(
+          Joi.object({
+            p1: Joi.string().required(), // Player 1 ID
+            p2: Joi.string().required(), // Player 2 ID
+            results: Joi.array().items(Joi.number().required()).length(3).required(), // Results for each player
+          }),
+        ),
       }),
     )
-    .optional(), // Matches array is optional
+    .optional(), // Matches information is optional
   trophy: Joi.array().items(Joi.string()).optional(), // Trophy is optional
 }).unknown(false); // do not allow additional properties
 


### PR DESCRIPTION
# Issues

1. Player and results schema not consistent in the import and create Joi schemas
2. Match schema in import didn't match up to the total structure of rounds and matches within rounds
 
Took a while to figure it out because the matches data structure has duplicate "matches" names at different levels, eg the relevant snippet below. As well, the handler for adding rounds does a single round at a time, but since that "round" contains "matches" as the key name as well, it is confusing off the bat.
```
{
	"matches": [{
		"matches": [{
			"p1": "play1",
			"results": [2,0,0],
			"p2": "play2"
		},{
			"p1": "play2",
			"results": [1,2,1],
			"p2": "play1"
		}]
	},
	{
		"matches": [{
			"p1": "play1",
			"results": [0,0,0],
			"p2": "Unknown Opponent"
		}]
	}]
}
```

# Testing

## Before 

Case 1: Create a record with players but no matches. Then do the import process to create a deck for a user. ✔️ 

Case 2: Create a record with players and at least one round of matches. and then do the import process to create a deck for a user. ❌ fails with `matches[0].player1` is required

## After 

Case 1: Works the same ✔️ 

Case 2: Create a record with players and at least one round of matches. and then do the import process to create a deck for a user. ✔️ Deck imported, matches are unchanged