### PR TITLE
Export decks from draft records

### DIFF
--- a/src/client/components/DeckCard.tsx
+++ b/src/client/components/DeckCard.tsx
@@ -104,12 +104,14 @@ const DeckCard: React.FC<DeckCardProps> = ({ seat, draft, view = 'draft', seatIn
       .flat(4);
   }, [draft.cards, seat.mainboard]);
 
+  const mbCount = sorted.length;
+
   return (
     <Card>
       <CardHeader>
         <Flexbox direction="col" alignItems="start" gap="1">
           <Text semibold lg>
-            {seat.name}
+            {seat.name} ({mbCount})
           </Text>
           {!seat.bot && (
             <Text md semibold>
@@ -140,7 +142,7 @@ const DeckCard: React.FC<DeckCardProps> = ({ seat, draft, view = 'draft', seatIn
             <>
               <CardBody className="border-bottom">
                 <Text semibold lg>
-                  Sideboard
+                  Sideboard ({sbCount})
                 </Text>
               </CardBody>
               <DeckStacksStatic piles={stackedSideboard} cards={draft.cards} />
@@ -151,14 +153,14 @@ const DeckCard: React.FC<DeckCardProps> = ({ seat, draft, view = 'draft', seatIn
       {view === 'visual' && (
         <CardBody>
           <Text semibold lg>
-            Mainboard
+            Mainboard ({mbCount})
           </Text>
           <CardGrid cards={sorted} xs={8} />
           {seat.sideboard.flat(2).length > 0 && (
             <>
               <hr className="my-4" />
               <Text semibold lg>
-                Sideboard
+                Sideboard ({sbCount})
               </Text>
               <CardGrid cards={seat.sideboard.flat(2).map((cardIndex) => draft.cards[cardIndex])} xs={8} />
             </>

--- a/src/client/components/draft/DraftExportMenu.tsx
+++ b/src/client/components/draft/DraftExportMenu.tsx
@@ -1,0 +1,74 @@
+import React, { useCallback } from 'react';
+
+import { Flexbox } from 'components/base/Layout';
+import Link from 'components/base/Link';
+import NavMenu from 'components/base/NavMenu';
+import Draft from 'datatypes/Draft';
+import useAlerts, { Alerts } from 'hooks/UseAlerts';
+
+interface DraftExportMenuProps {
+  draft: Draft;
+  seatIndex: string;
+}
+
+const DraftExportMenu: React.FC<DraftExportMenuProps> = ({ draft, seatIndex }) => {
+  const { alerts, addAlert, dismissAlerts } = useAlerts();
+
+  const copyToClipboard = useCallback(async () => {
+    const cards = draft.cards;
+    const mainboard = draft.seats[parseInt(seatIndex || '0')].mainboard;
+
+    //Equivalent logic to the backend
+    const cardNames = [];
+    for (const row of mainboard) {
+      for (const col of row) {
+        for (const cardIndex of col) {
+          const cardName = cards[cardIndex].details?.name;
+          if (cardName) {
+            cardNames.push(cardName);
+          }
+        }
+      }
+    }
+
+    await navigator.clipboard.writeText(cardNames.join('\n'));
+    addAlert('success', 'Copied.');
+    //Auto dismiss after a few seconds
+    setTimeout(dismissAlerts, 3000);
+  }, [addAlert, dismissAlerts, draft, seatIndex]);
+
+  return (
+    <NavMenu label="Export">
+      <Flexbox direction="col" gap="2" className="p-3">
+        <Link href={`/cube/deck/download/txt/${draft.id}/${seatIndex}`} className="dropdown-item">
+          Card Names (.txt)
+        </Link>
+        <Link href={`#`} onClick={copyToClipboard} className="dropdown-item">
+          Card Names to Clipboard (.txt)
+        </Link>
+        <Link href={`/cube/deck/download/forge/${draft.id}/${seatIndex}`} className="dropdown-item">
+          Forge (.dck)
+        </Link>
+        <Link href={`/cube/deck/download/xmage/${draft.id}/${seatIndex}`} className="dropdown-item">
+          XMage (.dck)
+        </Link>
+        <Link href={`/cube/deck/download/mtgo/${draft.id}/${seatIndex}`} className="dropdown-item">
+          MTGO (.txt)
+        </Link>
+        <Link href={`/cube/deck/download/arena/${draft.id}/${seatIndex}`} className="dropdown-item">
+          Arena (.txt)
+        </Link>
+        <Link href={`/cube/deck/download/cockatrice/${draft.id}/${seatIndex}`} className="dropdown-item">
+          Cockatrice (.txt)
+        </Link>
+        <Link href={`/cube/deck/download/topdecked/${draft.id}/${seatIndex}`} className="dropdown-item">
+          TopDecked (.csv)
+        </Link>
+        <Alerts alerts={alerts} />
+      </Flexbox>
+    </NavMenu>
+  );
+};
+
+DraftExportMenu.displayName = 'DraftExportMenu';
+export default DraftExportMenu;

--- a/src/client/pages/CubeDeckPage.tsx
+++ b/src/client/pages/CubeDeckPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext } from 'react';
+import React, { useContext } from 'react';
 
 import { ChevronUpIcon, ThreeBarsIcon } from '@primer/octicons-react';
 
@@ -7,11 +7,11 @@ import Collapse from 'components/base/Collapse';
 import Controls from 'components/base/Controls';
 import { Col, Flexbox, Row } from 'components/base/Layout';
 import Link from 'components/base/Link';
-import NavMenu from 'components/base/NavMenu';
 import ResponsiveDiv from 'components/base/ResponsiveDiv';
 import Select from 'components/base/Select';
 import CustomImageToggler from 'components/CustomImageToggler';
 import DeckCard from 'components/DeckCard';
+import DraftExportMenu from 'components/draft/DraftExportMenu';
 import DynamicFlash from 'components/DynamicFlash';
 import SampleHandModal from 'components/modals/SampleHandModal';
 import RenderToRoot from 'components/RenderToRoot';
@@ -21,7 +21,6 @@ import UserContext from 'contexts/UserContext';
 import Cube from 'datatypes/Cube';
 import Draft from 'datatypes/Draft';
 import User from 'datatypes/User';
-import useAlerts, { Alerts } from 'hooks/UseAlerts';
 import useQueryParam from 'hooks/useQueryParam';
 import useToggle from 'hooks/UseToggle';
 import CubeLayout from 'layouts/CubeLayout';
@@ -40,30 +39,6 @@ const CubeDeckPage: React.FC<CubeDeckPageProps> = ({ cube, draft, loginCallback 
   const [seatIndex, setSeatIndex] = useQueryParam('seat', '0');
   const [view, setView] = useQueryParam('view', 'draft');
   const [expanded, toggleExpanded] = useToggle(false);
-  const { alerts, addAlert, dismissAlerts } = useAlerts();
-
-  const copyToClipboard = useCallback(async () => {
-    const cards = draft.cards;
-    const mainboard = draft.seats[parseInt(seatIndex || '0')].mainboard;
-
-    //Equivalent logic to the backend
-    const cardNames = [];
-    for (const row of mainboard) {
-      for (const col of row) {
-        for (const cardIndex of col) {
-          const cardName = cards[cardIndex].details?.name;
-          if (cardName) {
-            cardNames.push(cardName);
-          }
-        }
-      }
-    }
-
-    await navigator.clipboard.writeText(cardNames.join('\n'));
-    addAlert('success', 'Copied.');
-    //Auto dismiss after a few seconds
-    setTimeout(dismissAlerts, 3000);
-  }, [addAlert, dismissAlerts, draft, seatIndex]);
 
   const controls = (
     <>
@@ -79,35 +54,7 @@ const CubeDeckPage: React.FC<CubeDeckPageProps> = ({ cube, draft, loginCallback 
       </SampleHandModalLink>
       <Link href={`/cube/deck/rebuild/${draft.id}/${seatIndex}`}>Clone and Rebuild</Link>
       <CustomImageToggler />
-      <NavMenu label="Export">
-        <Flexbox direction="col" gap="2" className="p-3">
-          <Link href={`/cube/deck/download/txt/${draft.id}/${seatIndex}`} className="dropdown-item">
-            Card Names (.txt)
-          </Link>
-          <Link href={`#`} onClick={copyToClipboard} className="dropdown-item">
-            Card Names to Clipboard (.txt)
-          </Link>
-          <Link href={`/cube/deck/download/forge/${draft.id}/${seatIndex}`} className="dropdown-item">
-            Forge (.dck)
-          </Link>
-          <Link href={`/cube/deck/download/xmage/${draft.id}/${seatIndex}`} className="dropdown-item">
-            XMage (.dck)
-          </Link>
-          <Link href={`/cube/deck/download/mtgo/${draft.id}/${seatIndex}`} className="dropdown-item">
-            MTGO (.txt)
-          </Link>
-          <Link href={`/cube/deck/download/arena/${draft.id}/${seatIndex}`} className="dropdown-item">
-            Arena (.txt)
-          </Link>
-          <Link href={`/cube/deck/download/cockatrice/${draft.id}/${seatIndex}`} className="dropdown-item">
-            Cockatrice (.txt)
-          </Link>
-          <Link href={`/cube/deck/download/topdecked/${draft.id}/${seatIndex}`} className="dropdown-item">
-            TopDecked (.csv)
-          </Link>
-          <Alerts alerts={alerts} />
-        </Flexbox>
-      </NavMenu>
+      <DraftExportMenu draft={draft} seatIndex={seatIndex} />
     </>
   );
 

--- a/src/client/records/RecordDecks.tsx
+++ b/src/client/records/RecordDecks.tsx
@@ -1,15 +1,22 @@
 import React, { useContext } from 'react';
 
+import { ChevronUpIcon, ThreeBarsIcon } from '@primer/octicons-react';
+
+import Button from 'components/base/Button';
 import { CardBody } from 'components/base/Card';
+import Collapse from 'components/base/Collapse';
 import { Flexbox } from 'components/base/Layout';
 import Link from 'components/base/Link';
+import ResponsiveDiv from 'components/base/ResponsiveDiv';
 import Select from 'components/base/Select';
 import Text from 'components/base/Text';
 import DeckCard from 'components/DeckCard';
+import DraftExportMenu from 'components/draft/DraftExportMenu';
 import CubeContext from 'contexts/CubeContext';
 import UserContext from 'contexts/UserContext';
 import Draft from 'datatypes/Draft';
 import Record from 'datatypes/Record';
+import useToggle from 'hooks/UseToggle';
 
 interface RecordDecksProps {
   record: Record;
@@ -32,6 +39,7 @@ const RecordDecks: React.FC<RecordDecksProps> = ({ record, draft }) => {
   const { cube } = useContext(CubeContext);
   const user = useContext(UserContext);
   const [selectedUserIndex, setSelectedUserIndex] = React.useState<number>(firstPlayerIndexWithDeck(record, draft));
+  const [expanded, toggleExpanded] = useToggle(false);
 
   const isOwner = user && cube && user.id === cube.owner.id;
 
@@ -56,24 +64,52 @@ const RecordDecks: React.FC<RecordDecksProps> = ({ record, draft }) => {
     );
   }
 
+  const controls = (
+    <>
+      <DraftExportMenu draft={draft} seatIndex={`${selectedUserIndex}`} />
+    </>
+  );
+
   return (
     <CardBody>
       <Flexbox direction="col" gap="2">
-        {isOwner && <Link href={`/cube/records/uploaddeck/${record.id}`}>Upload another deck to this record</Link>}
-        <Select
-          value={`${selectedUserIndex}`}
-          setValue={(value) => {
-            const index = parseInt(value, 10);
-            setSelectedUserIndex(index);
-          }}
-          label="View deck for player"
-          options={record.players
-            .map((player, index) => ({
-              value: `${index}`,
-              label: player.name,
-            }))
-            .filter((option) => draft.seats[parseInt(option.value, 10)]?.mainboard?.flat(3).length > 0)}
-        />
+        <Flexbox direction="row" justify="between" alignItems="center" className="py-2 px-4">
+          <Flexbox direction="row" justify="start" gap="4" alignItems="center">
+            {isOwner && <Link href={`/cube/records/uploaddeck/${record.id}`}>Upload another deck to this record</Link>}
+            <Select
+              value={`${selectedUserIndex}`}
+              setValue={(value) => {
+                const index = parseInt(value, 10);
+                setSelectedUserIndex(index);
+              }}
+              dense={true}
+              label="View deck for player"
+              options={record.players
+                .map((player, index) => ({
+                  value: `${index}`,
+                  label: player.name,
+                }))
+                .filter((option) => draft.seats[parseInt(option.value, 10)]?.mainboard?.flat(3).length > 0)}
+            />
+          </Flexbox>
+          <ResponsiveDiv baseVisible lg>
+            <Button color="secondary" onClick={toggleExpanded}>
+              {expanded ? <ChevronUpIcon size={32} /> : <ThreeBarsIcon size={32} />}
+            </Button>
+          </ResponsiveDiv>
+          <ResponsiveDiv lg>
+            <Flexbox direction="row" justify="start" gap="4" alignItems="center">
+              {controls}
+            </Flexbox>
+          </ResponsiveDiv>
+        </Flexbox>
+        <ResponsiveDiv baseVisible lg>
+          <Collapse isOpen={expanded}>
+            <Flexbox direction="col" gap="2" className="py-2 px-4">
+              {controls}
+            </Flexbox>
+          </Collapse>
+        </ResponsiveDiv>
         <DeckCard
           seat={draft.seats[selectedUserIndex]}
           draft={draft}


### PR DESCRIPTION
Record's contain drafts and so we can reuse the same export UI from the record page as we do on the playtest draft page.

# Changes
1. Refactor export UI into component
2. Add exporting to record's draft page
3. Add mainboard and sideboard counts in brackets

# Testing

## After

Empty drafts looks the same
<img width="468" height="313" alt="new-empty-draft-record" src="https://github.com/user-attachments/assets/4e0c73a7-72d0-47df-85af-88c0172431f6" />

Exporting in desktop view. I'm not stoked about the free floating ness of it, but I couldn't get the similar controls UI to look good either
<img width="1830" height="336" alt="draft-record-export" src="https://github.com/user-attachments/assets/5949487f-6719-4330-985e-c8ab5b57b271" />

Exporting in mobile view
<img width="517" height="505" alt="new-draft-record-export-mobile" src="https://github.com/user-attachments/assets/e2c6b2f4-d865-4539-af46-5c6585dd4605" />

Gif of exporting working
![new-export](https://github.com/user-attachments/assets/bd9ef808-f4dd-46f2-86e7-814b22adba0a)

