### PR TITLE
Improve blog create/edit so that validation failures can be fixed right away, without loss

### DIFF
--- a/src/client/components/EditBlogModal.tsx
+++ b/src/client/components/EditBlogModal.tsx
@@ -1,11 +1,12 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useContext, useState } from 'react';
 
 import BlogPost from '../../datatypes/BlogPost';
+import { CSRFContext } from '../contexts/CSRFContext';
+import Alert, { UncontrolledAlertProps } from './base/Alert';
 import Button from './base/Button';
 import Input from './base/Input';
 import { Flexbox } from './base/Layout';
 import { Modal, ModalBody, ModalFooter, ModalHeader } from './base/Modal';
-import CSRFForm from './CSRFForm';
 import TextEntry from './TextEntry';
 
 interface EditBlogModalProps {
@@ -16,48 +17,74 @@ interface EditBlogModalProps {
 }
 
 const EditBlogModal: React.FC<EditBlogModalProps> = ({ isOpen, setOpen, post, cubeID }) => {
+  const { csrfFetch } = useContext(CSRFContext);
   const [markdown, setMarkdown] = useState<string>(post?.body ?? '');
-  const formRef = React.createRef<HTMLFormElement>();
   const [title, setTitle] = useState<string>(post?.title ?? '');
-  const formData = useMemo(
-    () => ({
-      title,
-      markdown,
-    }),
-    [title, markdown],
-  );
+  const [postId] = useState<string>(post?.id ?? '');
+  const [alerts, setAlerts] = useState<UncontrolledAlertProps[]>([]);
+
+  const saveChanges = useCallback(async () => {
+    //Clear alerts when saving so easy to identify a new one appearing
+    setAlerts([]);
+
+    const response = await csrfFetch(`/cube/blog/post/${cubeID}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        title: title,
+        markdown: markdown,
+        id: postId,
+      }),
+    });
+
+    const body = await response.json();
+    if (response.ok) {
+      setAlerts([{ color: 'success', message: body.ok }]);
+      //Reload page to ensure state is updated
+      window.location.replace(body.redirect);
+    } else if (response.status === 403) {
+      setAlerts([{ color: 'danger', message: 'You must be logged in to create a blog post.' }]);
+    } else {
+      setAlerts([{ color: 'danger', message: body.error }]);
+    }
+  }, [csrfFetch, cubeID, postId, title, markdown]);
 
   return (
     <Modal isOpen={isOpen} setOpen={setOpen} lg>
-      <CSRFForm method="POST" action={`/cube/blog/post/${cubeID}`} ref={formRef} formData={formData}>
-        <ModalHeader setOpen={setOpen}>Edit Blog Post</ModalHeader>
-        <ModalBody>
-          <Flexbox direction="col" gap="2">
-            <Input
-              label="Title"
-              required
-              minLength={5}
-              maxLength={200}
-              name="title"
-              type="text"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-            />
-            {post && <input type="hidden" name="id" value={post.id} />}
-            <TextEntry name="markdown" value={markdown} setValue={setMarkdown} maxLength={10000} />
-          </Flexbox>
-        </ModalBody>
-        <ModalFooter>
-          <Flexbox direction="row" gap="2" className="w-full">
-            <Button type="submit" block color="primary">
-              Save
-            </Button>
-            <Button block color="secondary" onClick={() => setOpen(false)}>
-              Close
-            </Button>
-          </Flexbox>
-        </ModalFooter>
-      </CSRFForm>
+      <ModalHeader setOpen={setOpen}>Edit Blog Post</ModalHeader>
+      <ModalBody>
+        <Flexbox direction="col" gap="2">
+          <Input
+            label="Title"
+            required
+            minLength={5}
+            maxLength={100}
+            name="title"
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+          {post && <input type="hidden" name="id" value={post.id} />}
+          <TextEntry name="markdown" value={markdown} setValue={setMarkdown} maxLength={10000} />
+          {alerts.map(({ color, message }) => (
+            <Alert key={message} color={color} className="mt-2">
+              {message}
+            </Alert>
+          ))}
+        </Flexbox>
+      </ModalBody>
+      <ModalFooter>
+        <Flexbox direction="row" gap="2" className="w-full">
+          <Button type="submit" block color="primary" onClick={saveChanges}>
+            Save
+          </Button>
+          <Button block color="secondary" onClick={() => setOpen(false)}>
+            Close
+          </Button>
+        </Flexbox>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/src/client/components/TextEntry.tsx
+++ b/src/client/components/TextEntry.tsx
@@ -34,6 +34,7 @@ const TextEntry: React.FC<TextEntryProps> = ({ value = '', setValue, maxLength =
                     className="w-full markdown-input"
                     value={value}
                     onChange={(e) => setValue(e.target.value)}
+                    showCharacterLimit={true}
                   />
                 ),
                 onClick: () => setTab('0'),

--- a/src/client/components/base/TextArea.tsx
+++ b/src/client/components/base/TextArea.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect,useState } from 'react';
 
 import classNames from 'classnames';
 
@@ -40,7 +40,11 @@ const TextArea: React.FC<TextAreaProps> = ({
   maxLength,
   ...props
 }) => {
-  const [textLength, setTextLength] = useState(value ? value.length : 0);
+  const [textLength, setTextLength] = useState(value !== undefined ? value.length : 0);
+
+  useEffect(() => {
+    setTextLength(value !== undefined ? value.length : 0);
+  }, [value]);
 
   const handleChange = async (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     setTextLength(event.target.textLength);

--- a/src/client/components/base/TextArea.tsx
+++ b/src/client/components/base/TextArea.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import classNames from 'classnames';
 
@@ -20,6 +20,7 @@ export interface TextAreaProps extends React.TextareaHTMLAttributes<HTMLTextArea
   onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
   rows?: number;
   disabled?: boolean;
+  showCharacterLimit?: boolean;
 }
 
 const TextArea: React.FC<TextAreaProps> = ({
@@ -35,7 +36,20 @@ const TextArea: React.FC<TextAreaProps> = ({
   value,
   rows = 4,
   disabled = false,
+  showCharacterLimit = false,
+  maxLength,
+  ...props
 }) => {
+  const [textLength, setTextLength] = useState(value ? value.length : 0);
+
+  const handleChange = async (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setTextLength(event.target.textLength);
+    if (onChange) {
+      //Don't need to wait for this to finish
+      onChange(event);
+    }
+  };
+
   return (
     <div className="block w-full">
       <Flexbox justify="between" direction="row">
@@ -65,11 +79,22 @@ const TextArea: React.FC<TextAreaProps> = ({
         placeholder={placeholder}
         ref={innerRef}
         onKeyDown={disabled ? undefined : onKeyDown}
-        onChange={disabled ? undefined : onChange}
+        onChange={disabled ? undefined : handleChange}
         value={value}
         rows={rows}
         disabled={disabled}
+        maxLength={maxLength}
+        {...props}
       />
+      {showCharacterLimit && maxLength ? (
+        <div
+          className={classNames('p-2 rounded-b-md', {
+            'bg-red-100 text-red-800': textLength >= maxLength,
+          })}
+        >
+          {textLength} / {maxLength}
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/src/client/components/modals/CreateBlogModal.tsx
+++ b/src/client/components/modals/CreateBlogModal.tsx
@@ -1,13 +1,14 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useContext, useState } from 'react';
 
 import { findUserLinks } from 'markdown/parser';
 
+import { CSRFContext } from '../../contexts/CSRFContext';
+import Alert, { UncontrolledAlertProps } from '../base/Alert';
 import Button from '../base/Button';
 import Input from '../base/Input';
 import { Flexbox } from '../base/Layout';
 import { Modal, ModalFooter, ModalHeader } from '../base/Modal';
 import Text from '../base/Text';
-import CSRFForm from '../CSRFForm';
 import TextEntry from '../TextEntry';
 
 interface BlogPost {
@@ -24,52 +25,76 @@ interface CreateBlogModalProps {
 }
 
 const CreateBlogModal: React.FC<CreateBlogModalProps> = ({ isOpen, setOpen, post = null, cubeID }) => {
+  const { csrfFetch } = useContext(CSRFContext);
   const [markdown, setMarkdown] = useState<string>(post ? post.markdown : '');
   const [title, setTitle] = useState<string>(post ? post.title : '');
-  const formRef = React.createRef<HTMLFormElement>();
+  const [alerts, setAlerts] = useState<UncontrolledAlertProps[]>([]);
 
-  const formData = useMemo(() => {
-    return {
-      title: title,
-      markdown: markdown,
-      mentions: findUserLinks(markdown).join(';'),
-      id: post ? post.id : '',
-    };
-  }, [post, title, markdown]);
+  const saveChanges = useCallback(async () => {
+    //Clear alerts when saving so easy to identify a new one appearing
+    setAlerts([]);
+
+    const response = await csrfFetch(`/cube/blog/post/${cubeID}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        title: title,
+        markdown: markdown,
+        mentions: findUserLinks(markdown).join(';'),
+        id: '',
+      }),
+    });
+
+    const body = await response.json();
+    if (response.ok) {
+      setAlerts([{ color: 'success', message: body.ok }]);
+      //Reload page to ensure state is updated
+      window.location.replace(body.redirect);
+    } else if (response.status === 403) {
+      setAlerts([{ color: 'danger', message: 'You must be logged in to create a blog post.' }]);
+    } else {
+      setAlerts([{ color: 'danger', message: body.error }]);
+    }
+  }, [csrfFetch, cubeID, title, markdown]);
 
   return (
     <Modal isOpen={isOpen} setOpen={setOpen} lg>
-      <CSRFForm method="POST" action={`/cube/blog/post/${cubeID}`} formData={formData} ref={formRef}>
-        <Flexbox direction="col" gap="2" className="m-2">
-          <ModalHeader setOpen={setOpen}>Create Blog Post</ModalHeader>
-          <Text lg semibold>
-            Title:
-          </Text>
-          <Input
-            required
-            minLength={5}
-            maxLength={200}
-            name="title"
-            type="text"
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-          />
-          <Text lg semibold>
-            Body:
-          </Text>
-          <TextEntry name="markdown" value={markdown} setValue={setMarkdown} maxLength={10000} />
+      <Flexbox direction="col" gap="2" className="m-2">
+        <ModalHeader setOpen={setOpen}>Create Blog Post</ModalHeader>
+        <Text lg semibold>
+          Title:
+        </Text>
+        <Input
+          required
+          minLength={5}
+          maxLength={100}
+          name="title"
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <Text lg semibold>
+          Body:
+        </Text>
+        <TextEntry name="markdown" value={markdown} setValue={setMarkdown} maxLength={10000} />
+        {alerts.map(({ color, message }) => (
+          <Alert key={message} color={color} className="mt-2">
+            {message}
+          </Alert>
+        ))}
+      </Flexbox>
+      <ModalFooter>
+        <Flexbox direction="row" gap="2" className="w-full">
+          <Button color="primary" block onClick={saveChanges}>
+            Save
+          </Button>
+          <Button color="secondary" block onClick={() => setOpen(false)}>
+            Close
+          </Button>
         </Flexbox>
-        <ModalFooter>
-          <Flexbox direction="row" gap="2" className="w-full">
-            <Button color="primary" block onClick={() => formRef.current?.submit()}>
-              Save
-            </Button>
-            <Button color="secondary" block onClick={() => setOpen(false)}>
-              Close
-            </Button>
-          </Flexbox>
-        </ModalFooter>
-      </CSRFForm>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/src/router/routes/cube/blog.ts
+++ b/src/router/routes/cube/blog.ts
@@ -58,7 +58,6 @@ export const createBlogHandler = async (req: Request, res: Response) => {
     const cubeId = req.params.id;
     //Generally going to assume the cube exists here. Definitely required for a new blog, not so for an edit
     const cube = await Cube.getById(cubeId);
-    const redirectUrl = await getRedirectUrlForCube(req, cube);
 
     if (req.body.title.length < 5 || req.body.title.length > 100) {
       res.status(400).json({ error: 'Blog title length must be between 5 and 100 characters.' });
@@ -95,13 +94,12 @@ export const createBlogHandler = async (req: Request, res: Response) => {
 
       await Blog.put(blog);
 
+      const redirectUrl = await getRedirectUrlForCube(req, cube);
       res.status(200).json({ ok: 'Blog update successful, reloading...', redirect: redirectUrl });
       return;
     }
 
     if (!isCubeViewable(cube, user)) {
-      req.flash('danger', 'Cube not found');
-
       res.status(404).json({ error: 'Cube not found' });
       return;
     }
@@ -160,6 +158,7 @@ export const createBlogHandler = async (req: Request, res: Response) => {
 
     await Feed.batchPut(feedItems);
 
+    const redirectUrl = await getRedirectUrlForCube(req, cube);
     res.status(200).json({ ok: 'Blog post successful, reloading...', redirect: redirectUrl });
     return;
   } catch {

--- a/src/router/routes/cube/blog.ts
+++ b/src/router/routes/cube/blog.ts
@@ -2,7 +2,7 @@ import Blog from '../../../dynamo/models/blog';
 import Cube from '../../../dynamo/models/cube';
 import Feed from '../../../dynamo/models/feed';
 import User from '../../../dynamo/models/user';
-import { csrfProtection, ensureAuth } from '../../../routes/middleware';
+import { csrfProtection, ensureAuth, ensureAuthJson } from '../../../routes/middleware';
 import { Request, Response } from '../../../types/express';
 import { abbreviate, isCubeViewable } from '../../../util/cubefn';
 import generateMeta from '../../../util/meta';
@@ -61,32 +61,28 @@ export const createBlogHandler = async (req: Request, res: Response) => {
     const redirectUrl = await getRedirectUrlForCube(req, cube);
 
     if (req.body.title.length < 5 || req.body.title.length > 100) {
-      req.flash('danger', 'Blog title length must be between 5 and 100 characters.');
-
-      return redirect(req, res, redirectUrl);
+      res.status(400).json({ error: 'Blog title length must be between 5 and 100 characters.' });
+      return;
     }
 
     const { user } = req;
 
     if (!user) {
-      req.flash('danger', 'Please Login to publish a blog post.');
-
-      return redirect(req, res, redirectUrl);
+      res.status(401).json({ error: 'Please Login to publish a blog post.' });
+      return;
     }
 
     if (req.body.id && req.body.id.length > 0) {
       // update an existing blog post
       const blog = await Blog.getUnhydrated(req.body.id);
       if (!blog) {
-        req.flash('danger', 'Blog not found.');
-
-        return redirect(req, res, '/404');
+        res.status(404).json({ error: 'Blog not found.' });
+        return;
       }
 
       if (blog.owner !== user.id) {
-        req.flash('danger', 'Unable to update this blog post: Unauthorized.');
-
-        return redirect(req, res, redirectUrl);
+        res.status(403).json({ error: 'Unable to update this blog post: Unauthorized.' });
+        return;
       }
 
       blog.body = req.body.markdown.substring(0, 10000);
@@ -94,28 +90,32 @@ export const createBlogHandler = async (req: Request, res: Response) => {
 
       await Blog.put(blog);
 
-      req.flash('success', 'Blog update successful');
-
-      return redirect(req, res, redirectUrl);
+      res.status(200).json({ ok: 'Blog update successful, reloading...', redirect: redirectUrl });
+      return;
     }
 
     if (!isCubeViewable(cube, user)) {
       req.flash('danger', 'Cube not found');
 
-      return redirect(req, res, '/cube/blog/404');
+      res.status(404).json({ error: 'Cube not found' });
+      return;
     }
 
     // if this cube has no cards, we deny them from making any changes
     // this is a spam prevention measure
     if (cube.cardCount === 0) {
-      req.flash('danger', 'Cannot post a blog for an empty cube. Please add cards to the cube first.');
-
-      return redirect(req, res, redirectUrl);
+      res.status(400).json({ error: 'Cannot post a blog for an empty cube. Please add cards to the cube first.' });
+      return;
     }
 
     if (cube.owner.id !== user.id) {
-      req.flash('danger', 'Unable to post this blog post: Unauthorized.');
-      return redirect(req, res, redirectUrl);
+      res.status(403).json({ error: 'Unable to post this blog post: Unauthorized.' });
+      return;
+    }
+
+    if (req.body.markdown && req.body.markdown.length > 10000) {
+      res.status(400).json({ error: 'Blog post markdown cannot be longer than 10,000 characters.' });
+      return;
     }
 
     const id: string = await Blog.put({
@@ -160,12 +160,11 @@ export const createBlogHandler = async (req: Request, res: Response) => {
 
     await Feed.batchPut(feedItems);
 
-    req.flash('success', 'Blog post successful');
-
-    return redirect(req, res, redirectUrl);
-  } catch (err) {
-    //Not worried about cube not existing if we get a server error
-    return handleRouteError(req, res, err, `/cube/blog/${encodeURIComponent(req.params.id)}`);
+    res.status(200).json({ ok: 'Blog post successful, reloading...', redirect: redirectUrl });
+    return;
+  } catch {
+    res.status(500).json({ error: 'Unexpected error.' });
+    return;
   }
 };
 
@@ -279,7 +278,7 @@ export const routes = [
   {
     method: 'post',
     path: '/post/:id',
-    handler: [ensureAuth, csrfProtection, createBlogHandler],
+    handler: [ensureAuthJson, csrfProtection, createBlogHandler],
   },
   {
     method: 'get',

--- a/src/router/routes/cube/blog.ts
+++ b/src/router/routes/cube/blog.ts
@@ -72,6 +72,11 @@ export const createBlogHandler = async (req: Request, res: Response) => {
       return;
     }
 
+    if (req.body.markdown && req.body.markdown.length > 10000) {
+      res.status(400).json({ error: 'Blog post markdown cannot be longer than 10,000 characters.' });
+      return;
+    }
+
     if (req.body.id && req.body.id.length > 0) {
       // update an existing blog post
       const blog = await Blog.getUnhydrated(req.body.id);
@@ -110,11 +115,6 @@ export const createBlogHandler = async (req: Request, res: Response) => {
 
     if (cube.owner.id !== user.id) {
       res.status(403).json({ error: 'Unable to post this blog post: Unauthorized.' });
-      return;
-    }
-
-    if (req.body.markdown && req.body.markdown.length > 10000) {
-      res.status(400).json({ error: 'Blog post markdown cannot be longer than 10,000 characters.' });
       return;
     }
 

--- a/src/routes/middleware.js
+++ b/src/routes/middleware.js
@@ -12,6 +12,15 @@ const ensureAuth = (req, res, next) => {
   return redirect(req, res, '/user/login');
 };
 
+const ensureAuthJson = (req, res, next) => {
+  if (req.isAuthenticated()) {
+    return next();
+  }
+
+  res.status(403).json({ error: 'You must be logged in.' });
+  return;
+};
+
 const ensureRole = (role) => async (req, res, next) => {
   if (!req.isAuthenticated()) {
     req.flash('danger', 'Please login to view this content');
@@ -29,7 +38,7 @@ const ensureRole = (role) => async (req, res, next) => {
 const csrfProtection = [
   csurf(),
   (req, res, next) => {
-    const {nickname} = req.body;
+    const { nickname } = req.body;
 
     if (nickname !== undefined && nickname !== 'Your Nickname') {
       // probably a malicious request
@@ -73,14 +82,14 @@ const answers = [
   'forest', // 'What is the name of the basic land that produces green mana?'
 ];
 
-async function recaptcha (req, res, next) {
+async function recaptcha(req, res, next) {
   const { captcha, question, answer } = req.body;
-  
+
   if (!question || !answer) {
     req.flash('danger', 'Please answer the security question');
     return redirect(req, res, '/');
   }
-  
+
   const index = questions.indexOf(question);
 
   if (index === -1 || answers[index].toLowerCase() !== answer.toLowerCase()) {
@@ -111,7 +120,6 @@ async function recaptcha (req, res, next) {
   next();
 }
 
-
 function flashValidationErrors(req, res, next) {
   const errors = validationResult(req).formatWith(({ msg }) => msg);
   req.validated = errors.isEmpty();
@@ -140,6 +148,7 @@ function jsonValidationErrors(req, res, next) {
 
 module.exports = {
   ensureAuth,
+  ensureAuthJson,
   ensureRole,
   csrfProtection,
   flashValidationErrors,


### PR DESCRIPTION
As reported on Discord, you can hit the limit for blog post text (10K characters) without knowing ahead and when you hit the limit the rest of the text is cut off. 

This improves the UX by changing from a form post to a POST fetch, so on failures we can show an error message and the user can fix. As well, properly handle max length on text areas including showing the current character count against the limit.

# Testing

# After

Errors are shown without a page reload, so nothing is lost. The user can modify and try saving again.
<img width="982" height="692" alt="new-failure-message-with-page-reload" src="https://github.com/user-attachments/assets/be9a9295-e9ae-426e-8275-9860f5abc166" />

The server side checks are also done, even in this case where I used dev tools to change the max length of the field (though not the component).
<img width="989" height="712" alt="new-max-length-server-side-error" src="https://github.com/user-attachments/assets/2c195249-9ff4-4658-b362-076e70e2dfbc" />

Can see the character count as typed and when the limit is hit, shows in red.
![new-text-limit-and-indicator](https://github.com/user-attachments/assets/a87b5f7a-797e-4f23-8f85-d28df1440ed3)

Text max length and limit also shows on places like Cube Overview
<img width="990" height="695" alt="new-overview-character-limit" src="https://github.com/user-attachments/assets/72082aac-51c9-43e7-81ad-2b1ee9120754" />

Successful editing of a blog post, even from the user's blog page.
![new-edit-blog-post](https://github.com/user-attachments/assets/2c2295ce-5688-40a5-8169-e7ca488053d6)

Cube update blog also has max length and count indicator
<img width="1196" height="543" alt="image" src="https://github.com/user-attachments/assets/0f04c43d-c6f2-4811-ae22-98dbbd5c3490" />


