### PR TITLE
Fix error with Cube short id case sensitivity when updating

### DIFF
--- a/src/dynamo/models/cube.js
+++ b/src/dynamo/models/cube.js
@@ -245,7 +245,7 @@ const exportData = {
       return hydrate(byId.Item);
     }
 
-    const byShortId = await cubeHash.getSortedByName(`shortid:${id}`);
+    const byShortId = await cubeHash.getSortedByName(cubeHash.getShortIdHash(id));
     if (byShortId.items.length > 0) {
       const cubeId = byShortId.items[0].cube;
       const query = await client.get(cubeId);

--- a/src/dynamo/models/cubeHash.js
+++ b/src/dynamo/models/cubeHash.js
@@ -41,11 +41,16 @@ const client = createClient({
   FIELDS,
 });
 
+const getShortIdHash = (shortId) => {
+  //Case sensitive!
+  return `shortid:${shortId}`;
+};
+
 const hashShortId = (metadata) => {
   if (!metadata.shortId || metadata.shortId.length === 0) {
     return [];
   }
-  return [`shortid:${metadata.shortId}`];
+  return [getShortIdHash(metadata.shortId)];
 };
 
 const hashFeatured = (metadata) => {
@@ -247,5 +252,6 @@ module.exports = {
       [FIELDS.CUBE_ID]: metadata.id,
     }));
   },
+  getShortIdHash,
   FIELDS,
 };

--- a/src/dynamo/models/cubeHash.js
+++ b/src/dynamo/models/cubeHash.js
@@ -129,7 +129,7 @@ const getHashesForCube = (metadata, cards) => {
   return [...new Set([...getHashesForCards(cards), ...getHashesForMetadata(metadata)])];
 };
 
