### PR TITLE
Improve weirdness around editing card CMC

### DIFF
--- a/src/client/components/card/CardModal.tsx
+++ b/src/client/components/card/CardModal.tsx
@@ -143,9 +143,9 @@ const CardModal: React.FC<CardModalProps> = ({
 
   const doCmcValidity = useCallback((input: HTMLInputElement) => {
     if (input.validity.patternMismatch) {
-      input.setCustomValidity('Cmc must be a non-negative number (integer or decimal).');
+      input.setCustomValidity('Mana Value must be a non-negative number (integer or decimal).');
     } else if (input.validity.valueMissing) {
-      input.setCustomValidity('Cmc must be set.');
+      input.setCustomValidity('Mana Value must be set.');
     } else {
       input.setCustomValidity('');
     }

--- a/src/client/components/card/CardModal.tsx
+++ b/src/client/components/card/CardModal.tsx
@@ -10,7 +10,6 @@ import ManaPoolButton from 'components/purchase/ManaPoolButton';
 import TCGPlayerButton from 'components/purchase/TCGPlayerButton';
 import withModal from 'components/WithModal';
 import {
-  cardCmc,
   cardColorCategory,
   cardColorIdentity,
   cardElo,
@@ -288,7 +287,7 @@ const CardModal: React.FC<CardModalProps> = ({
                   label="Mana Value"
                   type="text"
                   name="cmc"
-                  value={`${cardCmc(card)}`}
+                  value={`${card.cmc ?? card.details?.cmc ?? ''}`}
                   onChange={(event) => updateField('cmc', event.target.value)}
                   disabled={disabled}
                 />

--- a/src/client/components/card/CardModal.tsx
+++ b/src/client/components/card/CardModal.tsx
@@ -24,6 +24,7 @@ import {
   cardTags,
   cardTix,
   cardType,
+  isCardCmcValid,
   normalizeName,
 } from 'utils/cardutil';
 import { getLabels } from 'utils/Sort';
@@ -89,8 +90,6 @@ const CardModal: React.FC<CardModalProps> = ({
   allTags,
 }) => {
   const [versions, setVersions] = useState<Record<string, CardDetails> | null>(null);
-  //Default value is undefined so the field only shows red border when wrong, neutral otherwise
-  const [isCmcValid, setCmcValid] = useState<boolean | undefined>(undefined);
 
   useEffect(() => {
     if (!versionDict[normalizeName(cardName(card))]) {
@@ -120,7 +119,6 @@ const CardModal: React.FC<CardModalProps> = ({
   //When the card id changes, then update the image used. If we just checked card, it would be different
   //if any field in the modal is edited, which would lead the image to reset to the front face.
   if (prevCardID !== card.cardID) {
-    setCmcValid(undefined);
     setIsFrontImage(true);
     setPrevCardID(card.cardID);
     setImageUsed(getCardFrontImage(card));
@@ -151,7 +149,7 @@ const CardModal: React.FC<CardModalProps> = ({
     } else {
       input.setCustomValidity('');
     }
-    setCmcValid(input.reportValidity() ? undefined : false);
+    input.reportValidity();
   }, []);
 
   const onCmcChange = useCallback(
@@ -166,13 +164,6 @@ const CardModal: React.FC<CardModalProps> = ({
   const revertAction = useCallback(() => {
     if (card.editIndex !== undefined && card.board !== undefined) {
       revertEdit(card.editIndex, card.board);
-
-      const cmcInput: HTMLInputElement | null = document.querySelector('#cardModalCmc');
-      //Assume that the loaded state of the card has a valid CMC
-      if (cmcInput) {
-        setCmcValid(undefined);
-        cmcInput.setCustomValidity('');
-      }
     }
   }, [revertEdit, card]);
 
@@ -332,7 +323,7 @@ const CardModal: React.FC<CardModalProps> = ({
                   value={`${card.cmc ?? card.details?.cmc ?? ''}`}
                   onChange={onCmcChange}
                   disabled={disabled}
-                  valid={isCmcValid}
+                  valid={isCardCmcValid(card.cmc ?? card.details?.cmc).valid ? undefined : false}
                   placeholder={`${card.details?.cmc ?? ''}`}
                   otherInputProps={{
                     required: true,

--- a/src/client/components/cube/ListView.tsx
+++ b/src/client/components/cube/ListView.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useContext, useMemo, useState } from 'react';
 
 import {
-  cardCmc,
   cardColorIdentity,
   cardFullName,
   cardIndex,
@@ -87,6 +86,8 @@ const ListView: React.FC<ListViewProps> = ({ cards }) => {
   const { versionDict, editCard, tagColors, allTags, canEdit } = useContext(CubeContext);
   const [checked, setChecked] = useState<{ [key: string]: boolean }>({});
   const [pageSize, setPageSize] = useState(50);
+  //Default value is undefined so the field only shows red border when wrong, neutral otherwise
+  const [isCmcValid, setCmcValid] = useState<{ [key: string]: boolean | undefined }>({});
 
   const { sortPrimary, sortSecondary, sortTertiary, sortQuaternary, cube } = useContext(CubeContext);
 
@@ -130,6 +131,30 @@ const ListView: React.FC<ListViewProps> = ({ cards }) => {
       editCard(cardIndex(card), { ...card, [field]: value }, card.board || 'mainboard');
     },
     [editCard],
+  );
+
+  const doCmcValidity = useCallback((card: CardType, input: HTMLInputElement) => {
+    if (input.validity.patternMismatch) {
+      input.setCustomValidity('Cmc must be a non-negative number (integer or decimal).');
+    } else if (input.validity.valueMissing) {
+      input.setCustomValidity('Cmc must be set.');
+    } else {
+      input.setCustomValidity('');
+    }
+    const isValid = input.reportValidity() ? undefined : false;
+    setCmcValid((prevCmcValid) => ({
+      ...prevCmcValid,
+      [cardIndex(card)]: isValid,
+    }));
+  }, []);
+
+  const onCmcChange = useCallback(
+    (card: CardType, e: React.ChangeEvent<HTMLInputElement>) => {
+      const input = e.target;
+      updateField(card, 'cmc', input.value);
+      doCmcValidity(card, input);
+    },
+    [updateField, doCmcValidity],
   );
 
   const headers = ['Name', 'Version', 'Type', 'Status', 'Finish', 'CMC', 'Color Identity', 'Tags'];
@@ -188,8 +213,14 @@ const ListView: React.FC<ListViewProps> = ({ cards }) => {
       <Input
         type="text"
         name="cmc"
-        value={`${cardCmc(card)}`}
-        onChange={(event) => updateField(card, 'cmc', event.target.value)}
+        value={`${card.cmc ?? card.details?.cmc ?? ''}`}
+        onChange={(e) => onCmcChange(card, e)}
+        valid={isCmcValid[cardIndex(card)]}
+        placeholder={`${card.details?.cmc ?? ''}`}
+        otherInputProps={{
+          required: true,
+          pattern: '[0-9.]+',
+        }}
         style={{ maxWidth: '3rem' }}
       />
     ),

--- a/src/client/components/cube/ListView.tsx
+++ b/src/client/components/cube/ListView.tsx
@@ -134,9 +134,9 @@ const ListView: React.FC<ListViewProps> = ({ cards }) => {
 
   const doCmcValidity = useCallback((input: HTMLInputElement) => {
     if (input.validity.patternMismatch) {
-      input.setCustomValidity('Cmc must be a non-negative number (integer or decimal).');
+      input.setCustomValidity('Mana Value must be a non-negative number (integer or decimal).');
     } else if (input.validity.valueMissing) {
-      input.setCustomValidity('Cmc must be set.');
+      input.setCustomValidity('Mana Value must be set.');
     } else {
       input.setCustomValidity('');
     }

--- a/src/client/utils/cardutil.ts
+++ b/src/client/utils/cardutil.ts
@@ -185,20 +185,29 @@ export const CardDetails = (card: Card): CardDetailsType =>
     promo_types: [],
   };
 
-export const cardCmc = (card: Card): number => {
-  //cmc could be zero so we must check if it is set more specifically
-  if (card.cmc !== undefined && card.cmc !== null) {
-    // if it's a string
-    if (typeof card.cmc === 'string') {
-      // if it includes a dot, parse as float, otherwise parse as int
-      const parsed = card.cmc.includes('.') ? parseFloat(card.cmc) : parseInt(card.cmc);
-      // if parsed is NaN, fall back to details.cmc
-      if (Number.isNaN(parsed)) {
-        return card.details?.cmc ?? 0;
-      }
-      return parsed;
+export const isCardCmcValid = (cmc: string | number | undefined): { valid: boolean; value: number | undefined } => {
+  if (cmc === undefined || cmc === null || cmc === '') {
+    return { valid: false, value: undefined };
+  }
+
+  // if it's a string
+  if (typeof cmc === 'string') {
+    // if it includes a dot, parse as float, otherwise parse as int
+    const parsed = cmc.includes('.') ? parseFloat(cmc) : parseInt(cmc);
+    // if parsed is NaN, fall back to details.cmc
+    if (Number.isNaN(parsed)) {
+      return { valid: false, value: undefined };
     }
-    return card.cmc;
+    return { valid: true, value: parsed };
+  } else {
+    return { valid: true, value: cmc };
+  }
+};
+
+export const cardCmc = (card: Card): number => {
+  const isCmcValid = isCardCmcValid(card.cmc);
+  if (isCmcValid.valid) {
+    return isCmcValid.value!;
   }
 
   return card.details?.cmc ?? 0;

--- a/tests/utils/utils.test.ts
+++ b/tests/utils/utils.test.ts
@@ -450,6 +450,16 @@ describe('cardCmc', () => {
     card.cmc = 'not a number' as any;
     expect(cardCmc(card)).toBe(4);
   });
+
+  it('defaults to details cmc if card cmc is empty', () => {
+    const card = createCard({
+      details: createCardDetails({
+        cmc: 4,
+      }),
+    });
+    card.cmc = '' as any;
+    expect(cardCmc(card)).toBe(4);
+  });
 });
 
 describe('cardLegalIn', () => {


### PR DESCRIPTION
# Problem

As reported in Discord on mobile it is very hard to edit the CMC on mobile. Deleting the number does not appear to have an effect, even though the card is in a changed state. This occurs because the UI uses cardCmc for the input value, so when the text field is cleared the function falls back to the details CMC which often looks the same. However the card is in a state where the override cmc is an empty string yet the text input shows the card's true cmc. And if you are typing quickly, you'd end up adding a the desired number to the true CMC instead of replacing the CMC.

On desktop this is alleviated because you can easily select all the text and enter a new number, which bypasses. But the same problem exists.

In the end a user can easily cause the card's override cmc to be an invalid value, though thankfully since the rest of the code uses cardCmc it will fallback to the true CMC when it comes to things like filtering and sorting.

# Solution
Don't use cardCmc for the value of the text input, so that whatever the user typed is shown in the input and the fallback doesn't mess with what they've typed. Then use browser input validation standards to warn the user about missing or invalid CMCs, with the hopes they will correct it before saving the edits.

Updated on both the card modal and the list view.

# Testing

## Before

To illustrate the problem better, I started with an Esper Sentinal set with a CMC of 4 (true CMC is 1). I delete the 4 but the text input shows 1 since its showing the true CMC
![old-removing-cmc-falls-back-to-real-cmc](https://github.com/user-attachments/assets/abe0f46c-7320-46c9-9f40-758db957f6e4)

On mobile the same happens, though in this case I am deleting the 4 and entering a 3 but the end result is a 13.
![old-removing-cmc-falls-back-to-real-cmc-mobile-hard-to-edit](https://github.com/user-attachments/assets/d2956138-c83c-45b5-8ffd-de679abf1791)

Same action as the previous screenshot, except starting from the true cmc of 1.
![old-removing-cmc-falls-back-to-real-cmc-mobile-hard-to-edit2](https://github.com/user-attachments/assets/c3050fa0-be7a-4a58-a200-31217c85b657)

For extra technical details, can see that when you delete the text but it still shows 3, in the backend the card's cmc override is set to blank in comparison to the true cmc.
![old-can-remove-cmc-but-wouldnt-know-in-ui](https://github.com/user-attachments/assets/e6924d49-3512-49fe-bda6-0b438c135fab)

## After
**Note: Took these gifs before updating the messaging from CMC to Mana Value**

Showing the input warnings when the cmc is in a bad state. The input now uses the card's true CMC as the placeholder value, in case you need a reminder.
![new-card-modal-cmc-warnings](https://github.com/user-attachments/assets/de7f067c-f03a-4b62-b0b3-a5dd6eabb18e)

Similar stuff on the list view
![new-list-cmc-warnings](https://github.com/user-attachments/assets/4675d691-02b3-4931-8929-4a2cd0e519bb)

The validation will not prevent saving bad cmcs, so that has not changed.
![new-can-still-save-invalid-cmc](https://github.com/user-attachments/assets/7e384941-21d5-404d-8011-bce34eafef7e)

Zero is valid CMC, but negative isn't
![new-zero-valid-cmc](https://github.com/user-attachments/assets/6cf2bfcb-5b5c-4d11-8eff-350aee11bb8f)
![new-negative-cmcs-not-allowed](https://github.com/user-attachments/assets/202cdb6b-2fa8-4e9a-a5cd-1d5644899200)

Firefox warnings (Edge looks the same as Chrome):
<img width="498" height="140" alt="new-firefox-cmc-warnings" src="https://github.com/user-attachments/assets/24e58cfe-5075-4d63-84e1-6450510ded29" />
<img width="487" height="141" alt="new-firefox-cmc-warnings2" src="https://github.com/user-attachments/assets/f302ab6a-18aa-4b47-93fa-fa3066574a94" />

Chrome mobile validation messages
![new-mobile-cmc-warnings](https://github.com/user-attachments/assets/79036d1f-5a98-4ac6-a895-900a4080dca2)
