### PR TITLE
Fix error where changes to blog post title did not update form data for post.

### DIFF
--- a/src/client/components/modals/CreateBlogModal.tsx
+++ b/src/client/components/modals/CreateBlogModal.tsx
@@ -35,7 +35,7 @@ const CreateBlogModal: React.FC<CreateBlogModalProps> = ({ isOpen, setOpen, post
       mentions: findUserLinks(markdown).join(';'),
       id: post ? post.id : '',
     };
-  }, [post, markdown]);
+  }, [post, title, markdown]);
 
   return (
     <Modal isOpen={isOpen} setOpen={setOpen} lg>


### PR DESCRIPTION
The error is because the useMemo didn't have title in its dependencies, so changes to the title as a user typed didn't update the form. So the error could occur if someone tried to create a blog post with no body, or filled in the body before the title.

# Testing

## Before

Enter a title with enough characters, but no body
<img width="428" height="356" alt="old-6-char-title" src="https://github.com/user-attachments/assets/6c953666-d0cf-421a-ba91-ed6e15b202e4" />
The post does not contain title
<img width="983" height="572" alt="old-title-not-set-in-post" src="https://github.com/user-attachments/assets/f588e3f7-6ed3-4e15-b8e6-6db7fb235926" />

## After

Enter not enough characters
<img width="395" height="279" alt="new-bad-title" src="https://github.com/user-attachments/assets/97202a91-fa36-4c2a-97bd-8c9f4eb7434f" />
Post contains title and validation prevents
<img width="989" height="560" alt="new-fail" src="https://github.com/user-attachments/assets/769225cb-1276-474a-a835-67703937ef53" />

Enter enough
<img width="444" height="266" alt="new-6-character-title" src="https://github.com/user-attachments/assets/6e94229e-8210-407c-a50e-74279aa61250" />
Post contains and passes
<img width="987" height="427" alt="new-success" src="https://github.com/user-attachments/assets/b4f92169-d5a5-4078-b6eb-bbc250880a89" />