-const getSortedByFollowers = async (hash, ascending, lastKey, limit=36) => {
+const getSortedByFollowers = async (hash, ascending, lastKey, limit = 36) => {
   const result = await client.query({
     IndexName: 'SortedByFollowers',
     KeyConditionExpression: `#p1 = :hash`,
@@ -149,7 +149,7 @@ const getSortedByFollowers = async (hash, ascending, lastKey, limit=36) => {
   };
 };
 
-const getSortedByName = async (hash, ascending, lastKey, limit=36) => {
+const getSortedByName = async (hash, ascending, lastKey, limit = 36) => {
   const result = await client.query({
     IndexName: 'SortedByName',
     KeyConditionExpression: `#p1 = :hash`,
@@ -169,7 +169,7 @@ const getSortedByName = async (hash, ascending, lastKey, limit=36) => {
   };
 };
 
-const getSortedByCardCount = async (hash, ascending, lastKey, limit=36) => {
+const getSortedByCardCount = async (hash, ascending, lastKey, limit = 36) => {
   const result = await client.query({
     IndexName: 'SortedByCardCount',
     KeyConditionExpression: `#p1 = :hash`,
@@ -190,7 +190,7 @@ const getSortedByCardCount = async (hash, ascending, lastKey, limit=36) => {
 };
 
 module.exports = {
-  query: async (hash, ascending, lastKey, order, limit=36) => {
+  query: async (hash, ascending, lastKey, order, limit = 36) => {
     switch (order) {
       case 'pop':
         return getSortedByFollowers(hash, ascending, lastKey, limit);
@@ -207,7 +207,6 @@ module.exports = {
     let lastKey = null;
 
     do {
-       
       const result = await client.query({
         KeyConditionExpression: `#p1 = :cubeId`,
         ExpressionAttributeValues: {

--- a/src/router/routes/cube/api/editoverview.ts
+++ b/src/router/routes/cube/api/editoverview.ts
@@ -49,7 +49,7 @@ export const editOverviewHandler = async (req: Request, res: Response) => {
         return;
       }
 
-      const taken = await CubeHash.getSortedByName(`shortid:${updatedCube.shortId.toLowerCase()}`);
+      const taken = await CubeHash.getSortedByName(CubeHash.getShortIdHash(updatedCube.shortId));
 
       if (taken.items.length === 1 && taken.items[0].cube !== cube.id) {
         res.status(400).json({ error: 'Could not update cube, the short id is already taken.' });

--- a/tests/cube/api/editoverview.api.test.ts
+++ b/tests/cube/api/editoverview.api.test.ts
@@ -126,7 +126,7 @@ describe('Edit overview API', () => {
     const otherCubeHash = {
       name: 'OtherCube',
       cube: 'abcdefgh',
-      hash: 'shortid:foobar',
+      hash: 'shortid:Foobar',
       numFollowers: 0,
       cardCount: 540,
     };
@@ -138,12 +138,13 @@ describe('Edit overview API', () => {
       items: [otherCubeHash],
       lastKey: null,
     });
+    (CubeHash.getShortIdHash as jest.Mock).mockReturnValue('shortid:Foobar');
 
     const res = await call(editOverviewHandler).as(currentUser).withBody({ cube: newCube }).send();
 
     expect(Util.hasProfanity).toHaveBeenNthCalledWith(1, newCube.name);
     expect(Util.hasProfanity).toHaveBeenNthCalledWith(2, newCube.shortId);
-    expect(CubeHash.getSortedByName).toHaveBeenCalledWith(`shortid:foobar`);
+    expect(CubeHash.getSortedByName).toHaveBeenCalledWith(`shortid:Foobar`);
     expect(res.status).toEqual(400);
     expect(res.body).toEqual({
       error: expect.stringContaining('the short id is already taken'),
@@ -159,14 +160,14 @@ describe('Edit overview API', () => {
     const otherCubeHash = {
       name: 'OtherCube',
       cube: 'abcdefgh',
-      hash: 'shortid:foobar',
+      hash: 'shortid:Foobar',
       numFollowers: 0,
       cardCount: 540,
     };
     const otherCubeHashTwo = {
       name: 'OtherCube2',
       cube: 'aaa-bbb-ccc',
-      hash: 'shortid:foobar',
+      hash: 'shortid:Foobar',
       numFollowers: 5,
       cardCount: 340,
     };
@@ -178,12 +179,13 @@ describe('Edit overview API', () => {
       items: [otherCubeHash, otherCubeHashTwo],
       lastKey: null,
     });
+    (CubeHash.getShortIdHash as jest.Mock).mockReturnValue('shortid:Foobar');
 
     const res = await call(editOverviewHandler).as(currentUser).withBody({ cube: newCube }).send();
 
     expect(Util.hasProfanity).toHaveBeenNthCalledWith(1, newCube.name);
     expect(Util.hasProfanity).toHaveBeenNthCalledWith(2, newCube.shortId);
-    expect(CubeHash.getSortedByName).toHaveBeenCalledWith(`shortid:foobar`);
+    expect(CubeHash.getSortedByName).toHaveBeenCalledWith(`shortid:Foobar`);
     expect(res.status).toEqual(400);
     expect(res.body).toEqual({
       error: expect.stringContaining('the short id is already taken'),
@@ -211,6 +213,7 @@ describe('Edit overview API', () => {
     (CubeFn.isCubeViewable as jest.Mock).mockReturnValue(true);
     (Util.hasProfanity as jest.Mock).mockReturnValue(false);
     (CubeHash.getSortedByName as jest.Mock).mockResolvedValue({ items: [], lastKey: null });
+    (CubeHash.getShortIdHash as jest.Mock).mockReturnValue('shortid:bar');
     (CubeFn.getCubeId as jest.Mock).mockReturnValue(updatedCube.shortId);
 
     const res = await call(editOverviewHandler).as(currentUser).withBody({ cube: updatedCube }).send();
@@ -252,7 +255,6 @@ describe('Edit overview API', () => {
     (Cube.getById as jest.Mock).mockResolvedValue(existingCube);
     (CubeFn.isCubeViewable as jest.Mock).mockReturnValue(true);
     (Util.hasProfanity as jest.Mock).mockReturnValue(false);
-    (CubeHash.getSortedByName as jest.Mock).mockResolvedValue({ items: [], lastKey: null });
     (CubeFn.getCubeId as jest.Mock).mockReturnValue(updatedCube.id);
 
     const res = await call(editOverviewHandler).as(currentUser).withBody({ cube: updatedCube }).send();
@@ -326,6 +328,7 @@ describe('Edit overview API', () => {
     (CubeFn.isCubeViewable as jest.Mock).mockReturnValue(true);
     (Util.hasProfanity as jest.Mock).mockReturnValue(false);
     (CubeHash.getSortedByName as jest.Mock).mockResolvedValue({ items: [], lastKey: null });
+    (CubeHash.getShortIdHash as jest.Mock).mockReturnValue('shortid:bar');
     (CubeFn.getCubeId as jest.Mock).mockReturnValue(updatedCube.shortId);
 
     const res = await call(editOverviewHandler).as(currentUser).withBody({ cube: updatedCube }).send();
@@ -386,6 +389,7 @@ describe('Edit overview API', () => {
       items: [],
       lastKey: null,
     });
+    (CubeHash.getShortIdHash as jest.Mock).mockReturnValue('shortid:newid');
     (CubeFn.getCubeId as jest.Mock).mockReturnValue(updatedCube.shortId);
 
     const res = await call(editOverviewHandler).as(currentUser).withBody({ cube: updatedCube }).send();
@@ -430,6 +434,7 @@ describe('Edit overview API', () => {
       items: [],
       lastKey: null,
     });
+    (CubeHash.getShortIdHash as jest.Mock).mockReturnValue('shortid:');
     (CubeFn.getCubeId as jest.Mock).mockReturnValue(updatedCube.id);
 
     const res = await call(editOverviewHandler).as(currentUser).withBody({ cube: updatedCube }).send();


### PR DESCRIPTION
# Testing

## Before

You can update a cube to the same short ID as another one (Sagas), though that short ID will link to the older cube
![old-can-reuse-a-short-id-but-links-to-old-cube](https://github.com/user-attachments/assets/299cc2ff-c4e8-44df-9b25-8d8cac1f3e60)

You can use the same name with different casing, and then both cubes can be linked via the short id
![old-case-sensitive-names-work](https://github.com/user-attachments/assets/f89675a1-eb4c-4454-9aca-a2c7c663efa0)

## After

Now you cannot use the same short ID as another cube because the check is done with same case sensitivity
![new-cant-update-used-short-id](https://github.com/user-attachments/assets/ea1a31c1-a5da-4a70-ad7b-5967ee2a023a)

Same as before, two cubes can use similar short ids as long as different cases
![new-can-update-case-sensitive](https://github.com/user-attachments/assets/07329fe2-75ac-4796-a27a-d6e7fd064420)