### PR TITLE
Fix undefined in Analysis page causing page error

### DIFF
--- a/src/client/analytics/Averages.tsx
+++ b/src/client/analytics/Averages.tsx
@@ -72,10 +72,10 @@ const Averages: React.FC<AveragesProps> = ({ characteristics }) => {
               return true;
             })
             .map((card): [number, number] => {
-              return [
-                asfans[card.cardID] || 1,
-                parseFloat(characteristics[characteristic || DEFAULT_CHARACTERISTIC].get(card).toString()),
-              ];
+              //Even though characteristic.get should only return string or number, in some cases our functions are returning undefined
+              const charValue = characteristics[characteristic || DEFAULT_CHARACTERISTIC].get(card);
+              const value = charValue === undefined ? 0 : parseFloat(charValue.toString());
+              return [asfans[card.cardID] || 1, value];
             })
             .filter(([weight, x]) => {
               return weight && weight > 0 && (x || x === 0);

--- a/src/client/pages/CubeAnalysisPage.tsx
+++ b/src/client/pages/CubeAnalysisPage.tsx
@@ -73,12 +73,12 @@ const CubeAnalysisPage: React.FC<CubeAnalysisPageProps> = ({ cubeAnalytics, toke
     Power: convertToCharacteristic('Power', (card) => cardPower(card)),
     Toughness: convertToCharacteristic('Toughness', (card) => cardToughness(card)),
     elo: convertToCharacteristic('elo', (card) => cardElo(card)),
-    Price: convertToCharacteristic('Price', (card) => cardPrice(card)),
-    'Price USD': convertToCharacteristic('Price USD', (card) => cardNormalPrice(card)),
-    'Price USD Foil': convertToCharacteristic('Price USD Foil', (card) => cardFoilPrice(card)),
-    'Price USD Etched': convertToCharacteristic('Price USD Etched', (card) => cardEtchedPrice(card)),
-    'Price EUR': convertToCharacteristic('Price EUR', (card) => cardPriceEur(card)),
-    'MTGO TIX': convertToCharacteristic('MTGO TIX', (card) => cardTix(card)),
+    Price: convertToCharacteristic('Price', (card) => cardPrice(card) ?? 0),
+    'Price USD': convertToCharacteristic('Price USD', (card) => cardNormalPrice(card) ?? 0),
+    'Price USD Foil': convertToCharacteristic('Price USD Foil', (card) => cardFoilPrice(card) ?? 0),
+    'Price USD Etched': convertToCharacteristic('Price USD Etched', (card) => cardEtchedPrice(card) ?? 0),
+    'Price EUR': convertToCharacteristic('Price EUR', (card) => cardPriceEur(card) ?? 0),
+    'MTGO TIX': convertToCharacteristic('MTGO TIX', (card) => cardTix(card) ?? 0),
     'Cube elo': {
       get: getCubeElo,
       labels: (list: any[]) =>


### PR DESCRIPTION
I didn't explore into whether defaulting to zero affects the statistics in any way, as compared to ignoring the card entirely.

# Testing

## Before

Just loading up a test cube I had on my local and using the Price Characteristic I reproduced the discord error report
![old-undefined-pricing-error](https://github.com/user-attachments/assets/66c6c72b-fb88-4f09-8d4c-0b5c3d8a9aa1)
Turns out a card had no USD prices (which likely is because to run update cards I've had to comment out the downloading of prices cause so flaky)

## After

Prices fallback to zero, and undefined values from the characteristic function also does the same. So even though many cards have no Tix prices, the page doesn't error.
![new-undefined-prices-no-error](https://github.com/user-attachments/assets/ec48c36c-ab72-4d8d-9e75-af74e9956c59)
