### PR TITLE
Fix Summon: Choco/Mog name

### DIFF
--- a/src/jobs/update_cards.ts
+++ b/src/jobs/update_cards.ts
@@ -816,7 +816,7 @@ const loadCardKingdomPrices = async (): Promise<Record<string, number>> => {
   const json = await res.json();
 
   // eslint-disable-next-line no-console
-  console.log(`Loaded ${json.data.length} cards from Mana Pool`);
+  console.log(`Loaded ${json.data.length} cards from Card Kingdom`);
 
   return Object.fromEntries(json.data.map((card: any) => [card.scryfall_id, parseFloat(card.price_cents) / 100]));
 };

--- a/src/jobs/utils/update_cards.ts
+++ b/src/jobs/utils/update_cards.ts
@@ -115,13 +115,14 @@ export interface ScryfallSet {
 
 export function convertName(card: ScryfallCard, preflipped: boolean) {
   let str = card.name;
+  const faceNameSeperator = '//';
 
   if (preflipped) {
-    str = str.substring(str.indexOf('/') + 2); // second name
-  } else if (card.name.includes('/') && card.layout !== 'split') {
+    str = str.substring(str.indexOf(faceNameSeperator) + faceNameSeperator.length + 1); // second name
+  } else if (card.name.includes(faceNameSeperator) && card.layout !== 'split') {
     // NOTE: we want split cards to include both names
     // but other double face to use the first name
-    str = str.substring(0, str.indexOf('/')); // first name
+    str = str.substring(0, str.indexOf(faceNameSeperator)); // first name
   }
 
   //Trim the card name here before potentially adding art series suffix.

--- a/tests/jobs/update_cards.test.ts
+++ b/tests/jobs/update_cards.test.ts
@@ -52,4 +52,10 @@ describe('convertName', () => {
     const result = convertName(card, true);
     expect(result).toEqual(`Island ${ART_SERIES_CARD_SUFFIX}`);
   });
+
+  it('Card with single slash is a regular name', async () => {
+    const card = createScryfallCard('Summon: Choco/Mog', 'normal');
+    const result = convertName(card, false);
+    expect(result).toEqual(`Summon: Choco/Mog`);
+  });
 });


### PR DESCRIPTION
Make the name separator look for `//` instead of `/` only

# Testing

## Before

![old-delver](https://github.com/user-attachments/assets/3e91b68d-08ba-4f13-ad57-edf3dcc4b013)
![old-choco](https://github.com/user-attachments/assets/b1c717e9-5bb8-467e-8ed1-e84011b72567)

## After

![new-delver](https://github.com/user-attachments/assets/eeedc582-c0d1-489a-9dda-e8691693178f)
![new-choco-mob](https://github.com/user-attachments/assets/82d35a0e-a2a3-47ab-add0-3cf052c03eff)
