### PR TITLE
Fix incorrect status() method call.

### DIFF
--- a/src/routes/job_routes.js
+++ b/src/routes/job_routes.js
@@ -18,14 +18,14 @@ router.post('/featuredcubes/rotate', async (req, res) => {
   const { token } = req.body;
 
   if (token !== process.env.JOBS_TOKEN) {
-    return res.statusCode(401).send('Invalid token.');
+    return res.status(401).send('Invalid token.');
   }
 
   const response = await FeaturedQueue.querySortedByDate(null, 4);
   const rotate = await fq.rotateFeatured(response.items);
 
   if (rotate.success === 'false') {
-    return res.statusCode(500).send('featured cube rotation failed: ' + rotate.messages.join('\n'));
+    return res.status(500).send('featured cube rotation failed: ' + rotate.messages.join('\n'));
   }
 
   const olds = await User.batchGet(rotate.removed.map((f) => f.ownerID));


### PR DESCRIPTION
Saw this error when testing locally, such as when the queue didn't have 4 or more items in it.

# Testing

## Before

Server error when there was a rotation validation error
```
cube        | [
cube        |   'Unhandled Rejection at: Promise ',
cube        |   TypeError: res.statusCode is not a function
cube        |       at /home/node/app/src/routes/job_routes.js:28:16
cube        |       at processTicksAndRejections (node:internal/process/task_queues:95:5),
cube        |   'TypeError: res.statusCode is not a function\n' +
cube        |     '    at /home/node/app/src/routes/job_routes.js:28:16\n' +
cube        |     '    at processTicksAndRejections (node:internal/process/task_queues:95:5)'
cube        | ]
```

## After

Server response correct with 500 error when there was a rotation validation error
```
cube        | {
cube        |   "id": "103912b3-5306-407c-aaa5-0cb5999be6d0",
cube        |   "method": "POST",
cube        |   "path": "/job/featuredcubes/rotate",
cube        |   "user_id": null,
cube        |   "username": null,
cube        |   "remoteAddr": "127.0.0.1",
cube        |   "body": {
cube        |     "JOB_TOKEN": "XXXXXXXXX"
cube        |   },
cube        |   "duration": 12.06,
cube        |   "status": 500,
cube        |   "isError": false,
cube        |   "responseSize": 62
cube        | }
```