### PR TITLE
Fix card versions, such as in markdown, not matching exact scryfall id

### DIFF
--- a/src/routes/tools_routes.js
+++ b/src/routes/tools_routes.js
@@ -158,7 +158,8 @@ router.get('/card/:id', async (req, res) => {
         lastKey: history.lastKey,
         versions: carddb.oracleToId[card.oracle_id]
           .filter((cid) => cid !== card.scryfall_id)
-          .map((cardid) => cardFromId(cardid)),
+          .map((cardid) => cardFromId(cardid))
+          .filter((c) => !c.isExtra), //Card isExtra if its the preflipped backside
         draftedWith: related.draftedWith,
         cubedWith: related.cubedWith,
         synergistic: related.synergistic,

--- a/src/routes/tools_routes.js
+++ b/src/routes/tools_routes.js
@@ -42,7 +42,7 @@ const chooseIdFromInput = (req) => {
     // if id is a cardname, redirect to the default version for that card
     const possibleName = cardutil.decodeName(id);
     const ids = getIdsFromName(possibleName);
-    if (ids) {
+    if (ids !== undefined && ids.length > 0) {
       id = getMostReasonable(possibleName, printingPreference).scryfall_id;
     }
   }

--- a/src/util/imageutil.js
+++ b/src/util/imageutil.js
@@ -16,7 +16,7 @@ export function getImageData(imagename) {
   const name = cardutil.normalizeName(imagename);
   const ids = getIdsFromName(name);
 
-  if (ids) {
+  if (ids !== undefined && ids.length > 0) {
     const byName = cardFromId(ids[0]);
     if (byName.scryfall_id) {
       return {


### PR DESCRIPTION
# Testing

## Before

Old border card shown even though the scryfall id is a newer version
<img width="3840" height="1080" alt="image" src="https://github.com/user-attachments/assets/3c7da165-d538-4c2c-8c1b-e1c4984bd07e" />

Versions list shows backside cards 
<img width="833" height="474" alt="image" src="https://github.com/user-attachments/assets/41c9bcb2-2b81-4058-9b62-94f2f2b54a22" />

# After

Correct versions of front and back sides show
![new-versions-and-backs](https://github.com/user-attachments/assets/d226ea9d-438e-4bef-93ac-7c05c728ba25)

Versions list only shows frontside. Unlike scryfall, CubeCobra doesn't include the current version of the card being looked at in the side list
<img width="662" height="347" alt="image" src="https://github.com/user-attachments/assets/9fc9613b-b0d6-4b2f-922a-f92a0bebb5f6" />

Can see on Scryfall the versions doesn't contain backsides only
<img width="412" height="484" alt="image" src="https://github.com/user-attachments/assets/ae74ea88-c8dc-42eb-86d8-92a850e8ad32" />

