### PR TITLE
Fix indefinite paging that needs two clicks when the next page is full

### DIFF
--- a/src/client/components/IndefinitePaginatedList.tsx
+++ b/src/client/components/IndefinitePaginatedList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext,useState } from 'react';
+import React, { useCallback, useContext, useState } from 'react';
 
 import { CSRFContext } from '../contexts/CSRFContext';
 import { Card, CardBody, CardHeader } from './base/Card';
@@ -64,6 +64,7 @@ const IndefinitePaginatedList = <T,>({
 
     if (response.ok) {
       const json = await response.json();
+      // eslint-disable-next-line no-console
       console.log(json);
       if (json.success === 'true') {
         const newItems = [...items, ...json.items];
@@ -79,7 +80,7 @@ const IndefinitePaginatedList = <T,>({
       }
     }
     setLoading(false);
-  }, [lastKey, items, page]);
+  }, [csrfFetch, fetchMoreRoute, lastKey, items, setItems, pageSize, setLastKey, page]);
 
   const pager = (
     <Pagination

--- a/src/client/components/IndefinitePaginatedList.tsx
+++ b/src/client/components/IndefinitePaginatedList.tsx
@@ -71,9 +71,8 @@ const IndefinitePaginatedList = <T,>({
         setItems(newItems);
 
         const numItemsShowOnLastPage = items.length % pageSize;
-        const newItemsShowOnLastPage = newItems.length % pageSize;
-
-        if (numItemsShowOnLastPage === 0 && newItemsShowOnLastPage > 0) {
+        //If current page is full and we just fetched more items, then move to next page
+        if (numItemsShowOnLastPage === 0 && json.items.length > 0) {
           setPage(page + 1);
         }
         setLastKey(json.lastKey);


### PR DESCRIPTION
I noticed this when testing blogs. When the current page is full and the next page fetched is also full, then it takes two clicks to see the next page contents. Applies to more than blogs.

# Testing

## Before

Takes two clicks to see the next page
![old-paging-takes-two-clicks2](https://github.com/user-attachments/assets/094b4054-1766-41be-8778-0b6a23ea702e)

## After

Takes one click
![new-paging](https://github.com/user-attachments/assets/e1ed5540-c2c9-4aeb-af98-de0c0dcbb774)

Same behaviour as before when there is nothing in the next page
![when-exactly-a-page-of-items](https://github.com/user-attachments/assets/d3be7860-5e6b-470d-be71-24097ff05e60)
