### PR TITLE
Better heading support for anchors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cubecobra",
-  "version": "1.2.6",
+  "version": "1.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cubecobra",
-      "version": "1.2.6",
+      "version": "1.2.8",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
@@ -94,6 +94,7 @@
         "react-qr-code": "^2.0.15",
         "react-syntax-highlighter": "^15.3.0",
         "react-timeago": "^7.1.0",
+        "react-to-text": "^2.0.1",
         "rehype-katex": "^7.0.0",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.0",
@@ -21740,6 +21741,16 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-to-text": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/react-to-text/-/react-to-text-2.0.1.tgz",
+      "integrity": "sha512-4lGuxY+/PqASinxrv7/ydE8wGdnZCGsTNIFiO6DKykzy703jI5pc0/fyyB6BNrBWmtYJ7H9dGY80PJ3V1/8UIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "react-qr-code": "^2.0.15",
     "react-syntax-highlighter": "^15.3.0",
     "react-timeago": "^7.1.0",
+    "react-to-text": "^2.0.1",
     "rehype-katex": "^7.0.0",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.0",

--- a/src/client/components/Markdown.tsx
+++ b/src/client/components/Markdown.tsx
@@ -6,6 +6,7 @@ import { slug } from 'github-slugger';
 import ReactMarkdown, { MarkdownProps } from 'react-markdown';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { a11yDark, a11yLight } from 'react-syntax-highlighter/dist/cjs/styles/hljs';
+import reactToText from 'react-to-text';
 
 import { ALL_PLUGINS, ALL_REHYPE_PLUGINS, LIMITED_REHYPE_PLUGINS } from 'markdown/parser';
 import { isInternalURL, isSamePageURL } from 'utils/Util';
@@ -24,25 +25,9 @@ import withModal, { WithModalProps } from './WithModal';
  * That plugin, and its friend rehype-autolink-headings only interact with literal h# elements, but we have configured
  * ReactMarkdown with custom components (renderers) for those which generate Text components (they are not h# elements)
  */
-function generateHeadingId(headingText: ReactNode): string {
-  /*
-   * An object means an Iterable<ReactNode>. We only want to use any string parts of it to make the slug
-   */
-  if (typeof headingText === 'object') {
-    const strings: string[] = [];
-    for (const [, value] of Object.entries(headingText!)) {
-      if (typeof value === 'string') {
-        strings.push(value.trim());
-      }
-    }
-    return slug(strings.join('-'), false);
-
-    //A plain string would be just text content
-  } else if (typeof headingText === 'string') {
-    //Simplfied, slug replaces spaces with dashes and strips non-alphanumeric content
-    return slug(String(headingText), false);
-  }
-  return '';
+function generateHeadingId(node: ReactNode): string {
+  //Since headings can contain non-text stuff like LateX, use reactToText to get any textual parts of the heading
+  return slug(reactToText(node).trim(), false) ?? '';
 }
 
 type AutocardLinkProps = WithAutocardProps & LinkProps;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1710,11 +1710,6 @@
   optionalDependencies:
     "@img/sharp-libvips-linuxmusl-x64" "1.0.4"
 
-"@img/sharp-win32-x64@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz"
-  integrity sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==
-
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz"
@@ -11295,7 +11290,7 @@ react-csv@^2.0.3:
   resolved "https://registry.npmjs.org/react-csv/-/react-csv-2.2.2.tgz"
   integrity sha512-RG5hOcZKZFigIGE8LxIEV/OgS1vigFQT4EkaHeKgyuCbUAu9Nbd/1RYq++bJcJJ9VOqO/n9TZRADsXNDR4VEpw==
 
-"react-dom@^16.8.0 || ^17.0.0 || ^18.0.0", react-dom@^18, react-dom@^18.0.0, react-dom@^18.3.1, react-dom@>=16, react-dom@>=16.13.1, react-dom@>=16.8.0:
+"react-dom@^16.8.0 || ^17.0.0 || ^18.0.0", react-dom@^18, react-dom@^18.0.0, react-dom@^18.2.0, react-dom@^18.3.1, react-dom@>=16, react-dom@>=16.13.1, react-dom@>=16.8.0:
   version "18.3.1"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz"
   integrity sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==
@@ -11382,7 +11377,12 @@ react-timeago@^7.1.0:
   resolved "https://registry.npmjs.org/react-timeago/-/react-timeago-7.2.0.tgz"
   integrity sha512-2KsBEEs+qRhKx/kekUVNSTIpop3Jwd7SRBm0R4Eiq3mPeswRGSsftY9FpKsE/lXLdURyQFiHeHFrIUxLYskG5g==
 
-react@*, "react@^16.0.0 || ^17.0.0 || ^18.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0", react@^18, react@^18.0.0, react@^18.3.1, "react@>= 0.14.0", react@>=16, react@>=16.13.1, react@>=16.3, react@>=16.4.1, react@>=16.6.0, react@>=16.8.0, react@>=18:
+react-to-text@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/react-to-text/-/react-to-text-2.0.1.tgz"
+  integrity sha512-4lGuxY+/PqASinxrv7/ydE8wGdnZCGsTNIFiO6DKykzy703jI5pc0/fyyB6BNrBWmtYJ7H9dGY80PJ3V1/8UIg==
+
+react@*, "react@^16.0.0 || ^17.0.0 || ^18.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0", react@^18, react@^18.0.0, react@^18.2.0, react@^18.3.1, "react@>= 0.14.0", react@>=16, react@>=16.13.1, react@>=16.3, react@>=16.4.1, react@>=16.6.0, react@>=16.8.0, react@>=18:
   version "18.3.1"
   resolved "https://registry.npmjs.org/react/-/react-18.3.1.tgz"
   integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==


### PR DESCRIPTION
Fixes #2706 2706

Found a simple library (https://github.com/lhansford/react-to-text) that does the work of getting the textual contents of a heading. Thus opening up more complex contents which generates an anchor to the heading.

# Testing

## Before

Can see from the HTML only "Boats" gets an id for anchoring to, as it is the only one where the header text is just a string
<img width="897" height="825" alt="old-complex-headers-no-anchors" src="https://github.com/user-attachments/assets/7e87715a-fdbf-4230-b5be-db1a8d116e8c" />

## After

Now all of the headers have an id to anchor (though of course the latex ones aren't very usable)
<img width="902" height="824" alt="new-header-anchors-more-possibilities" src="https://github.com/user-attachments/assets/57a18767-1955-4a14-8be9-00b24a1ced5c" />
