### PR TITLE
Only use printed names for English cards.

### DIFF
--- a/src/jobs/utils/update_cards.ts
+++ b/src/jobs/utils/update_cards.ts
@@ -140,17 +140,22 @@ export interface ScryfallSet {
   printed_size?: number;
 }
 
+const ALLOWED_PRINTED_LANGUAGES = ['en'];
+
 export function convertName(card: ScryfallCard, preflipped: boolean) {
-  let str = card.printed_name || card.name;
+  const isAllowedPrintedLanguage = ALLOWED_PRINTED_LANGUAGES.includes(card.lang);
+
+  const nameField = isAllowedPrintedLanguage ? 'printed_name' : 'name';
+  let str = card[nameField] || card.name;
   const faces = card?.card_faces || [];
 
   //In src/jobs/update_cards.ts preflipped cards have their faces reduced to just the backside face
   if (preflipped) {
-    str = faces[0].printed_name || faces[0].name;
+    str = faces[0][nameField] || faces[0].name;
   } else if (card.layout !== 'split' && faces.length > 1) {
     // NOTE: we want split cards to include both names
     // but other double face to use the first name
-    str = faces[0].printed_name || faces[0].name;
+    str = faces[0][nameField] || faces[0].name;
   }
 
   //Trim the card name here before potentially adding art series suffix.

--- a/tests/jobs/update_cards.test.ts
+++ b/tests/jobs/update_cards.test.ts
@@ -89,4 +89,62 @@ describe('convertName', () => {
     const result = convertName(card, false);
     expect(result).toEqual(`SP//dr, Piloted by Peni`);
   });
+
+  it('Non-english printed names arent used', async () => {
+    const card = createScryfallCard('Silvan Library', 'normal');
+    card.printed_name = 'Biblioteca silvana';
+    card.lang = 'es';
+    const result = convertName(card, false);
+    expect(result).toEqual(`Silvan Library`);
+  });
+
+  it('Non-english printed names arent used, multiple faces', async () => {
+    const face = createCardFace('Aclazotz, Deepest Betrayal');
+    face.printed_name = '最深の裏切り、アクロゾズ';
+
+    const face2 = createCardFace('Temple of the Dead');
+    face2.printed_name = '死者の神殿';
+
+    const card = createScryfallCard('Aclazotz, Deepest Betrayal // Temple of the Dead', 'transform', [face, face2]);
+    card.lang = 'jp';
+    const result = convertName(card, false);
+    expect(result).toEqual(`Aclazotz, Deepest Betrayal`);
+
+    //Backsides are only passed the back face
+    const backCard = createScryfallCard('Aclazotz, Deepest Betrayal // Temple of the Dead', 'transform', [face2]);
+    card.lang = 'jp';
+
+    const backResult = convertName(backCard, true);
+    expect(backResult).toEqual(`Temple of the Dead`);
+  });
+
+  it('Phyrexian language isnt real', async () => {
+    const card = createScryfallCard('Phyrexian Arena', 'normal');
+    card.printed_name = '|fyrs,CebDZFst.';
+    card.lang = 'ph';
+    const result = convertName(card, false);
+    expect(result).toEqual(`Phyrexian Arena`);
+  });
+
+  it('Neither is Quenya (Elvish)', async () => {
+    const card = createScryfallCard('Sol ring', 'normal');
+    card.printed_name = ' ';
+    card.lang = 'qya';
+    const result = convertName(card, false);
+    expect(result).toEqual(`Sol ring`);
+  });
+
+  it('Phyrexian language isnt real, card face edition', async () => {
+    const face = createCardFace('Mental mistep');
+    face.printed_name = '|Vgu$e&yl,tFRErt.';
+
+    const face2 = createCardFace('Mental mistep2');
+    face2.printed_name = '|Vgu$e&yl,tFRErt2.';
+
+    const card = createScryfallCard('Phyrexian Arena', 'normal', [face, face2]);
+    card.printed_name = '|fyrs,CebDZFst.';
+    card.lang = 'ph';
+    const result = convertName(card, false);
+    expect(result).toEqual(`Mental mistep`);
+  });
 });


### PR DESCRIPTION
The code feels ugly for me, would love ideas to improve

# Testing
Ran update-cards script each time.

## Before

<img width="893" height="517" alt="old-phryexian-print-text" src="https://github.com/user-attachments/assets/0a3e7204-4d59-4120-9fde-419015662e55" />
<img width="859" height="579" alt="old-fbb-slyvan" src="https://github.com/user-attachments/assets/2bde08bd-ef97-4785-a079-62117e781899" />


## After

<img width="884" height="582" alt="new-phryexian-print-text" src="https://github.com/user-attachments/assets/9158ebc6-1513-4496-a47e-e80d4b9ea28a" />
<img width="824" height="709" alt="new-fbb-sylvan" src="https://github.com/user-attachments/assets/2e349188-dd3b-4a2f-96e0-e32b894f499d" />
