### PR TITLE
Fix redirect back to the page you were on after login

### DIFF
--- a/src/client/components/forms/LoginForm.tsx
+++ b/src/client/components/forms/LoginForm.tsx
@@ -3,16 +3,14 @@ import React from 'react';
 import Input from '../base/Input';
 import CSRFForm from '../CSRFForm';
 
-interface LoginModalProps {
-  loginCallback: string;
+interface LoginFormProps {
   formRef: React.RefObject<HTMLFormElement>;
 }
 
-const LoginForm: React.FC<LoginModalProps> = ({ loginCallback, formRef }) => {
+const LoginForm: React.FC<LoginFormProps> = ({ formRef }) => {
   const [formData, setFormData] = React.useState<Record<string, string>>({
     username: '',
     password: '',
-    loginCallback: loginCallback,
   });
 
   return (

--- a/src/client/components/modals/LoginModal.tsx
+++ b/src/client/components/modals/LoginModal.tsx
@@ -1,23 +1,22 @@
 import React from 'react';
 
-import { Modal, ModalBody, ModalFooter,ModalHeader } from '../base/Modal';
+import { Modal, ModalBody, ModalFooter, ModalHeader } from '../base/Modal';
 import LoginForm from '../forms/LoginForm';
 import LoadingButton from '../LoadingButton';
 
 interface LoginModalProps {
   isOpen: boolean;
   setOpen: (open: boolean) => void;
-  loginCallback: string;
 }
 
-const LoginModal: React.FC<LoginModalProps> = ({ isOpen, setOpen, loginCallback }) => {
+const LoginModal: React.FC<LoginModalProps> = ({ isOpen, setOpen }) => {
   const formRef = React.useRef<HTMLFormElement>(null);
 
   return (
     <Modal sm isOpen={isOpen} setOpen={setOpen}>
       <ModalHeader setOpen={setOpen}>Login</ModalHeader>
       <ModalBody>
-        <LoginForm loginCallback={loginCallback} formRef={formRef} />
+        <LoginForm formRef={formRef} />
       </ModalBody>
       <ModalFooter>
         <LoadingButton color="primary" outline block onClick={() => formRef.current?.submit()}>

--- a/src/client/components/nav/Navbar.tsx
+++ b/src/client/components/nav/Navbar.tsx
@@ -67,7 +67,6 @@ const navItems = [
 type NavbarProps = {
   expanded: boolean;
   toggle: () => void;
-  loginCallback?: string;
 };
 
 const Navbar: React.FC<NavbarProps> = ({ toggle, expanded }) => {

--- a/src/client/layouts/MainLayout.tsx
+++ b/src/client/layouts/MainLayout.tsx
@@ -15,10 +15,9 @@ import Footer from 'layouts/Footer';
 
 interface MainLayoutProps {
   children: React.ReactNode;
-  loginCallback?: string;
 }
 
-const MainLayout: React.FC<MainLayoutProps> = ({ children, loginCallback = '/' }) => {
+const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
   const [expanded, toggle] = useToggle(false);
   const user = useContext(UserContext);
 
@@ -42,7 +41,7 @@ const MainLayout: React.FC<MainLayoutProps> = ({ children, loginCallback = '/' }
 
   return (
     <Flexbox className="min-h-screen text-text" direction="col">
-      <Navbar expanded={expanded} toggle={toggle} loginCallback={loginCallback} />
+      <Navbar expanded={expanded} toggle={toggle} />
       <div className="bg-bg flex-grow">
         <Container xxxl>
           <Flexbox className="flex-grow max-w-full" direction="row" gap="4">

--- a/src/client/pages/AdminDashboardPage.tsx
+++ b/src/client/pages/AdminDashboardPage.tsx
@@ -10,17 +10,15 @@ import RenderToRoot from 'components/RenderToRoot';
 import MainLayout from 'layouts/MainLayout';
 
 interface AdminDashboardPageProps {
-  loginCallback?: string;
   noticeCount: number;
   contentInReview: number;
 }
 
 const AdminDashboardPage: React.FC<AdminDashboardPageProps> = ({
-  loginCallback = '/',
   noticeCount,
   contentInReview,
 }) => (
-  <MainLayout loginCallback={loginCallback}>
+  <MainLayout>
     <DynamicFlash />
     <Container sm>
       <Card className="my-3 mx-4">

--- a/src/client/pages/ApplicationPage.tsx
+++ b/src/client/pages/ApplicationPage.tsx
@@ -11,11 +11,7 @@ import DynamicFlash from 'components/DynamicFlash';
 import RenderToRoot from 'components/RenderToRoot';
 import MainLayout from 'layouts/MainLayout';
 
-interface AdminDashboardPageProps {
-  loginCallback?: string;
-}
-
-const ApplicationPage: React.FC<AdminDashboardPageProps> = ({ loginCallback = '/' }) => {
+const ApplicationPage: React.FC = () => {
   const [info, setInfo] = React.useState<string>('');
   const formRef = React.useRef<HTMLFormElement>(null);
   const formData = useMemo(
@@ -26,7 +22,7 @@ const ApplicationPage: React.FC<AdminDashboardPageProps> = ({ loginCallback = '/
   );
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <DynamicFlash />
       <Container md>
         <Card className="my-3 mx-4">

--- a/src/client/pages/ArticlePage.tsx
+++ b/src/client/pages/ArticlePage.tsx
@@ -12,15 +12,14 @@ import { ContentStatus } from 'datatypes/Content';
 import MainLayout from 'layouts/MainLayout';
 
 interface ArticlePageProps {
-  loginCallback?: string;
   article: ArticleType;
 }
 
-const ArticlePage: React.FC<ArticlePageProps> = ({ loginCallback = '/', article }) => {
+const ArticlePage: React.FC<ArticlePageProps> = ({ article }) => {
   const user = useContext(UserContext);
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <Banner />
       <DynamicFlash />
       <Card className="my-2">

--- a/src/client/pages/ArticlesPage.tsx
+++ b/src/client/pages/ArticlesPage.tsx
@@ -9,17 +9,16 @@ import RenderToRoot from 'components/RenderToRoot';
 import ArticleType from 'datatypes/Article';
 import MainLayout from 'layouts/MainLayout';
 interface ArticlesPageProps {
-  loginCallback?: string;
   articles: ArticleType[];
   lastKey: any; // Define a more specific type if possible
 }
 
-const ArticlesPage: React.FC<ArticlesPageProps> = ({ loginCallback = '/', articles, lastKey }) => {
+const ArticlesPage: React.FC<ArticlesPageProps> = ({ articles, lastKey }) => {
   const [items, setItems] = useState<ArticleType[]>(articles);
   const [currentLastKey, setLastKey] = useState(lastKey);
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <Flexbox direction="col" gap="2" className="my-2">
         <Banner />
         <DynamicFlash />

--- a/src/client/pages/BlogPostPage.tsx
+++ b/src/client/pages/BlogPostPage.tsx
@@ -9,11 +9,10 @@ import MainLayout from 'layouts/MainLayout';
 
 interface BlogPostPageProps {
   post: BlogPostType;
-  loginCallback?: string;
 }
 
-const BlogPostPage: React.FC<BlogPostPageProps> = ({ post, loginCallback = '/' }) => (
-  <MainLayout loginCallback={loginCallback}>
+const BlogPostPage: React.FC<BlogPostPageProps> = ({ post }) => (
+  <MainLayout>
     <Banner />
     <DynamicFlash />
     <BlogPost key={post.id} post={post} noScroll className="my-2" />

--- a/src/client/pages/BrowseContentPage.tsx
+++ b/src/client/pages/BrowseContentPage.tsx
@@ -15,17 +15,16 @@ import Video from 'datatypes/Video';
 import MainLayout from 'layouts/MainLayout';
 
 interface BrowseContentPageProps {
-  loginCallback?: string;
   content: Content[];
   lastKey: any; // Define a more specific type if possible
 }
 
-const BrowseContentPage: React.FC<BrowseContentPageProps> = ({ loginCallback = '/', content, lastKey }) => {
+const BrowseContentPage: React.FC<BrowseContentPageProps> = ({ content, lastKey }) => {
   const [items, setItems] = useState<Content[]>(content);
   const [currentLastKey, setLastKey] = useState(lastKey);
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <Flexbox direction="col" gap="2" className="my-2">
         <Banner />
         <DynamicFlash />

--- a/src/client/pages/BulkUploadPage.tsx
+++ b/src/client/pages/BulkUploadPage.tsx
@@ -155,7 +155,6 @@ interface BulkUploadPageProps {
     maybeboard: CardType[];
   };
   added: string[];
-  loginCallback?: string;
   blogpost: {
     title: string;
     html: string;
@@ -163,8 +162,8 @@ interface BulkUploadPageProps {
   missing: string[];
 }
 
-const BulkUploadPage: React.FC<BulkUploadPageProps> = ({ cube, cards, added, loginCallback, missing }) => (
-  <MainLayout loginCallback={loginCallback}>
+const BulkUploadPage: React.FC<BulkUploadPageProps> = ({ cube, cards, added, missing }) => (
+  <MainLayout>
     <DynamicFlash />
     <CubeLayout cube={cube} cards={cards} activeLink="list" useChangedCards>
       <BulkUploadPageRaw added={added} missing={missing} />

--- a/src/client/pages/CardPage.tsx
+++ b/src/client/pages/CardPage.tsx
@@ -34,14 +34,12 @@ interface CardPageProps {
     other: CardDetails[];
   };
   versions: CardDetails[];
-  loginCallback: string;
 }
 
 const CardPage: React.FC<CardPageProps> = ({
   card,
   history,
   versions,
-  loginCallback,
   draftedWith,
   cubedWith,
   synergistic,
@@ -64,7 +62,7 @@ const CardPage: React.FC<CardPageProps> = ({
   });
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <DynamicFlash />
       <Banner />
       <Row className="my-3">

--- a/src/client/pages/CardSearchPage.tsx
+++ b/src/client/pages/CardSearchPage.tsx
@@ -5,14 +5,10 @@ import RenderToRoot from 'components/RenderToRoot';
 import { FilterContextProvider } from 'contexts/FilterContext';
 import MainLayout from 'layouts/MainLayout';
 
-interface CardSearchPageProps {
-  loginCallback?: string;
-}
-
-const CardSearchPage: React.FC<CardSearchPageProps> = ({ loginCallback = '/' }) => {
+const CardSearchPage: React.FC = () => {
   return (
     <FilterContextProvider>
-      <MainLayout loginCallback={loginCallback}>
+      <MainLayout>
         <CardSearch />
       </MainLayout>
     </FilterContextProvider>

--- a/src/client/pages/CommentPage.tsx
+++ b/src/client/pages/CommentPage.tsx
@@ -38,14 +38,13 @@ const translateLink: { [key: string]: (id: string) => string } = {
 
 interface CommentPageProps {
   comment: CommentType;
-  loginCallback?: string;
 }
 
-const CommentPage: React.FC<CommentPageProps> = ({ comment, loginCallback = '/' }) => {
+const CommentPage: React.FC<CommentPageProps> = ({ comment }) => {
   const [content, setContent] = useState<CommentType>(comment);
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <Banner />
       <DynamicFlash />
       <Card className="my-3">

--- a/src/client/pages/ContactPage.tsx
+++ b/src/client/pages/ContactPage.tsx
@@ -9,12 +9,8 @@ import DynamicFlash from 'components/DynamicFlash';
 import RenderToRoot from 'components/RenderToRoot';
 import MainLayout from 'layouts/MainLayout';
 
-interface ContactPageProps {
-  loginCallback?: string;
-}
-
-const ContactPage: React.FC<ContactPageProps> = ({ loginCallback = '/' }) => (
-  <MainLayout loginCallback={loginCallback}>
+const ContactPage: React.FC = () => (
+  <MainLayout>
     <Banner />
     <DynamicFlash />
     <Card className="my-3 mx-4">

--- a/src/client/pages/CreateNewRecordPage.tsx
+++ b/src/client/pages/CreateNewRecordPage.tsx
@@ -21,16 +21,15 @@ import EditPlayerList from '../records/EditPlayerList';
 
 interface CreateNewRecordPageProps {
   cube: Cube;
-  loginCallback?: string;
 }
 
-const CreateNewRecordPage: React.FC<CreateNewRecordPageProps> = ({ cube, loginCallback = '/' }) => {
+const CreateNewRecordPage: React.FC<CreateNewRecordPageProps> = ({ cube }) => {
   const [step, setStep] = React.useState(0);
   const [record, setRecord] = React.useState<Partial<Record>>({});
   const formRef = React.createRef<HTMLFormElement>();
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <CubeLayout cube={cube} activeLink="records">
         <DynamicFlash />
         <Card className="my-2">

--- a/src/client/pages/CreateRecordFromDraftPage.tsx
+++ b/src/client/pages/CreateRecordFromDraftPage.tsx
@@ -26,7 +26,6 @@ import EditDescription from '../records/EditDescription';
 
 interface CreateRecordFromDraftPageProps {
   cube: Cube;
-  loginCallback?: string;
   decks: Draft[];
   decksLastKey?: any;
 }
@@ -37,7 +36,6 @@ const CreateRecordFromDraftPage: React.FC<CreateRecordFromDraftPageProps> = ({
   cube,
   decks,
   decksLastKey,
-  loginCallback = '/',
 }) => {
   const [step, setStep] = useState(0);
   const { csrfFetch } = useContext(CSRFContext);
@@ -91,7 +89,7 @@ const CreateRecordFromDraftPage: React.FC<CreateRecordFromDraftPageProps> = ({
   );
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <CubeLayout cube={cube} activeLink="records">
         <DynamicFlash />
         <Card className="my-2">

--- a/src/client/pages/CreatorsPage.tsx
+++ b/src/client/pages/CreatorsPage.tsx
@@ -58,9 +58,9 @@ const CreatorsPage: React.FC<CreatorsPageProps> = ({ articles, videos, podcasts 
       <TabContent
         activeTab={parseInt(tab || '0', 10)}
         contents={[
-          <CreatorArticles articles={articles.items} lastKey={articles.lastKey} />,
-          <CreatorPodcasts podcasts={podcasts.items} lastKey={podcasts.lastKey} />,
-          <CreatorVideos videos={videos.items} lastKey={videos.lastKey} />,
+          <CreatorArticles articles={articles.items} lastKey={articles.lastKey} key="articles" />,
+          <CreatorPodcasts podcasts={podcasts.items} lastKey={podcasts.lastKey} key="podcasts" />,
+          <CreatorVideos videos={videos.items} lastKey={videos.lastKey} key="videos" />,
         ]}
         className="mt-2"
       />

--- a/src/client/pages/CreatorsPage.tsx
+++ b/src/client/pages/CreatorsPage.tsx
@@ -19,17 +19,16 @@ interface ContentItems {
 }
 
 interface CreatorsPageProps {
-  loginCallback?: string;
   articles: ContentItems;
   videos: ContentItems;
   podcasts: ContentItems;
 }
 
-const CreatorsPage: React.FC<CreatorsPageProps> = ({ loginCallback = '/', articles, videos, podcasts }) => {
+const CreatorsPage: React.FC<CreatorsPageProps> = ({ articles, videos, podcasts }) => {
   const [tab, setTab] = useQueryParam('tab', '0');
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <Controls>
         <Flexbox direction="col" gap="2" className="mx-2">
           <Banner />

--- a/src/client/pages/CubeAnalysisPage.tsx
+++ b/src/client/pages/CubeAnalysisPage.tsx
@@ -223,7 +223,6 @@ const CubeAnalysisPage: React.FC<CubeAnalysisPageProps> = ({ cubeAnalytics, toke
 interface CubeAnalysisPageWrapperProps {
   cube: Cube; // Adjust the type as needed
   cards: CubeCards;
-  loginCallback?: string;
   cubeAnalytics: any; // Adjust the type as needed
   tokenMap: { [key: string]: CardType };
 }
@@ -231,12 +230,11 @@ interface CubeAnalysisPageWrapperProps {
 const CubeAnalysisPageWrapper: React.FC<CubeAnalysisPageWrapperProps> = ({
   cube,
   cards,
-  loginCallback = '/',
   cubeAnalytics,
   tokenMap,
 }) => {
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <CubeLayout cube={cube} cards={cards} activeLink="analysis">
         <CubeAnalysisPage cubeAnalytics={cubeAnalytics} tokenMap={tokenMap} />
       </CubeLayout>

--- a/src/client/pages/CubeBlogPage.tsx
+++ b/src/client/pages/CubeBlogPage.tsx
@@ -19,20 +19,19 @@ interface CubeBlogPageProps {
   cube: Cube;
   lastKey: any;
   posts: PostType[];
-  loginCallback?: string;
 }
 
 const CreateBlogModalLink = withModal(Link, CreateBlogModal);
 
 const PAGE_SIZE = 20;
 
-const CubeBlogPage: React.FC<CubeBlogPageProps> = ({ cube, lastKey, posts, loginCallback = '/' }) => {
+const CubeBlogPage: React.FC<CubeBlogPageProps> = ({ cube, lastKey, posts }) => {
   const [items, setItems] = useState(posts);
   const [currentLastKey, setLastKey] = useState(lastKey);
   const user = useContext(UserContext);
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <CubeLayout cube={cube} activeLink="blog" hasControls={!!user && cube.owner.id === user.id}>
         <Controls>
           <Flexbox direction="row" justify="start" gap="4" alignItems="center" className="py-2 px-4">

--- a/src/client/pages/CubeComparePage.tsx
+++ b/src/client/pages/CubeComparePage.tsx
@@ -19,7 +19,6 @@ interface CubeComparePageProps {
   cards: Card[];
   cube: Cube;
   cubeB: Cube;
-  loginCallback?: string;
   onlyA: string[];
   onlyB: string[];
   both: string[];
@@ -53,14 +52,13 @@ const CubeComparePage: React.FC<CubeComparePageProps> = ({
   cards,
   cube,
   cubeB,
-  loginCallback = '/',
   onlyA,
   onlyB,
   both,
 }) => {
   return (
     <FilterContextProvider>
-      <MainLayout loginCallback={loginCallback}>
+      <MainLayout>
         <DisplayContextProvider cubeID={cube.id}>
           <ChangesContextProvider cube={cube}>
             <CubeContextProvider initialCube={cube} cards={{ mainboard: cards, maybeboard: [] }}>

--- a/src/client/pages/CubeDeckPage.tsx
+++ b/src/client/pages/CubeDeckPage.tsx
@@ -31,10 +31,9 @@ const SampleHandModalLink = withModal(Link, SampleHandModal);
 interface CubeDeckPageProps {
   cube: Cube;
   draft: Draft;
-  loginCallback: string;
 }
 
-const CubeDeckPage: React.FC<CubeDeckPageProps> = ({ cube, draft, loginCallback }) => {
+const CubeDeckPage: React.FC<CubeDeckPageProps> = ({ cube, draft }) => {
   const user = useContext(UserContext);
   const [seatIndex, setSeatIndex] = useQueryParam('seat', '0');
   const [view, setView] = useQueryParam('view', 'draft');
@@ -59,7 +58,7 @@ const CubeDeckPage: React.FC<CubeDeckPageProps> = ({ cube, draft, loginCallback 
   );
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <DisplayContextProvider cubeID={cube.id}>
         <CubeLayout cube={cube} activeLink="playtest" hasControls>
           <Controls>

--- a/src/client/pages/CubeDeckbuilderPage.tsx
+++ b/src/client/pages/CubeDeckbuilderPage.tsx
@@ -21,10 +21,9 @@ import MainLayout from '../layouts/MainLayout';
 interface CubeDeckbuilderPageProps {
   cube: Cube;
   initialDeck: Draft;
-  loginCallback: string;
 }
 
-const CubeDeckbuilderPage: React.FC<CubeDeckbuilderPageProps> = ({ cube, initialDeck, loginCallback }) => {
+const CubeDeckbuilderPage: React.FC<CubeDeckbuilderPageProps> = ({ cube, initialDeck }) => {
   const [mainboard, setMainboard] = useState<number[][][]>(initialDeck.seats[0].mainboard);
   const [sideboard, setSideboard] = useState<number[][][]>(initialDeck.seats[0].sideboard);
   const [dragStartTime, setDragStartTime] = useState<number | null>(null);
@@ -112,7 +111,7 @@ const CubeDeckbuilderPage: React.FC<CubeDeckbuilderPageProps> = ({ cube, initial
   );
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <DisplayContextProvider cubeID={cube.id}>
         <CubeLayout cube={cube} activeLink="playtest" hasControls>
           <DeckbuilderNavbar

--- a/src/client/pages/CubeDraftPage.tsx
+++ b/src/client/pages/CubeDraftPage.tsx
@@ -24,7 +24,6 @@ import { getCardDefaultRowColumn, getInitialState, setupPicks } from '../../util
 interface CubeDraftPageProps {
   cube: Cube;
   draft: Draft;
-  loginCallback?: string;
 }
 
 interface PredictResponse {
@@ -69,7 +68,7 @@ const processPredictions = (json: PredictResponse, packCards: any[]) => {
   return packCards.map((card) => predictionsMap.get(card.oracle_id) || 0);
 };
 
-const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallback }) => {
+const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft }) => {
   // Draft State
   // These reflect the current state of the draft objects, including the cards in the pack, the picks made, and the ratings for each card.
   const [state, setState] = useLocalStorage(`draftstate-${draft.id}`, getInitialState(draft));
@@ -732,7 +731,7 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft, loginCallbac
     pendingPick !== null;
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <DisplayContextProvider cubeID={cube.id}>
         <CubeLayout cube={cube} activeLink="playtest">
           <Alerts alerts={alerts} />

--- a/src/client/pages/CubeHistoryPage.tsx
+++ b/src/client/pages/CubeHistoryPage.tsx
@@ -11,11 +11,10 @@ interface CubeHistoryPageProps {
   cube: Cube;
   changes: Record<string, any>[];
   lastKey?: string;
-  loginCallback?: string;
 }
 
-const CubeHistoryPage: React.FC<CubeHistoryPageProps> = ({ cube, changes, lastKey, loginCallback }) => (
-  <MainLayout loginCallback={loginCallback}>
+const CubeHistoryPage: React.FC<CubeHistoryPageProps> = ({ cube, changes, lastKey }) => (
+  <MainLayout>
     <DisplayContextProvider cubeID={cube.id}>
       <CubeLayout cube={cube} activeLink="history">
         <CubeHistory changes={changes} lastKey={lastKey} />

--- a/src/client/pages/CubeListPage.tsx
+++ b/src/client/pages/CubeListPage.tsx
@@ -27,7 +27,6 @@ interface CubeListPageProps {
     mainboard: Card[];
     maybeboard: Card[];
   };
-  loginCallback?: string;
 }
 
 const boardToName: Record<BoardType, string> = {
@@ -104,8 +103,8 @@ const CubeListPageRaw: React.FC = () => {
   );
 };
 
-const CubeListPage: React.FC<CubeListPageProps> = ({ cube, cards, loginCallback = '/' }) => (
-  <MainLayout loginCallback={loginCallback}>
+const CubeListPage: React.FC<CubeListPageProps> = ({ cube, cards }) => (
+  <MainLayout>
     <DisplayContextProvider cubeID={cube.id}>
       <CubeLayout cube={cube} cards={cards} activeLink="list" loadVersionDict useChangedCards hasControls>
         <CubeListPageRaw />

--- a/src/client/pages/CubeOverviewPage.tsx
+++ b/src/client/pages/CubeOverviewPage.tsx
@@ -34,7 +34,6 @@ interface CubeOverviewProps {
   cards: CubeCards;
   followed: boolean;
   followersCount: number;
-  loginCallback: () => void;
 }
 
 const CubeOverview: React.FC<CubeOverviewProps> = ({

--- a/src/client/pages/CubePlaytestPage.tsx
+++ b/src/client/pages/CubePlaytestPage.tsx
@@ -30,7 +30,6 @@ interface CubePlaytestPageProps {
   decksLastKey: any;
   previousPacks?: any[];
   previousPacksLastKey?: any;
-  loginCallback?: string;
 }
 
 const UploadDecklistModalLink = withModal(Link, UploadDecklistModal);
@@ -42,7 +41,6 @@ const CubePlaytestPage: React.FC<CubePlaytestPageProps> = ({
   decksLastKey,
   previousPacks = [],
   previousPacksLastKey,
-  loginCallback = '/',
 }) => {
   const user = useContext(UserContext);
   const defaultFormat = cube.defaultFormat ?? -1;
@@ -65,7 +63,7 @@ const CubePlaytestPage: React.FC<CubePlaytestPageProps> = ({
   );
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <CubeLayout cube={cube} activeLink="playtest" hasControls={!!user && cube.owner.id === user.id}>
         <Flexbox direction="col" gap="2" className="mb-2">
           {user && cube.owner.id === user.id && (

--- a/src/client/pages/CubeRecordsPage.tsx
+++ b/src/client/pages/CubeRecordsPage.tsx
@@ -25,7 +25,6 @@ interface CubeRecordsPageProps {
   cards: CubeCards;
   decks: Draft[];
   decksLastKey: any;
-  loginCallback?: string;
   records: Record[];
   analyticsData?: RecordAnalytic;
   lastKey: any;
@@ -37,7 +36,6 @@ const CubeRecordsPage: React.FC<CubeRecordsPageProps> = ({
   records,
   analyticsData,
   lastKey,
-  loginCallback = '/',
 }) => {
   const user = useContext(UserContext);
   const [activeTab, setActiveTab] = useQueryParam('tab', '0');
@@ -58,7 +56,7 @@ const CubeRecordsPage: React.FC<CubeRecordsPageProps> = ({
   ];
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <CubeLayout cube={cube} cards={cards} activeLink="records" hasControls={!!user && cube.owner.id === user.id}>
         {user && cube.owner.id === user.id && (
           <Controls>

--- a/src/client/pages/CubeSamplePackPage.tsx
+++ b/src/client/pages/CubeSamplePackPage.tsx
@@ -17,12 +17,11 @@ interface SamplePackPageProps {
   seed: string;
   pack: CardType[];
   cube: Cube;
-  loginCallback?: string;
 }
 
-const SamplePackPage: React.FC<SamplePackPageProps> = ({ seed, pack, cube, loginCallback = '/' }) => {
+const SamplePackPage: React.FC<SamplePackPageProps> = ({ seed, pack, cube }) => {
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <CubeLayout cube={cube} activeLink="playtest">
         <Flexbox direction="col" gap="2" className="my-2">
           <DynamicFlash />

--- a/src/client/pages/DailyP1P1HistoryPage.tsx
+++ b/src/client/pages/DailyP1P1HistoryPage.tsx
@@ -24,13 +24,11 @@ interface DailyP1P1HistoryItem extends DailyP1P1 {
 interface DailyP1P1HistoryPageProps {
   history: DailyP1P1HistoryItem[];
   hasMore: boolean;
-  loginCallback?: string;
 }
 
 const DailyP1P1HistoryPage: React.FC<DailyP1P1HistoryPageProps> = ({
   history: initialHistory,
   hasMore: initialHasMore,
-  loginCallback = '/',
 }) => {
   const [history, setHistory] = useState(initialHistory);
   const [hasMore, setHasMore] = useState(initialHasMore);
@@ -59,7 +57,7 @@ const DailyP1P1HistoryPage: React.FC<DailyP1P1HistoryPageProps> = ({
   }, [loading, hasMore, lastKey]);
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <DynamicFlash />
       <Card className="my-3">
         <CardHeader>

--- a/src/client/pages/DashboardPage.tsx
+++ b/src/client/pages/DashboardPage.tsx
@@ -32,7 +32,6 @@ interface DashboardPageProps {
   posts: BlogPost[];
   decks: Draft[];
   content: any[];
-  loginCallback?: string;
   featured?: Cube[];
   dailyP1P1?: {
     pack: P1P1Pack;
@@ -50,7 +49,6 @@ const DashboardPage: React.FC<DashboardPageProps> = ({
   lastKey,
   lastDeckKey,
   decks,
-  loginCallback = '/',
   content,
   featured = [],
   dailyP1P1,
@@ -65,7 +63,7 @@ const DashboardPage: React.FC<DashboardPageProps> = ({
   }
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <Banner />
       <DynamicFlash />
       <Row className="my-2">

--- a/src/client/pages/DevBlog.tsx
+++ b/src/client/pages/DevBlog.tsx
@@ -23,7 +23,6 @@ interface DevBlogEntryProps {
 interface DevBlogProps {
   blogs: any[];
   lastKey: string | null;
-  loginCallback?: string;
 }
 
 const loader = (
@@ -82,7 +81,7 @@ const DevBlogEntry: React.FC<DevBlogEntryProps> = ({ items, setItems }) => {
   );
 };
 
-const DevBlog: React.FC<DevBlogProps> = ({ blogs, lastKey, loginCallback = '/' }) => {
+const DevBlog: React.FC<DevBlogProps> = ({ blogs, lastKey }) => {
   const { csrfFetch } = useContext(CSRFContext);
   const [items, setItems] = useState(blogs);
   const [currentLastKey, setLastKey] = useState(lastKey);
@@ -113,7 +112,7 @@ const DevBlog: React.FC<DevBlogProps> = ({ blogs, lastKey, loginCallback = '/' }
   }, [items, setItems, currentLastKey]);
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <Flexbox direction="col" gap="2" className="my-2">
         <Banner />
         <DynamicFlash />

--- a/src/client/pages/DevBlog.tsx
+++ b/src/client/pages/DevBlog.tsx
@@ -55,12 +55,14 @@ const DevBlogEntry: React.FC<DevBlogEntryProps> = ({ items, setItems }) => {
         setTitle('');
         setBody('');
       } else {
+        // eslint-disable-next-line no-console
         console.error(json);
       }
     } else {
+      // eslint-disable-next-line no-console
       console.error(response);
     }
-  }, [title, body, setItems, items]);
+  }, [csrfFetch, title, body, setItems, items]);
 
   return (
     <Card className="my-3">
@@ -109,7 +111,7 @@ const DevBlog: React.FC<DevBlogProps> = ({ blogs, lastKey }) => {
       }
     }
     setLoading(false);
-  }, [items, setItems, currentLastKey]);
+  }, [csrfFetch, currentLastKey, items]);
 
   return (
     <MainLayout>

--- a/src/client/pages/DonatePage.tsx
+++ b/src/client/pages/DonatePage.tsx
@@ -8,12 +8,8 @@ import DynamicFlash from 'components/DynamicFlash';
 import RenderToRoot from 'components/RenderToRoot';
 import MainLayout from 'layouts/MainLayout';
 
-interface DonatePageProps {
-  loginCallback?: string;
-}
-
-const DonatePage: React.FC<DonatePageProps> = ({ loginCallback = '/' }) => (
-  <MainLayout loginCallback={loginCallback}>
+const DonatePage: React.FC = () => (
+  <MainLayout>
     <DynamicFlash />
     <Card className="my-3 mx-4">
       <CardHeader>

--- a/src/client/pages/EditArticlePage.tsx
+++ b/src/client/pages/EditArticlePage.tsx
@@ -16,11 +16,10 @@ import useQueryParam from 'hooks/useQueryParam';
 import MainLayout from 'layouts/MainLayout';
 
 interface EditArticlePageProps {
-  loginCallback?: string;
   article: ArticleType;
 }
 
-const EditArticlePage: React.FC<EditArticlePageProps> = ({ loginCallback = '/', article }) => {
+const EditArticlePage: React.FC<EditArticlePageProps> = ({ article }) => {
   const [tab, setTab] = useQueryParam('tab', '0');
   const [body, setBody] = useState(article.body);
   const [title, setTitle] = useState(article.title);
@@ -56,7 +55,7 @@ const EditArticlePage: React.FC<EditArticlePageProps> = ({ loginCallback = '/', 
     article.body !== body || article.title !== title || article.imageName !== imageName || article.short !== short;
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <Card className="my-2">
         <CardBody>
           <Flexbox direction="row" justify="between">

--- a/src/client/pages/EditPodcastPage.tsx
+++ b/src/client/pages/EditPodcastPage.tsx
@@ -16,11 +16,10 @@ import useQueryParam from 'hooks/useQueryParam';
 import MainLayout from 'layouts/MainLayout';
 
 interface EditPodcastPageProps {
-  loginCallback?: string;
   podcast: PodcastType;
 }
 
-const EditPodcastPage: React.FC<EditPodcastPageProps> = ({ loginCallback = '/', podcast }) => {
+const EditPodcastPage: React.FC<EditPodcastPageProps> = ({ podcast }) => {
   const [tab, setTab] = useQueryParam('tab', '0');
   const [rss, setRss] = useState(podcast.url);
   const saveFormRef = React.createRef<HTMLFormElement>();
@@ -29,7 +28,7 @@ const EditPodcastPage: React.FC<EditPodcastPageProps> = ({ loginCallback = '/', 
   const hasChanges = podcast.url !== rss;
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <Card className="my-2">
         <CardBody>
           <Flexbox direction="row" justify="between">

--- a/src/client/pages/EditVideoPage.tsx
+++ b/src/client/pages/EditVideoPage.tsx
@@ -16,11 +16,10 @@ import useQueryParam from 'hooks/useQueryParam';
 import MainLayout from 'layouts/MainLayout';
 
 interface EditVideoPageProps {
-  loginCallback?: string;
   video: VideoType;
 }
 
-const EditVideoPage: React.FC<EditVideoPageProps> = ({ loginCallback = '/', video }) => {
+const EditVideoPage: React.FC<EditVideoPageProps> = ({ video }) => {
   const [tab, setTab] = useQueryParam('tab', '0');
   const [body, setBody] = useState(video.body);
   const [short, setShort] = useState(video.short);
@@ -56,7 +55,7 @@ const EditVideoPage: React.FC<EditVideoPageProps> = ({ loginCallback = '/', vide
   const hasChanges = video.body !== body || video.url !== url || video.title !== title || video.imageName !== imageName;
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <Card className="my-2">
         <DynamicFlash />
         <CardBody>

--- a/src/client/pages/ErrorPage.tsx
+++ b/src/client/pages/ErrorPage.tsx
@@ -15,6 +15,7 @@ interface ErrorPageProps {
 }
 
 const ErrorPage: React.FC<ErrorPageProps> = ({ title, error, requestId, details }) => {
+  // eslint-disable-next-line no-console
   console.log(details);
 
   return (

--- a/src/client/pages/ErrorPage.tsx
+++ b/src/client/pages/ErrorPage.tsx
@@ -12,14 +12,13 @@ interface ErrorPageProps {
   requestId?: string;
   error?: string;
   details?: Record<string, unknown>;
-  loginCallback?: string;
 }
 
-const ErrorPage: React.FC<ErrorPageProps> = ({ title, error, requestId, loginCallback = '/', details }) => {
+const ErrorPage: React.FC<ErrorPageProps> = ({ title, error, requestId, details }) => {
   console.log(details);
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <DynamicFlash />
       <Card className="my-2">
         <CardHeader>

--- a/src/client/pages/ExplorePage.tsx
+++ b/src/client/pages/ExplorePage.tsx
@@ -14,12 +14,11 @@ interface ExplorePageProps {
   featured: Cube[];
   drafted: Cube[];
   popular: Cube[];
-  loginCallback?: string;
 }
 
-const ExplorePage: React.FC<ExplorePageProps> = ({ recents, featured, drafted, popular, loginCallback = '/' }) => {
+const ExplorePage: React.FC<ExplorePageProps> = ({ recents, featured, drafted, popular }) => {
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <CubeSearchNavBar />
       <DynamicFlash />
       <Row>

--- a/src/client/pages/FeaturedCubesQueuePage.tsx
+++ b/src/client/pages/FeaturedCubesQueuePage.tsx
@@ -17,15 +17,14 @@ interface FeaturedCubesQueuePageProps {
   cubes: Cube[];
   daysBetweenRotations: number;
   lastRotation: number;
-  loginCallback: string;
 }
 
 const AddCubeButton = withModal(Button, AddCubeModal);
 const RotateButton = withModal(Button, ConfirmActionModal);
 
-const FeaturedCubesQueuePage: React.FC<FeaturedCubesQueuePageProps> = ({ cubes, lastRotation, loginCallback }) => {
+const FeaturedCubesQueuePage: React.FC<FeaturedCubesQueuePageProps> = ({ cubes, lastRotation }) => {
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <Flexbox direction="col" gap="2" className="my-2">
         <DynamicFlash />
         <Card>

--- a/src/client/pages/FiltersPage.tsx
+++ b/src/client/pages/FiltersPage.tsx
@@ -12,12 +12,8 @@ import MainLayout from 'layouts/MainLayout';
 
 import { CARD_STATUSES, FINISHES } from '../../datatypes/Card';
 
-interface FiltersPageProps {
-  loginCallback: string;
-}
-
-const FiltersPage: React.FC<FiltersPageProps> = ({ loginCallback }) => (
-  <MainLayout loginCallback={loginCallback}>
+const FiltersPage: React.FC = () => (
+  <MainLayout>
     <Flexbox direction="col" gap="2" className="my-2">
       <Banner />
       <DynamicFlash />

--- a/src/client/pages/GridDraftPage.tsx
+++ b/src/client/pages/GridDraftPage.tsx
@@ -80,7 +80,6 @@ const GridDraftPage: React.FC<GridDraftPageProps> = ({ cube, initialDraft, seatN
   const drafterStates = useMemo(() => {
     return [0, 1].map((idx) => getGridDrafterState({ gridDraft, seatNumber: idx }));
   }, [gridDraft]);
-  console.log(drafterStates);
   const { turn, numPacks, packNum, pickNum } = drafterStates[seatNum];
   const { cardsInPack } = drafterStates[turn ? 0 : 1];
   const doneDrafting = packNum >= numPacks;
@@ -113,7 +112,7 @@ const GridDraftPage: React.FC<GridDraftPageProps> = ({ cube, initialDraft, seatN
         submitDeckForm.current?.submit?.();
       }
     })();
-  }, [doneDrafting, gridDraft]);
+  }, [csrfFetch, doneDrafting, gridDraft]);
 
   useEffect(() => {
     if (botDrafterState.turn && draftType === 'bot') {

--- a/src/client/pages/GridDraftPage.tsx
+++ b/src/client/pages/GridDraftPage.tsx
@@ -68,10 +68,9 @@ interface GridDraftPageProps {
   cube: Cube;
   initialDraft: Draft;
   seatNumber?: number;
-  loginCallback?: string;
 }
 
-const GridDraftPage: React.FC<GridDraftPageProps> = ({ cube, initialDraft, seatNumber, loginCallback }) => {
+const GridDraftPage: React.FC<GridDraftPageProps> = ({ cube, initialDraft, seatNumber }) => {
   const { cards } = initialDraft;
   const { csrfFetch } = useContext(CSRFContext);
   const draftType = initialDraft.seats[1].bot ? 'bot' : '2playerlocal';
@@ -126,7 +125,7 @@ const GridDraftPage: React.FC<GridDraftPageProps> = ({ cube, initialDraft, seatN
   }, [draftType, botDrafterState, mutations, botIndex]);
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <DisplayContextProvider cubeID={cube.id}>
         <CubeLayout cube={cube} activeLink="playtest">
           <DynamicFlash />

--- a/src/client/pages/GridDraftPage.tsx
+++ b/src/client/pages/GridDraftPage.tsx
@@ -48,6 +48,7 @@ const useMutatableGridDraft = (initialGridDraft: Draft) => {
   const mutations = fromEntries(
     Object.entries(MUTATIONS).map(([name, mutation]) => [
       name,
+      // eslint-disable-next-line react-hooks/rules-of-hooks
       useCallback(
         ({ seatIndex, cardIndices }: { seatIndex: number; cardIndices: number[][] }) =>
           setGridDraft((oldGridDraft) => {
@@ -57,6 +58,7 @@ const useMutatableGridDraft = (initialGridDraft: Draft) => {
             mutation({ newGridDraft, seatIndex, cardIndices });
             return newGridDraft;
           }),
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [mutation, setGridDraft, cards],
       ),
     ]),

--- a/src/client/pages/ImportRecordPage.tsx
+++ b/src/client/pages/ImportRecordPage.tsx
@@ -237,10 +237,9 @@ const SelectRecordStep: React.FC<SelectRecordStepProps> = ({ cubeId, selectedRec
 
 interface ImportRecordPageProps {
   cards: CardDetails[];
-  loginCallback?: string;
 }
 
-const ImportRecordPage: React.FC<ImportRecordPageProps> = ({ cards, loginCallback = '/' }) => {
+const ImportRecordPage: React.FC<ImportRecordPageProps> = ({ cards }) => {
   const user: User | null = useContext(UserContext);
   const [isYourCube, setIsYourCube] = React.useState(true);
   const [existingRecord, setExistingRecord] = React.useState<boolean>(false);
@@ -251,7 +250,7 @@ const ImportRecordPage: React.FC<ImportRecordPageProps> = ({ cards, loginCallbac
   const [cardState, setCardState] = useState<CardDetails[]>(cards);
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <DynamicFlash />
       <Card className="my-2">
         <CardHeader>

--- a/src/client/pages/InfoPage.tsx
+++ b/src/client/pages/InfoPage.tsx
@@ -15,11 +15,10 @@ interface InfoPageProps {
     text: string;
     table?: [string, string][];
   }[];
-  loginCallback?: string;
 }
 
-const InfoPage: React.FC<InfoPageProps> = ({ title, content, loginCallback }) => (
-  <MainLayout loginCallback={loginCallback}>
+const InfoPage: React.FC<InfoPageProps> = ({ title, content }) => (
+  <MainLayout>
     <Banner />
     <DynamicFlash />
     <Card className="my-3 mx-4">

--- a/src/client/pages/LandingPage.tsx
+++ b/src/client/pages/LandingPage.tsx
@@ -24,12 +24,11 @@ interface LandingPageProps {
   featured: Cube[];
   content: Article[];
   recentDecks: Draft[];
-  loginCallback: string;
 }
 
-const LandingPage: React.FC<LandingPageProps> = ({ featured, recentDecks, content, loginCallback }) => {
+const LandingPage: React.FC<LandingPageProps> = ({ featured, recentDecks, content }) => {
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <CubeSearchNavBar />
       <DynamicFlash />
       <Row className="mt-2">

--- a/src/client/pages/LeaveWarningPage.tsx
+++ b/src/client/pages/LeaveWarningPage.tsx
@@ -10,13 +10,12 @@ import MainLayout from 'layouts/MainLayout';
 
 interface LeaveWarningPageProps {
   url: string;
-  loginCallback?: string;
 }
 
 const back = () => (window.history.length > 1 ? window.history.back() : window.close());
 
-const LeaveWarningPage: React.FC<LeaveWarningPageProps> = ({ url, loginCallback = '/' }) => (
-  <MainLayout loginCallback={loginCallback}>
+const LeaveWarningPage: React.FC<LeaveWarningPageProps> = ({ url }) => (
+  <MainLayout>
     <DynamicFlash />
     <Card className="my-3">
       <CardHeader>

--- a/src/client/pages/LoginPage.tsx
+++ b/src/client/pages/LoginPage.tsx
@@ -24,7 +24,7 @@ const LoginPage: React.FC = () => {
         </CardHeader>
         <CardBody>
           <Flexbox direction="col" gap="2">
-            <LoginForm loginCallback={'/'} formRef={formRef} />
+            <LoginForm formRef={formRef} />
             <Button type="submit" color="primary" block onClick={() => formRef.current?.submit()}>
               Login
             </Button>

--- a/src/client/pages/LoginPage.tsx
+++ b/src/client/pages/LoginPage.tsx
@@ -13,7 +13,7 @@ import MainLayout from 'layouts/MainLayout';
 const LoginPage: React.FC = () => {
   const formRef = React.useRef<HTMLFormElement>(null);
   return (
-    <MainLayout loginCallback={'/'}>
+    <MainLayout>
       <Banner />
       <DynamicFlash />
       <Card className="my-3">

--- a/src/client/pages/LostPasswordPage.tsx
+++ b/src/client/pages/LostPasswordPage.tsx
@@ -8,12 +8,9 @@ import LostPasswordForm from 'components/forms/LostPasswordForm';
 import RenderToRoot from 'components/RenderToRoot';
 import MainLayout from 'layouts/MainLayout';
 
-interface LostPasswordPageProps {
-  loginCallback?: string;
-}
 
-const LostPasswordPage: React.FC<LostPasswordPageProps> = ({ loginCallback = '/' }) => (
-  <MainLayout loginCallback={loginCallback}>
+const LostPasswordPage: React.FC = () => (
+  <MainLayout>
     <Banner />
     <DynamicFlash />
     <Card className="my-3">

--- a/src/client/pages/MarkdownPage.tsx
+++ b/src/client/pages/MarkdownPage.tsx
@@ -12,12 +12,8 @@ import Markdown from 'components/Markdown';
 import RenderToRoot from 'components/RenderToRoot';
 import MainLayout from 'layouts/MainLayout';
 
-interface MarkdownProps {
-  loginCallback?: string;
-}
-
-const MarkdownPage: React.FC<MarkdownProps> = ({ loginCallback = '/' }) => (
-  <MainLayout loginCallback={loginCallback}>
+const MarkdownPage: React.FC = () => (
+  <MainLayout>
     <Banner />
     <DynamicFlash />
     <Card className="my-3 mx-4">
@@ -824,9 +820,5 @@ const MarkdownPage: React.FC<MarkdownProps> = ({ loginCallback = '/' }) => (
     </Card>
   </MainLayout>
 );
-
-MarkdownPage.propTypes = {
-  loginCallback: PropTypes.string,
-};
 
 export default RenderToRoot(MarkdownPage);

--- a/src/client/pages/MarkdownPage.tsx
+++ b/src/client/pages/MarkdownPage.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import PropTypes from 'prop-types';
-
 import Banner from 'components/Banner';
 import { Card, CardBody, CardHeader } from 'components/base/Card';
 import { Col, Flexbox, Row } from 'components/base/Layout';

--- a/src/client/pages/MerchandisePage.tsx
+++ b/src/client/pages/MerchandisePage.tsx
@@ -22,7 +22,6 @@ interface InfoPageProps {
     text: string;
     table?: [string, string][];
   }[];
-  loginCallback?: string;
 }
 
 const products = [
@@ -49,7 +48,7 @@ const products = [
   },
 ];
 
-const InfoPage: React.FC<InfoPageProps> = ({ loginCallback }) => {
+const InfoPage: React.FC = () => {
   const [volume, setVolume] = React.useState<Record<string, number>>(
     Object.fromEntries(products.map((product) => [product.id, 0])),
   );
@@ -73,7 +72,7 @@ const InfoPage: React.FC<InfoPageProps> = ({ loginCallback }) => {
   };
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <Banner />
       <DynamicFlash />
       <Card className="my-3 mx-4">

--- a/src/client/pages/MerchandisePage.tsx
+++ b/src/client/pages/MerchandisePage.tsx
@@ -15,15 +15,6 @@ import MainLayout from 'layouts/MainLayout';
 
 const ConfirmActionButton = withModal(Button, ConfirmActionModal);
 
-interface InfoPageProps {
-  title: string;
-  content: {
-    label: string;
-    text: string;
-    table?: [string, string][];
-  }[];
-}
-
 const products = [
   {
     name: 'Year of the Snake Playmat',

--- a/src/client/pages/NoticePage.tsx
+++ b/src/client/pages/NoticePage.tsx
@@ -28,17 +28,16 @@ interface Notice {
 }
 
 interface NoticePageProps {
-  loginCallback?: string;
   notices: Notice[];
 }
 
-const NoticePage: React.FC<NoticePageProps> = ({ loginCallback = '/', notices }) => {
+const NoticePage: React.FC<NoticePageProps> = ({ notices }) => {
   const applications = notices.filter((notice) => notice.type === NoticeType.APPLICATION);
   const commentReports = notices.filter((notice) => notice.type === NoticeType.COMMENT_REPORT);
   const cubeReports = notices.filter((notice) => notice.type === NoticeType.CUBE_REPORT);
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <DynamicFlash />
       <Card className="my-3">
         <CardHeader>

--- a/src/client/pages/NotificationsPage.tsx
+++ b/src/client/pages/NotificationsPage.tsx
@@ -15,12 +15,11 @@ import MainLayout from 'layouts/MainLayout';
 interface NotificationsPageProps {
   notifications: NotificationType[];
   lastKey?: string;
-  loginCallback?: string;
 }
 
 const PAGE_SIZE = 18;
 
-const NotificationsPage: React.FC<NotificationsPageProps> = ({ notifications, lastKey, loginCallback }) => {
+const NotificationsPage: React.FC<NotificationsPageProps> = ({ notifications, lastKey }) => {
   const [items, setItems] = useState<NotificationType[]>(notifications);
   const { csrfFetch } = useContext(CSRFContext);
   const [currentLastKey, setLastKey] = useState(lastKey);
@@ -69,7 +68,7 @@ const NotificationsPage: React.FC<NotificationsPageProps> = ({ notifications, la
     />
   );
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <Banner />
       <DynamicFlash />
       <Card className="my-3">

--- a/src/client/pages/PackagePage.tsx
+++ b/src/client/pages/PackagePage.tsx
@@ -10,11 +10,10 @@ import CardPackageType from '../../datatypes/CardPackage';
 
 interface PackagePageProps {
   pack: CardPackageType;
-  loginCallback?: string;
 }
 
-const PackagePage: React.FC<PackagePageProps> = ({ pack, loginCallback = '/' }) => (
-  <MainLayout loginCallback={loginCallback}>
+const PackagePage: React.FC<PackagePageProps> = ({ pack }) => (
+  <MainLayout>
     <Banner />
     <DynamicFlash />
     <CardPackage cardPackage={pack} />

--- a/src/client/pages/PackagesPage.tsx
+++ b/src/client/pages/PackagesPage.tsx
@@ -26,12 +26,11 @@ import CardPackageData, { CardPackageStatus } from '../../datatypes/CardPackage'
 const CreatePackageModalLink = withModal(Button, CreatePackageModal);
 
 interface PackagesPageProps {
-  loginCallback?: string;
   items: CardPackageData[];
   lastKey: string | null;
 }
 
-const PackagesPage: React.FC<PackagesPageProps> = ({ loginCallback = '/', items, lastKey }) => {
+const PackagesPage: React.FC<PackagesPageProps> = ({ items, lastKey }) => {
   const user = useContext(UserContext);
   const { csrfFetch } = useContext(CSRFContext);
 
@@ -103,7 +102,7 @@ const PackagesPage: React.FC<PackagesPageProps> = ({ loginCallback = '/', items,
   );
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <Flexbox direction="col" gap="4" className="pb-4">
         <Controls className="p-2">
           <Banner />

--- a/src/client/pages/PasswordResetPage.tsx
+++ b/src/client/pages/PasswordResetPage.tsx
@@ -9,12 +9,11 @@ import RenderToRoot from 'components/RenderToRoot';
 import MainLayout from 'layouts/MainLayout';
 
 interface PasswordResetPageProps {
-  loginCallback?: string;
   code: string;
 }
 
-const PasswordResetPage: React.FC<PasswordResetPageProps> = ({ loginCallback = '/', code }) => (
-  <MainLayout loginCallback={loginCallback}>
+const PasswordResetPage: React.FC<PasswordResetPageProps> = ({ code }) => (
+  <MainLayout>
     <Banner />
     <DynamicFlash />
     <Card className="my-3">

--- a/src/client/pages/PodcastEpisodePage.tsx
+++ b/src/client/pages/PodcastEpisodePage.tsx
@@ -15,13 +15,12 @@ import Episode from 'datatypes/Episode';
 import MainLayout from 'layouts/MainLayout';
 
 interface PodcastEpisodePageProps {
-  loginCallback?: string;
   episode: Episode;
 }
 
-const PodcastEpisodePage: React.FC<PodcastEpisodePageProps> = ({ loginCallback = '/', episode }) => {
+const PodcastEpisodePage: React.FC<PodcastEpisodePageProps> = ({ episode }) => {
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <DynamicFlash />
       <Card className="my-3">
         <CardHeader>

--- a/src/client/pages/PodcastPage.tsx
+++ b/src/client/pages/PodcastPage.tsx
@@ -10,14 +10,13 @@ import PodcastType from 'datatypes/Podcast';
 import MainLayout from 'layouts/MainLayout';
 
 interface PodcastPageProps {
-  loginCallback?: string;
   podcast: PodcastType;
   episodes: Episode[];
 }
 
-const PodcastPage: React.FC<PodcastPageProps> = ({ loginCallback = '/', podcast, episodes }) => {
+const PodcastPage: React.FC<PodcastPageProps> = ({ podcast, episodes }) => {
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <Banner />
       <DynamicFlash />
       <Card className="my-3">

--- a/src/client/pages/PodcastsPage.tsx
+++ b/src/client/pages/PodcastsPage.tsx
@@ -15,7 +15,6 @@ import Podcast from 'datatypes/Podcast';
 import MainLayout from 'layouts/MainLayout';
 
 interface PodcastsPageProps {
-  loginCallback?: string;
   episodes: Episode[];
   podcasts: Podcast[];
   lastKey?: string;
@@ -23,7 +22,7 @@ interface PodcastsPageProps {
 
 const PAGE_SIZE = 24;
 
-const PodcastsPage: React.FC<PodcastsPageProps> = ({ loginCallback = '/', episodes, podcasts, lastKey }) => {
+const PodcastsPage: React.FC<PodcastsPageProps> = ({ episodes, podcasts, lastKey }) => {
   const [items, setItems] = useState(episodes);
   const { csrfFetch } = useContext(CSRFContext);
   const [currentLastKey, setLastKey] = useState(lastKey);
@@ -75,7 +74,7 @@ const PodcastsPage: React.FC<PodcastsPageProps> = ({ loginCallback = '/', episod
   );
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <Banner />
       <DynamicFlash />
       <Card className="my-3">

--- a/src/client/pages/PodcastsPage.tsx
+++ b/src/client/pages/PodcastsPage.tsx
@@ -54,7 +54,7 @@ const PodcastsPage: React.FC<PodcastsPageProps> = ({ episodes, podcasts, lastKey
       }
     }
     setLoading(false);
-  }, [items, currentLastKey, page]);
+  }, [csrfFetch, currentLastKey, items, page]);
 
   const pager = (
     <Pagination
@@ -62,6 +62,7 @@ const PodcastsPage: React.FC<PodcastsPageProps> = ({ episodes, podcasts, lastKey
       active={page}
       hasMore={hasMore}
       onClick={async (newPage) => {
+        // eslint-disable-next-line no-console
         console.log(newPage, pageCount);
         if (newPage >= pageCount) {
           await fetchMoreData();

--- a/src/client/pages/RecentlyUpdateCubesPage.tsx
+++ b/src/client/pages/RecentlyUpdateCubesPage.tsx
@@ -8,18 +8,17 @@ import MainLayout from 'layouts/MainLayout';
 
 interface SearchPageProps {
   items: Cube[];
-  loginCallback?: string;
   lastKey?: string;
   parsedQuery?: string[];
   query?: string;
 }
 
-const SearchPage: React.FC<SearchPageProps> = ({ items, loginCallback, lastKey }) => {
+const SearchPage: React.FC<SearchPageProps> = ({ items, lastKey }) => {
   const [feedItems, setFeedItems] = useState(items);
   const [currentLastKey, setCurrentLastKey] = useState(lastKey);
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <div className="my-3">
         <IndefinitePaginatedList
           items={feedItems}

--- a/src/client/pages/RecordPage.tsx
+++ b/src/client/pages/RecordPage.tsx
@@ -26,10 +26,9 @@ interface RecordPageProps {
   record: Record;
   draft?: Draft;
   players: User[];
-  loginCallback?: string;
 }
 
-const RecordPage: React.FC<RecordPageProps> = ({ cube, record, draft, players, loginCallback = '/' }) => {
+const RecordPage: React.FC<RecordPageProps> = ({ cube, record, draft, players }) => {
   const [activeTab, setActiveTab] = useQueryParam('tab', '0');
   const user = useContext(UserContext);
 
@@ -53,7 +52,7 @@ const RecordPage: React.FC<RecordPageProps> = ({ cube, record, draft, players, l
   ];
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <CubeLayout cube={cube} activeLink="records">
         <DynamicFlash />
         <Card className="my-2">

--- a/src/client/pages/RecordUploadDeckPage.tsx
+++ b/src/client/pages/RecordUploadDeckPage.tsx
@@ -22,10 +22,9 @@ interface RecordUploadDeckPageProps {
   cube: Cube;
   record: Record;
   draft?: Draft;
-  loginCallback?: string;
 }
 
-const RecordUploadDeckPage: React.FC<RecordUploadDeckPageProps> = ({ cube, record, draft, loginCallback = '/' }) => {
+const RecordUploadDeckPage: React.FC<RecordUploadDeckPageProps> = ({ cube, record, draft }) => {
   const formRef = createRef<HTMLFormElement>();
   const [selectedUser, setSelectedUser] = useState<number>(0);
   const [cards, setCards] = useState<CardDetails[]>([]);
@@ -49,7 +48,7 @@ const RecordUploadDeckPage: React.FC<RecordUploadDeckPageProps> = ({ cube, recor
   }, [selectedUser, record.players.length, draft, cards.length]);
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <CubeLayout cube={cube} activeLink="records">
         <DynamicFlash />
         <Card className="my-2">

--- a/src/client/pages/RegisterPage.tsx
+++ b/src/client/pages/RegisterPage.tsx
@@ -11,11 +11,10 @@ import MainLayout from 'layouts/MainLayout';
 interface RegisterPageProps {
   email?: string;
   username?: string;
-  loginCallback?: string;
 }
 
-const RegisterPage: React.FC<RegisterPageProps> = ({ email = '', username = '', loginCallback = '/' }) => (
-  <MainLayout loginCallback={loginCallback}>
+const RegisterPage: React.FC<RegisterPageProps> = ({ email = '', username = '' }) => (
+  <MainLayout>
     <Banner />
     <DynamicFlash />
     <Card className="my-3">

--- a/src/client/pages/ReviewContentPage.tsx
+++ b/src/client/pages/ReviewContentPage.tsx
@@ -17,7 +17,6 @@ interface Document {
 }
 
 interface ReviewContentPageProps {
-  loginCallback?: string;
   content: Document[];
 }
 
@@ -27,9 +26,9 @@ const typeMap = {
   p: 'podcast',
 };
 
-const ReviewContentPage: React.FC<ReviewContentPageProps> = ({ loginCallback = '/', content }) => {
+const ReviewContentPage: React.FC<ReviewContentPageProps> = ({ content }) => {
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <DynamicFlash />
       <Card className="my-3">
         <CardHeader>

--- a/src/client/pages/SearchPage.tsx
+++ b/src/client/pages/SearchPage.tsx
@@ -71,7 +71,7 @@ const SearchPage: React.FC<SearchPageProps> = ({ cubes, lastKey, parsedQuery, qu
       }
     }
     setLoading(false);
-  }, [currentAscending, currentLastKey, currentOrder, currentQuery, items, page]);
+  }, [csrfFetch, currentAscending, currentLastKey, currentOrder, currentQuery, items, page]);
 
   const go = useCallback(
     async (query: string, order: string, ascending: string) => {
@@ -106,7 +106,7 @@ const SearchPage: React.FC<SearchPageProps> = ({ cubes, lastKey, parsedQuery, qu
       }
       setLoading(false);
     },
-    [setCurrentAscending, setCurrentOrder, setCurrentQuery, setCurrentLastKey],
+    [setCurrentQuery, setCurrentOrder, setCurrentAscending, csrfFetch],
   );
 
   const pager = (

--- a/src/client/pages/SearchPage.tsx
+++ b/src/client/pages/SearchPage.tsx
@@ -16,7 +16,6 @@ import MainLayout from 'layouts/MainLayout';
 
 interface SearchPageProps {
   cubes: Cube[];
-  loginCallback?: string;
   lastKey?: string;
   parsedQuery?: string[];
   query?: string;
@@ -24,7 +23,7 @@ interface SearchPageProps {
 
 const PAGE_SIZE = 36;
 
-const SearchPage: React.FC<SearchPageProps> = ({ cubes, loginCallback, lastKey, parsedQuery, query }) => {
+const SearchPage: React.FC<SearchPageProps> = ({ cubes, lastKey, parsedQuery, query }) => {
   const [items, setItems] = useState<Cube[]>(cubes);
   const [currentLastKey, setCurrentLastKey] = useState(lastKey);
   const [loading, setLoading] = useState(false);
@@ -127,7 +126,7 @@ const SearchPage: React.FC<SearchPageProps> = ({ cubes, loginCallback, lastKey, 
   );
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <CubeSearchController
         query={currentQuery}
         order={currentOrder}

--- a/src/client/pages/TopCardsPage.tsx
+++ b/src/client/pages/TopCardsPage.tsx
@@ -4,13 +4,10 @@ import RenderToRoot from 'components/RenderToRoot';
 import TopCardsTable from 'components/TopCardsTable';
 import { FilterContextProvider } from 'contexts/FilterContext';
 import MainLayout from 'layouts/MainLayout';
-interface TopCardsPageProps {
-  loginCallback?: string;
-}
 
-const TopCardsPage: React.FC<TopCardsPageProps> = ({ loginCallback = '/' }) => (
+const TopCardsPage: React.FC = () => (
   <FilterContextProvider>
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <TopCardsTable />
     </MainLayout>
   </FilterContextProvider>

--- a/src/client/pages/UserAccountPage.tsx
+++ b/src/client/pages/UserAccountPage.tsx
@@ -18,7 +18,6 @@ import MainLayout from 'layouts/MainLayout';
 
 interface UserAccountPageProps {
   defaultNav: string;
-  loginCallback?: string;
   patreonClientId: string;
   patreonRedirectUri: string;
   patron?: Patron;
@@ -29,7 +28,6 @@ interface UserAccountPageProps {
 }
 
 const UserAccountPage: React.FC<UserAccountPageProps> = ({
-  loginCallback,
   patreonClientId,
   patreonRedirectUri,
   patron,
@@ -38,7 +36,7 @@ const UserAccountPage: React.FC<UserAccountPageProps> = ({
   const [activeTab, setActiveTab] = useQueryParam('tab', '0');
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <Banner />
       <DynamicFlash />
       <Card className="my-3">

--- a/src/client/pages/UserBlogPage.tsx
+++ b/src/client/pages/UserBlogPage.tsx
@@ -17,7 +17,6 @@ interface UserBlogPageProps {
   followersCount: number;
   following: boolean;
   posts: BlogPostType[];
-  loginCallback?: string;
   lastKey?: string;
 }
 
@@ -28,7 +27,6 @@ const UserBlogPage: React.FC<UserBlogPageProps> = ({
   following,
   posts,
   owner,
-  loginCallback = '/',
   lastKey,
 }) => {
   const [items, setItems] = useState(posts);
@@ -85,7 +83,7 @@ const UserBlogPage: React.FC<UserBlogPageProps> = ({
   );
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <UserLayout user={owner} followersCount={followersCount} following={following} activeLink="blog">
         <DynamicFlash />
         {items.length > 0 ? (

--- a/src/client/pages/UserCubePage.tsx
+++ b/src/client/pages/UserCubePage.tsx
@@ -20,7 +20,6 @@ interface UserCubePageProps {
   followersCount: number;
   following: boolean;
   cubes: Cube[];
-  loginCallback: string;
 }
 
 const UserCubePage: React.FC<UserCubePageProps> = ({
@@ -28,11 +27,10 @@ const UserCubePage: React.FC<UserCubePageProps> = ({
   followersCount,
   following,
   cubes,
-  loginCallback = '/',
 }) => {
   const user = useContext(UserContext);
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <UserLayout user={owner} followersCount={followersCount} following={following} activeLink="view">
         <DynamicFlash />
         <Flexbox direction="col" className="my-3" gap="2">

--- a/src/client/pages/UserDecksPage.tsx
+++ b/src/client/pages/UserDecksPage.tsx
@@ -18,7 +18,6 @@ interface UserDecksPageProps {
   followersCount: number;
   following: boolean;
   decks: Draft[];
-  loginCallback?: string;
   lastKey?: any;
 }
 
@@ -29,7 +28,6 @@ const UserDecksPage: React.FC<UserDecksPageProps> = ({
   following,
   decks,
   owner,
-  loginCallback = '/',
   lastKey,
 }) => {
   const { csrfFetch } = useContext(CSRFContext);
@@ -85,7 +83,7 @@ const UserDecksPage: React.FC<UserDecksPageProps> = ({
   );
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <UserLayout user={owner} followersCount={followersCount} following={following} activeLink="decks">
         <DynamicFlash />
 

--- a/src/client/pages/UserSocialPage.tsx
+++ b/src/client/pages/UserSocialPage.tsx
@@ -16,16 +16,14 @@ interface UserSocialPageProps {
   followedCubes: Cube[];
   followedUsers: User[];
   followers: User[];
-  loginCallback?: string;
 }
 
 const UserSocialPage: React.FC<UserSocialPageProps> = ({
   followedCubes,
   followedUsers,
   followers,
-  loginCallback = '/',
 }) => (
-  <MainLayout loginCallback={loginCallback}>
+  <MainLayout>
     <Banner />
     <DynamicFlash />
     <Row className="my-3">

--- a/src/client/pages/VersionPage.tsx
+++ b/src/client/pages/VersionPage.tsx
@@ -8,12 +8,11 @@ import MainLayout from 'layouts/MainLayout';
 interface VersionPageProps {
   version: string;
   host: string;
-  loginCallback?: string;
 }
 
-const VersionPage: React.FC<VersionPageProps> = ({ version, host, loginCallback = '/' }) => {
+const VersionPage: React.FC<VersionPageProps> = ({ version, host }) => {
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <Card className="my-3">
         <CardHeader>
           <Text semibold lg>

--- a/src/client/pages/VideoPage.tsx
+++ b/src/client/pages/VideoPage.tsx
@@ -8,12 +8,11 @@ import MainLayout from 'layouts/MainLayout';
 import VideoType from '../../datatypes/Video';
 import Video from '../components/content/Video';
 interface VideoPageProps {
-  loginCallback?: string;
   video: VideoType;
 }
 
-const VideoPage: React.FC<VideoPageProps> = ({ loginCallback = '/', video }) => (
-  <MainLayout loginCallback={loginCallback}>
+const VideoPage: React.FC<VideoPageProps> = ({ video }) => (
+  <MainLayout>
     <DynamicFlash />
     <Card className="my-3">
       <Video video={video} />

--- a/src/client/pages/VideosPage.tsx
+++ b/src/client/pages/VideosPage.tsx
@@ -10,17 +10,16 @@ import Video from 'datatypes/Video';
 import MainLayout from 'layouts/MainLayout';
 
 interface VideosPageProps {
-  loginCallback?: string;
   videos: Video[];
   lastKey?: string;
 }
 
-const VideosPage: React.FC<VideosPageProps> = ({ loginCallback = '/', videos, lastKey }) => {
+const VideosPage: React.FC<VideosPageProps> = ({ videos, lastKey }) => {
   const [items, setItems] = useState(videos);
   const [currentLastKey, setLastKey] = useState(lastKey);
 
   return (
-    <MainLayout loginCallback={loginCallback}>
+    <MainLayout>
       <Flexbox direction="col" gap="2" className="my-2">
         <Banner />
         <DynamicFlash />

--- a/src/routes/users_routes.js
+++ b/src/routes/users_routes.js
@@ -8,6 +8,7 @@ const util = require('../util/util');
 const fq = require('../util/featuredQueue');
 import sendEmail from '../util/email';
 const { handleRouteError, render, redirect } = require('../util/render');
+const { getSafeReferrer } = require('../util/util');
 
 // Bring in models
 const User = require('../dynamo/models/user');
@@ -433,11 +434,7 @@ router.post('/login', async (req, res) => {
   }
 
   req.body.username = user.username;
-  // TODO: fix confirmation and check it here.
-  let redirectRoute = '/';
-  if (req.body.loginCallback) {
-    redirectRoute = req.body.loginCallback;
-  }
+  let redirectRoute = getSafeReferrer(req) || '/';
   passport.authenticate('local', {
     successRedirect: redirectRoute,
     failureRedirect: '/user/login',

--- a/src/routes/users_routes.js
+++ b/src/routes/users_routes.js
@@ -434,9 +434,10 @@ router.post('/login', async (req, res) => {
   }
 
   req.body.username = user.username;
-  let redirectRoute = getSafeReferrer(req) || '/';
+  const redirectRoute = getSafeReferrer(req) || '/';
   passport.authenticate('local', {
-    successRedirect: redirectRoute,
+    //Landing is the public default page, dashboard is the logged in one
+    successRedirect: redirectRoute === '/landing' ? '/dashboard' : redirectRoute,
     failureRedirect: '/user/login',
     failureFlash: { type: 'danger' },
   })(req, res, () => {

--- a/src/util/render.js
+++ b/src/util/render.js
@@ -69,7 +69,6 @@ const render = (req, res, page, reactProps = {}, options = {}) => {
       };
     }
 
-    reactProps.loginCallback = req.baseUrl + req.path;
     reactProps.nitroPayEnabled = process.env.NITROPAY_ENABLED === 'true';
     reactProps.baseUrl = utils.getBaseUrl();
     reactProps.captchaSiteKey = process.env.CAPTCHA_SITE_KEY;


### PR DESCRIPTION
The loginCallback wasn't doing anything. Fixed by using safe redirect.

99% of these changes are removing the loginCallback prop

# Testing

## Before

Always sent to dashboard on login
![old-login-always-to-dashboard](https://github.com/user-attachments/assets/10e0e8b4-d48b-4b80-8e43-d17420049d64)

## After

Sent to the page you were on
![new-after-login-return-to-page-you-were-on](https://github.com/user-attachments/assets/92519a67-bb2f-4fd3-846e-a2ff5b86d516)

Exception is when you started on the public landing page, take you to your dashboard on login
![new-landing-login-to-dashboard](https://github.com/user-attachments/assets/a1478aa4-27a2-42f6-b0af-d813f4cf04cb)
