### PR TITLE
Fix podcast episodes using images from other podcasts

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -29,7 +29,7 @@ module.exports = {
   coverageDirectory: 'coverage',
   coverageReporters: ['json', 'text'],
   collectCoverageFrom: [
-    'src/**/*.{ts,tsx}',
+    'src/**/*.{js,ts,tsx}',
     'src/dynamo/models/*.js',
     'src/client/filtering/*.js',
     '!src/**/*.d.ts',

--- a/src/dynamo/models/content.ts
+++ b/src/dynamo/models/content.ts
@@ -194,6 +194,20 @@ const content = {
       lastKey: result.LastEvaluatedKey,
     };
   },
+  getPodcastEpisodes: async (id: string, status: string): Promise<Episode[]> => {
+    const episodes: Episode[] = [];
+    let lastKey = undefined;
+
+    do {
+      const result = await content.getByTypeAndStatus(ContentType.EPISODE, status, lastKey);
+      lastKey = result.lastKey;
+
+      const filteredEpisodes = ((result.items as Episode[]) || []).filter((item) => item.podcast === id);
+      episodes.push(...filteredEpisodes);
+    } while (lastKey);
+
+    return episodes;
+  },
   getByTypeAndOwner: async (
     type: ContentType,
     owner: string,

--- a/src/routes/content_routes.js
+++ b/src/routes/content_routes.js
@@ -116,6 +116,7 @@ router.post('/getmorevideos', async (req, res) => {
 });
 
 router.get('/podcasts', async (req, res) => {
+  //Get episodes across all podcasts
   const content = await Content.getByTypeAndStatus(ContentType.EPISODE, ContentStatus.PUBLISHED);
   const podcasts = await Content.getByTypeAndStatus(ContentType.PODCAST, ContentStatus.PUBLISHED);
 
@@ -128,6 +129,7 @@ router.get('/podcasts', async (req, res) => {
 
 router.post('/getmorepodcasts', async (req, res) => {
   const { lastKey } = req.body;
+  //Get episodes across all podcasts
   const content = await Content.getByTypeAndStatus(ContentType.EPISODE, ContentStatus.PUBLISHED, lastKey);
 
   return res.status(200).send({
@@ -193,13 +195,8 @@ router.get('/podcast/:id', async (req, res) => {
     req.flash('danger', 'Podcast not found');
     return redirect(req, res, '/content/browse');
   }
-  let result = await Content.getByTypeAndStatus(ContentType.EPISODE, ContentStatus.PUBLISHED);
-  let episodes = result.items.filter((item) => item.podcast === podcast.id);
 
-  while (result.lastKey) {
-    result = await Content.getByTypeAndStatus(ContentType.EPISODE, ContentStatus.PUBLISHED, result.lastKey);
-    episodes = [...episodes, ...result.items.filter((item) => item.podcast === podcast.id)];
-  }
+  const episodes = await Content.getPodcastEpisodes(podcast.id, ContentStatus.PUBLISHED);
 
   const baseUrl = util.getBaseUrl();
   return render(

--- a/src/util/podcast.js
+++ b/src/util/podcast.js
@@ -17,14 +17,8 @@ const updatePodcast = async (podcast) => {
   const feedEpisodes = await getFeedEpisodes(podcast.url);
 
   let items = [];
-  const existingEpisodes = [];
-  let lastKey = null;
 
-  do {
-    const result = await Content.getByTypeAndStatus(ContentType.EPISODE, ContentStatus.PUBLISHED, lastKey);
-    lastKey = result.lastKey;
-    existingEpisodes.push(...result.items);
-  } while (lastKey);
+  const existingEpisodes = await Content.getPodcastEpisodes(podcast.id, ContentStatus.PUBLISHED);
 
   const existingGuids = existingEpisodes.map((episode) => episode.podcastGuid);
 

--- a/src/util/podcast.js
+++ b/src/util/podcast.js
@@ -11,28 +11,27 @@ const removeSpan = (text) =>
     allowedTags: sanitizeHtml.defaults.allowedTags.filter((tag) => tag !== 'span'),
   });
 
-const updatePodcast = async (podcast) => {
+export const updatePodcast = async (podcast) => {
   const feedData = await getFeedData(podcast.url);
-
   const feedEpisodes = await getFeedEpisodes(podcast.url);
-
-  let items = [];
-
   const existingEpisodes = await Content.getPodcastEpisodes(podcast.id, ContentStatus.PUBLISHED);
-
   const existingGuids = existingEpisodes.map((episode) => episode.podcastGuid);
 
-  // if image is different
+  // Find episodes that need image updates
+  const episodesToUpdate = existingEpisodes.filter((episode) => episode.image !== feedData.image);
+
+  if (episodesToUpdate.length > 0) {
+    await Content.batchPut(
+      episodesToUpdate.map((episode) => ({
+        ...episode,
+        image: feedData.image,
+      })),
+    );
+  }
+
+  // Update podcast image if different
   if (podcast.image !== feedData.image) {
-    // we need to fix this and all episodes
     podcast.image = feedData.image;
-
-    items = existingEpisodes.map((episode) => ({
-      ...episode,
-      image: feedData.image,
-    }));
-
-    await Content.batchPut(items);
     await Content.update(podcast);
   }
 

--- a/tests/content/podcast.test.ts
+++ b/tests/content/podcast.test.ts
@@ -1,0 +1,234 @@
+import { ContentStatus, ContentType } from '../../src/datatypes/Content';
+import Content from '../../src/dynamo/models/content';
+import { updatePodcast } from '../../src/util/podcast';
+import { getFeedData, getFeedEpisodes } from '../../src/util/rss';
+import { createEpisode, createPodcast, createUser } from '../test-utils/data';
+
+const mockSanitize = jest.fn((text) => text);
+
+jest.mock('html-to-text', () => ({
+  convert: jest.fn((text) => text),
+}));
+
+jest.mock('sanitize-html', () => {
+  const module = jest.fn((text) => mockSanitize(text));
+  //@ts-expect-error -- hh
+  module.defaults = {
+    allowedTags: ['span', 'div', 'p'],
+  };
+  return module;
+});
+
+jest.mock('../../src/util/rss');
+jest.mock('../../src/dynamo/models/content');
+
+describe('Podcast Utils', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    // Reset sanitize mock to default behavior
+    mockSanitize.mockImplementation((text) => text);
+  });
+
+  describe('updatePodcast', () => {
+    it('should update podcast and episode images when feed image changes', async () => {
+      const mockPodcast = createPodcast({
+        image: 'old-image.jpg',
+        id: 'podcast-1',
+        owner: createUser({ id: 'user-1' }),
+      });
+
+      const mockEpisodes = [
+        createEpisode({ podcast: 'podcast-1', image: 'old-image.jpg' }),
+        createEpisode({ podcast: 'podcast-1', image: 'old-image.jpg' }),
+      ];
+
+      (getFeedData as jest.Mock).mockResolvedValue({
+        image: 'new-image.jpg',
+      });
+      (getFeedEpisodes as jest.Mock).mockResolvedValue([]);
+      (Content.getPodcastEpisodes as jest.Mock).mockResolvedValue(mockEpisodes);
+
+      await updatePodcast(mockPodcast);
+
+      expect(Content.batchPut).toHaveBeenCalledWith(
+        mockEpisodes.map((episode) => ({
+          ...episode,
+          image: 'new-image.jpg',
+        })),
+      );
+      expect(Content.update).toHaveBeenCalledWith({
+        ...mockPodcast,
+        image: 'new-image.jpg',
+        date: expect.any(Number),
+      });
+    });
+
+    it('should add new episodes from feed that do not exist', async () => {
+      // Setup sanitize mock to strip HTML
+      mockSanitize.mockImplementation((text) => text.replace(/<[^>]*>/g, ''));
+
+      const mockPodcast = createPodcast({
+        id: 'podcast-1',
+        owner: createUser({ id: 'user-1' }),
+        image: 'image.jpg',
+        title: 'Test Podcast',
+      });
+
+      const mockFeedEpisodes = [
+        {
+          title: 'New Episode 1',
+          description: '<span>Description 1</span>',
+          date: '2025-08-22',
+          guid: 'guid-1',
+          link: 'http://example.com/1',
+          source: 'http://example.com/1.mp3',
+        },
+        {
+          title: 'New Episode 2',
+          description: '<div>Description 2</div>',
+          date: '2025-08-21',
+          guid: 'guid-2',
+          link: 'http://example.com/2',
+          source: 'http://example.com/2.mp3',
+        },
+      ];
+
+      (getFeedData as jest.Mock).mockResolvedValue({
+        image: 'image.jpg',
+      });
+      (getFeedEpisodes as jest.Mock).mockResolvedValue(mockFeedEpisodes);
+      (Content.getPodcastEpisodes as jest.Mock).mockResolvedValue([]);
+
+      await updatePodcast(mockPodcast);
+
+      expect(Content.put).toHaveBeenCalledTimes(2);
+      expect(Content.put).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'New Episode 1',
+          body: 'Description 1',
+          podcastGuid: 'guid-1',
+          status: ContentStatus.PUBLISHED,
+        }),
+        ContentType.EPISODE,
+      );
+
+      // Verify second episode was also sanitized
+      expect(Content.put).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'New Episode 2',
+          body: 'Description 2',
+          podcastGuid: 'guid-2',
+          status: ContentStatus.PUBLISHED,
+        }),
+        ContentType.EPISODE,
+      );
+    });
+
+    it('should not add episodes that already exist', async () => {
+      const mockPodcast = createPodcast({
+        id: 'podcast-1',
+        owner: createUser({ id: 'user-1' }),
+      });
+
+      const existingEpisode = createEpisode({
+        podcast: 'podcast-1',
+        podcastGuid: 'existing-guid',
+      });
+
+      const mockFeedEpisodes = [
+        {
+          title: 'Existing Episode',
+          description: 'Description',
+          date: '2025-08-22',
+          guid: 'existing-guid',
+          link: 'http://example.com/1',
+          source: 'http://example.com/1.mp3',
+        },
+      ];
+
+      (getFeedData as jest.Mock).mockResolvedValue({
+        image: mockPodcast.image,
+      });
+      (getFeedEpisodes as jest.Mock).mockResolvedValue(mockFeedEpisodes);
+      (Content.getPodcastEpisodes as jest.Mock).mockResolvedValue([existingEpisode]);
+
+      await updatePodcast(mockPodcast);
+
+      expect(Content.put).not.toHaveBeenCalled();
+      expect(Content.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          date: expect.any(Number),
+        }),
+      );
+    });
+
+    it('should update episode images when feed image changes, even if podcast image matches', async () => {
+      const mockPodcast = createPodcast({
+        image: 'new-image.jpg', // Podcast already has new image
+        id: 'podcast-1',
+        owner: createUser({ id: 'user-1' }),
+      });
+
+      const mockEpisodes = [
+        createEpisode({ podcast: 'podcast-1', image: 'old-image.jpg' }),
+        createEpisode({ podcast: 'podcast-1', image: 'old-image.jpg' }),
+      ];
+
+      (getFeedData as jest.Mock).mockResolvedValue({
+        image: 'new-image.jpg',
+      });
+      (getFeedEpisodes as jest.Mock).mockResolvedValue([]);
+      (Content.getPodcastEpisodes as jest.Mock).mockResolvedValue(mockEpisodes);
+
+      await updatePodcast(mockPodcast);
+
+      // Should update episodes even though podcast image matches
+      expect(Content.batchPut).toHaveBeenCalledWith(
+        mockEpisodes.map((episode) => ({
+          ...episode,
+          image: 'new-image.jpg',
+        })),
+      );
+
+      // Should not update podcast since image already matches
+      expect(Content.update).toHaveBeenCalledWith({
+        ...mockPodcast,
+        date: expect.any(Number),
+      });
+    });
+
+    it('should update both podcast and episode images when they differ from feed', async () => {
+      const mockPodcast = createPodcast({
+        image: 'old-image.jpg',
+        id: 'podcast-1',
+        owner: createUser({ id: 'user-1' }),
+      });
+
+      const mockEpisodes = [
+        createEpisode({ podcast: 'podcast-1', image: 'different-image.jpg' }),
+        createEpisode({ podcast: 'podcast-1', image: 'another-image.jpg' }),
+      ];
+
+      (getFeedData as jest.Mock).mockResolvedValue({
+        image: 'new-image.jpg',
+      });
+      (getFeedEpisodes as jest.Mock).mockResolvedValue([]);
+      (Content.getPodcastEpisodes as jest.Mock).mockResolvedValue(mockEpisodes);
+
+      await updatePodcast(mockPodcast);
+
+      expect(Content.batchPut).toHaveBeenCalledWith(
+        mockEpisodes.map((episode) => ({
+          ...episode,
+          image: 'new-image.jpg',
+        })),
+      );
+
+      expect(Content.update).toHaveBeenCalledWith({
+        ...mockPodcast,
+        image: 'new-image.jpg',
+        date: expect.any(Number),
+      });
+    });
+  });
+});


### PR DESCRIPTION
Related to Discord posts:
* https://discord.com/channels/592787488523943937/1407535494945964073
* https://discord.com/channels/592787488523943937/1364210510962233374/1364362550753493053

It wasn't until I looked at the code today did I notice that the fetching of episodes in the update job doesn't filter to the podcast in the parameter =(

# Testing

Setup
1. Added two podcasts to my local from CubeCobra
2. Ran the update job in my browser via console
3. Episodes created and some episodes of the first were set with the image of the second, because the podcast default image is a scryfall URL
5. Ran update job again with debugger to validate that existingEpisodes includes episodes from both content

# After
Setup:
Manually updated the image of the podcasts via awslocal, so they are different from the feed

Test:
1. Trigger the update job with debugging
2. Validate existingEpisodes only contains episodes for the podcast in the parameter
3. Reload podcast episodes lists and all images matched the podcast
