### PR TITLE
Lazy loading Card versions and Autocomplete information

### DIFF
--- a/src/client/components/cube/ListView.tsx
+++ b/src/client/components/cube/ListView.tsx
@@ -100,7 +100,7 @@ const ListView: React.FC<ListViewProps> = ({ cards }) => {
         sortQuaternary || 'Alphabetical',
         cube.showUnsorted || false,
       ),
-    [cards, cube.showUnsorted, sortQuaternary, sortPrimary, sortSecondary],
+    [cards, sortPrimary, sortSecondary, sortTertiary, sortQuaternary, cube.showUnsorted],
   );
 
   const handleCheck = useCallback(

--- a/src/client/components/modals/WithCardModal.tsx
+++ b/src/client/components/modals/WithCardModal.tsx
@@ -26,6 +26,7 @@ const withCardModal = <P,>(Tag: React.ComponentType<P>) => {
         } else {
           event.preventDefault();
           const { board, index } = props.modalprops.card;
+          // eslint-disable-next-line no-console
           console.log('board', board, 'index', index);
           if (board !== undefined && index !== undefined) setModalSelection({ board, index });
           setModalOpen(true);


### PR DESCRIPTION
# Changes
Based on discussion from Discord on ways to improve performance / reduce network traffic.

I highly leveraged Copilot for this, enough that I ran out of free credits lol. I had googled about JavaScript proxies and React Lazy loading beforehand, but didn't have experience with the syntax.

1. Card versions in CubeContext lazy loaded when used, which is in the CardModal or ListView
2. Autocomplete input lazy loads the tree data when the input is not-empty. This mainly affects the edit part with Adds and Removes
    1. For removes we could built the tree from the cards already loaded, instead of making a fetch call
    2. In some usages of the Autocomplete such as cube/user image, it isn't actually lazy since once rendered the input has a value

## Potential downsides
By lazy loading people with slow connections might have reduced user experience since these changes don't use any loading state. That would be most visible looking at the cube list view.

## Looking at next
In CubeAnalysis page the recommendations and combos load right away. Part of the reason why is that the TabbedView renders all contents but hides the non-active tab, so the useEffect in the tabs triggers right away. I played around with only rendering the active tab and while that worked, it got a bit messy since each time the tab rendered it would fetch the data unless it was "cached" outside the component.

# Testing

Tested in:
* Desktop Chrome, Firefox, Edge
* Mobile Chrome and Firefox

## Before

Cube pages fetch two autocomplete lists and card versions right away
![old-cube-list-eager-loads](https://github.com/user-attachments/assets/7a8ad73b-3aae-4b07-8b4f-1b3afe8ead98)
Packages modal loads autocomplete list right away
![old-package-eager-load](https://github.com/user-attachments/assets/98bafe26-6142-40db-8da7-0f240f61c62b)
Advanced filter modal eager loading tags (also the could be computed from the current card list so tag updates exist)
![old-eager-load-filter-tag](https://github.com/user-attachments/assets/d27499a8-7498-4644-9d4b-d1dc07e935c1)

## After

On Cube page load the 3 calls are lazy loaded
![new-lazy-load-3](https://github.com/user-attachments/assets/b083569c-6f0b-43e5-9af1-d9288a6fd14b)
Can see the card versions loaded in when looking at the list view, which uses them.
![new-lazy-load-4](https://github.com/user-attachments/assets/b1827217-c033-41c1-9081-c091b5d3a47c)
Or when clicking into the card modal.
![new-lazy-load-5](https://github.com/user-attachments/assets/bb88ab3b-655c-4bc6-92fd-b4e54ee998ed)

The edit autocompletes lazy load too.
![new-autocomplete-lazy-load](https://github.com/user-attachments/assets/b855d0b2-e596-40fd-a02d-89f9e880f9be)
Same with card name autocomplete in record
![new-lazy-load-autocomplete-records](https://github.com/user-attachments/assets/5954408f-122f-4395-94a3-18a614a5e3d8)
Or in the cube filter advanced modal for tags
![new-lazy-load-autocomplete-tags](https://github.com/user-attachments/assets/cb5a9f27-0210-4b48-8344-c30113ac145e)
