### PR TITLE
Fix double body in post for pasting text into cube

### DIFF
--- a/src/client/components/base/TextArea.tsx
+++ b/src/client/components/base/TextArea.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect,useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import classNames from 'classnames';
 
@@ -38,7 +38,6 @@ const TextArea: React.FC<TextAreaProps> = ({
   disabled = false,
   showCharacterLimit = false,
   maxLength,
-  ...props
 }) => {
   const [textLength, setTextLength] = useState(value !== undefined ? value.length : 0);
 
@@ -88,7 +87,6 @@ const TextArea: React.FC<TextAreaProps> = ({
         rows={rows}
         disabled={disabled}
         maxLength={maxLength}
-        {...props}
       />
       {showCharacterLimit && maxLength ? (
         <div


### PR DESCRIPTION
# Testing

## Before

There are two body values in the post, so on the backend req.body,body is a list and not a string, so when we match() to get lines that function doesn't exist on a list
![old-duplicate-body](https://github.com/user-attachments/assets/6394d0aa-42aa-41f3-8d42-231ab91ac57d)

## After

Import works.
![new-paste-import-working2 gif](https://github.com/user-attachments/assets/16840d6f-95da-40d1-84e1-064cd161fd06)

