### PR TITLE
Fix leave page yes button not working.

### DIFF
--- a/src/client/pages/LeaveWarningPage.tsx
+++ b/src/client/pages/LeaveWarningPage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import Button from 'components/base/Button';
 import { Card, CardBody, CardFooter, CardHeader } from 'components/base/Card';
+import { Flexbox } from 'components/base/Layout';
 import Text from 'components/base/Text';
 import DynamicFlash from 'components/DynamicFlash';
 import RenderToRoot from 'components/RenderToRoot';
@@ -30,12 +31,14 @@ const LeaveWarningPage: React.FC<LeaveWarningPageProps> = ({ url, loginCallback 
         <p>Are you sure you want to proceed?</p>
       </CardBody>
       <CardFooter>
-        <Button href={url} color="danger">
-          Yes, continue
-        </Button>
-        <Button color="secondary" onClick={back}>
-          Go back
-        </Button>
+        <Flexbox direction="row" gap="2" className="m-2">
+          <Button href={url} color="danger" type="link">
+            Yes, continue
+          </Button>
+          <Button color="secondary" onClick={back}>
+            Go back
+          </Button>
+        </Flexbox>
       </CardFooter>
     </Card>
   </MainLayout>


### PR DESCRIPTION
Make it a proper link button and adjust styling so the buttons are beside each other.

In markdown clicking an external link will open the modal version of "you are leaving cube cobra". To get to this leave page you have to right click -> open that external link.

# Testing

# After 

![new-leave-page-working](https://github.com/user-attachments/assets/4fe006c7-0bc3-46f9-8c87-6ce2e636d1d2)

