### PR TITLE
Fix Universes Beyond promo types causing reasonable cards to fail

### DIFF
--- a/docs/card-print-decision-making.md
+++ b/docs/card-print-decision-making.md
@@ -25,7 +25,7 @@ The "Reasonableness" of a print is a function that filters the possible printing
 
 The reasonable filter does not have a hard and fast definition. It does it's best to filter out non-standard printings of cards using a variety of checks, but it may not match each individual's perception.
 
-The function itself is `reasonableCard` in [carddb.ts](../src/util/carddb.ts). It depends on the Update cards logic in [update_cards.ts](../src/jobs/update_cards.ts) especially for the `isExtra` field which CubeCobra adds on top of the Scryfall Card fields.
+The function itself is `reasonableCard` in [cardutil.ts](../src/client/utils/cardutil.ts). It depends on the Update cards logic in [update_cards.ts](../src/jobs/update_cards.ts) especially for the `isExtra` field which CubeCobra adds on top of the Scryfall Card fields.
 
 Here is a short summary of what a reasonable card strives to be:
 

--- a/src/client/utils/cardutil.ts
+++ b/src/client/utils/cardutil.ts
@@ -561,6 +561,15 @@ export const cardIsLand = (card: Card): boolean => {
   return cardType(card).includes('Land') || card.colorCategory === 'Lands';
 };
 
+const arePromoTypesReasonable = (card: CardDetailsType): boolean => {
+  return (
+    card.promo_types === undefined ||
+    //Post Omenpaths support (https://scryfall.com/blog/through-the-omenpaths-added-plus-english-printed-text-support-235) ll
+    //UB cards have this promo type
+    (Array.isArray(card.promo_types) && card.promo_types.length === 1 && card.promo_types[0] === 'universesbeyond')
+  );
+};
+
 export function reasonableCard(card: CardDetailsType): boolean {
   return (
     !card.isExtra &&
@@ -568,7 +577,7 @@ export function reasonableCard(card: CardDetailsType): boolean {
     !card.digital &&
     !card.isToken &&
     card.border_color !== 'gold' &&
-    card.promo_types === undefined &&
+    arePromoTypesReasonable(card) &&
     card.language === 'en' &&
     card.tcgplayer_id !== undefined &&
     card.collector_number.indexOf('★') === -1 &&

--- a/src/client/utils/cardutil.ts
+++ b/src/client/utils/cardutil.ts
@@ -561,6 +561,21 @@ export const cardIsLand = (card: Card): boolean => {
   return cardType(card).includes('Land') || card.colorCategory === 'Lands';
 };
 
+export function reasonableCard(card: CardDetailsType): boolean {
+  return (
+    !card.isExtra &&
+    !card.promo &&
+    !card.digital &&
+    !card.isToken &&
+    card.border_color !== 'gold' &&
+    card.promo_types === undefined &&
+    card.language === 'en' &&
+    card.tcgplayer_id !== undefined &&
+    card.collector_number.indexOf('★') === -1 &&
+    card.layout !== 'art_series'
+  );
+}
+
 export const CARD_CATEGORY_DETECTORS: Record<string, (details: CardDetailsType, card?: Card) => boolean> = {
   gold: (details) => details.colors.length > 1 && details.parsed_cost.every((symbol) => !symbol.includes('-')),
   twobrid: (details) => details.parsed_cost.some((symbol) => symbol.includes('-') && symbol.includes('2')),
@@ -572,14 +587,7 @@ export const CARD_CATEGORY_DETECTORS: Record<string, (details: CardDetailsType, 
   firstprint: (details) => !details.reprint,
   firstprinting: (details) => !details.reprint,
   digital: (details) => details.digital,
-  reasonable: (details) =>
-    !details.promo &&
-    !details.digital &&
-    details.border_color !== 'gold' &&
-    details.promo_types === undefined &&
-    details.language === 'en' &&
-    details.tcgplayer_id !== undefined &&
-    details.collector_number.indexOf('★') === -1,
+  reasonable: reasonableCard,
   dfc: (details) => ['transform', 'modal_dfc', 'meld', 'double_faced_token', 'double_sided'].includes(details.layout),
   mdfc: (details) => details.layout === 'modal_dfc',
   meld: (details) => details.layout === 'meld',

--- a/src/jobs/update_cards.ts
+++ b/src/jobs/update_cards.ts
@@ -21,7 +21,6 @@ import { ManaSymbol } from 'datatypes/Mana';
 import * as cardutil from '../client/utils/cardutil';
 import { s3 } from '../dynamo/s3client';
 import { CardMetadata, fileToAttribute } from '../util/cardCatalog';
-import { reasonableCard } from '../util/carddb';
 import * as util from '../util/util';
 import { convertName, ScryfallCard, ScryfallCardFace, ScryfallSet } from './utils/update_cards';
 
@@ -128,7 +127,7 @@ function addCardToCatalog(card: CardDetails, isExtra?: boolean) {
     if (card.image_flip) {
       cardImages.image_flip = card.image_flip;
     }
-    if (reasonableCard(card)) {
+    if (cardutil.reasonableCard(card)) {
       catalog.cardimages[normalizedName] = cardImages;
     }
   }
@@ -608,12 +607,12 @@ const STATIC_CARDS: ScryfallCard[] = [
       usd_foil: null,
       usd_etched: null,
       eur: null,
-      tix: null
+      tix: null,
     },
     image_uris: {
       small: '',
       normal: '/content/custom_card.png',
-      art_crop: '/content/custom_card_art_crop.png'
+      art_crop: '/content/custom_card_art_crop.png',
     },
     card_faces: undefined,
     loyalty: undefined,
@@ -637,7 +636,7 @@ const STATIC_CARDS: ScryfallCard[] = [
       vintage: 'not_legal',
       penny: 'not_legal',
       commander: 'not_legal',
-      brawl: 'not_legal'
+      brawl: 'not_legal',
     },
     layout: 'normal',
     rarity: 'common',
@@ -658,20 +657,25 @@ const STATIC_CARDS: ScryfallCard[] = [
     preview: {
       source: '',
       source_uri: '',
-      previewed_at: ''
+      previewed_at: '',
     },
     related_uris: {
       gatherer: '',
       tcgplayer_decks: '',
       edhrec: '',
-      mtgtop8: ''
+      mtgtop8: '',
     },
     all_parts: [],
-    object: 'card'
-  }
+    object: 'card',
+  },
 ];
 
-function saveStaticCard(card: ScryfallCard, metadata: CardMetadata | undefined, ckPrice: number | undefined, mpPrice: number | undefined) {
+function saveStaticCard(
+  card: ScryfallCard,
+  metadata: CardMetadata | undefined,
+  ckPrice: number | undefined,
+  mpPrice: number | undefined,
+) {
   if (card.layout === 'transform') {
     addCardToCatalog(convertCard(card, metadata, ckPrice, mpPrice, true), true);
   }
@@ -687,12 +691,7 @@ async function saveAllCards(
   // eslint-disable-next-line no-console
   console.info('Processing static cards...');
   for (const staticCard of STATIC_CARDS) {
-    saveStaticCard(
-      staticCard,
-      metadatadict[staticCard.oracle_id],
-      ckPrices[staticCard.id],
-      mpPrices[staticCard.id]
-    );
+    saveStaticCard(staticCard, metadatadict[staticCard.oracle_id], ckPrices[staticCard.id], mpPrices[staticCard.id]);
   }
   // eslint-disable-next-line no-console
   console.info(`Processed ${STATIC_CARDS.length} static cards.`);

--- a/src/util/carddb.ts
+++ b/src/util/carddb.ts
@@ -1,5 +1,5 @@
 import { filterCardsDetails, FilterFunction } from '../client/filtering/FilterCards';
-import { detailsToCard } from '../client/utils/cardutil';
+import { detailsToCard, reasonableCard } from '../client/utils/cardutil';
 import { SortFunctions } from '../client/utils/Sort';
 import { CardDetails, PrintingPreference } from '../datatypes/Card';
 import catalog from './cardCatalog';
@@ -63,21 +63,6 @@ export function cardFromId(id: string): CardDetails {
   }
 
   return details;
-}
-
-export function reasonableCard(card: CardDetails): boolean {
-  return (
-    !card.isExtra &&
-    !card.promo &&
-    !card.digital &&
-    !card.isToken &&
-    card.border_color !== 'gold' &&
-    card.promo_types === undefined &&
-    card.language === 'en' &&
-    card.tcgplayer_id !== undefined &&
-    card.collector_number.indexOf('★') === -1 &&
-    card.layout !== 'art_series'
-  );
 }
 
 export function reasonableId(id: string): boolean {

--- a/tests/cards/carddb.test.ts
+++ b/tests/cards/carddb.test.ts
@@ -29,7 +29,7 @@ jest.mock('../../src/util/cardCatalog', () => {
 
 import { FilterFunction } from '../../src/client/filtering/FilterCards';
 import Card, { CardDetails, PrintingPreference } from '../../src/datatypes/Card';
-import { getMostReasonable, reasonableCard } from '../../src/util/carddb';
+import { getMostReasonable } from '../../src/util/carddb';
 import { createCard, createCardDetails } from '../test-utils/data';
 
 const overridesForNormalDetails: Partial<CardDetails> = {
@@ -44,74 +44,6 @@ const overridesForNormalDetails: Partial<CardDetails> = {
   collector_number: '270',
   layout: 'normal',
 };
-
-describe('reasonableCard', () => {
-  it('Regular details are reasonable', async () => {
-    const details = createCardDetails(overridesForNormalDetails);
-
-    expect(reasonableCard(details)).toBeTruthy();
-  });
-
-  it('Extras are not reasonable', async () => {
-    const details = createCardDetails({ ...overridesForNormalDetails, isExtra: true });
-
-    expect(reasonableCard(details)).toBeFalsy();
-  });
-
-  it('Promos are not reasonable', async () => {
-    const details = createCardDetails({ ...overridesForNormalDetails, promo: true });
-
-    expect(reasonableCard(details)).toBeFalsy();
-  });
-
-  it('Digital cards are not reasonable', async () => {
-    const details = createCardDetails({ ...overridesForNormalDetails, digital: true });
-
-    expect(reasonableCard(details)).toBeFalsy();
-  });
-
-  it('Tokens are not reasonable', async () => {
-    const details = createCardDetails({ ...overridesForNormalDetails, isToken: true });
-
-    expect(reasonableCard(details)).toBeFalsy();
-  });
-
-  it('Gold borders are not reasonable', async () => {
-    const details = createCardDetails({ ...overridesForNormalDetails, border_color: 'gold' });
-
-    expect(reasonableCard(details)).toBeFalsy();
-  });
-
-  it('Promo variants are not reasonable', async () => {
-    const details = createCardDetails({ ...overridesForNormalDetails, promo_types: ['boosterfun'] });
-
-    expect(reasonableCard(details)).toBeFalsy();
-  });
-
-  it('Non-english cards are not reasonable', async () => {
-    const details = createCardDetails({ ...overridesForNormalDetails, language: 'fr' });
-
-    expect(reasonableCard(details)).toBeFalsy();
-  });
-
-  it('Must have TGC player ID to be reasonable', async () => {
-    const details = createCardDetails({ ...overridesForNormalDetails, tcgplayer_id: undefined });
-
-    expect(reasonableCard(details)).toBeFalsy();
-  });
-
-  it('Must not be a promo based on collector number to be reasonable', async () => {
-    const details = createCardDetails({ ...overridesForNormalDetails, collector_number: '177★' });
-
-    expect(reasonableCard(details)).toBeFalsy();
-  });
-
-  it('Must not be an art series card to be reasonable', async () => {
-    const details = createCardDetails({ ...overridesForNormalDetails, layout: 'art_series' });
-
-    expect(reasonableCard(details)).toBeFalsy();
-  });
-});
 
 describe('getMostReasonable', () => {
   afterEach(() => {

--- a/tests/cards/utils.test.ts
+++ b/tests/cards/utils.test.ts
@@ -1,4 +1,4 @@
-import { cardManaSymbols } from '../../src/client/utils/cardutil';
+import { cardManaSymbols, reasonableCard } from '../../src/client/utils/cardutil';
 import {
   getCardCountByColor,
   getCurveByColors,
@@ -6,8 +6,8 @@ import {
   getManaSymbolCount,
   getSourcesDistribution,
 } from '../../src/client/utils/deckutil';
-import Card from '../../src/datatypes/Card';
-import { createBasicLand, createCard, createCardFromDetails } from '../test-utils/data';
+import Card, { CardDetails } from '../../src/datatypes/Card';
+import { createBasicLand, createCard, createCardDetails, createCardFromDetails } from '../test-utils/data';
 
 describe('getManaSymbolCount', () => {
   it('should return the count of each mana symbols found in the deck', () => {
@@ -247,5 +247,86 @@ describe('cardManaSymbols', () => {
     expect(cardManaSymbols(createCardFromDetails({ parsed_cost: ['U-G', 'X-Y'] }))).toEqual([]);
     expect(cardManaSymbols(createCardFromDetails({ parsed_cost: ['G-X', 'G-5'] }))).toEqual([]);
     expect(cardManaSymbols(createCardFromDetails({ parsed_cost: ['X', '2-X'] }))).toEqual([]);
+  });
+});
+
+describe('reasonableCard', () => {
+  const overridesForNormalDetails: Partial<CardDetails> = {
+    isExtra: false,
+    promo: false,
+    digital: false,
+    isToken: false,
+    border_color: 'black',
+    promo_types: undefined,
+    language: 'en',
+    tcgplayer_id: '12345',
+    collector_number: '270',
+    layout: 'normal',
+  };
+
+  it('Regular details are reasonable', async () => {
+    const details = createCardDetails(overridesForNormalDetails);
+
+    expect(reasonableCard(details)).toBeTruthy();
+  });
+
+  it('Extras are not reasonable', async () => {
+    const details = createCardDetails({ ...overridesForNormalDetails, isExtra: true });
+
+    expect(reasonableCard(details)).toBeFalsy();
+  });
+
+  it('Promos are not reasonable', async () => {
+    const details = createCardDetails({ ...overridesForNormalDetails, promo: true });
+
+    expect(reasonableCard(details)).toBeFalsy();
+  });
+
+  it('Digital cards are not reasonable', async () => {
+    const details = createCardDetails({ ...overridesForNormalDetails, digital: true });
+
+    expect(reasonableCard(details)).toBeFalsy();
+  });
+
+  it('Tokens are not reasonable', async () => {
+    const details = createCardDetails({ ...overridesForNormalDetails, isToken: true });
+
+    expect(reasonableCard(details)).toBeFalsy();
+  });
+
+  it('Gold borders are not reasonable', async () => {
+    const details = createCardDetails({ ...overridesForNormalDetails, border_color: 'gold' });
+
+    expect(reasonableCard(details)).toBeFalsy();
+  });
+
+  it('Promo variants are not reasonable', async () => {
+    const details = createCardDetails({ ...overridesForNormalDetails, promo_types: ['boosterfun'] });
+
+    expect(reasonableCard(details)).toBeFalsy();
+  });
+
+  it('Non-english cards are not reasonable', async () => {
+    const details = createCardDetails({ ...overridesForNormalDetails, language: 'fr' });
+
+    expect(reasonableCard(details)).toBeFalsy();
+  });
+
+  it('Must have TGC player ID to be reasonable', async () => {
+    const details = createCardDetails({ ...overridesForNormalDetails, tcgplayer_id: undefined });
+
+    expect(reasonableCard(details)).toBeFalsy();
+  });
+
+  it('Must not be a promo based on collector number to be reasonable', async () => {
+    const details = createCardDetails({ ...overridesForNormalDetails, collector_number: '177★' });
+
+    expect(reasonableCard(details)).toBeFalsy();
+  });
+
+  it('Must not be an art series card to be reasonable', async () => {
+    const details = createCardDetails({ ...overridesForNormalDetails, layout: 'art_series' });
+
+    expect(reasonableCard(details)).toBeFalsy();
   });
 });

--- a/tests/cards/utils.test.ts
+++ b/tests/cards/utils.test.ts
@@ -306,6 +306,18 @@ describe('reasonableCard', () => {
     expect(reasonableCard(details)).toBeFalsy();
   });
 
+  it('Unless the only promo is universes beyond', async () => {
+    const details = createCardDetails({ ...overridesForNormalDetails, promo_types: ['universesbeyond'] });
+
+    expect(reasonableCard(details)).toBeTruthy();
+  });
+
+  it('More promo types on top of UB are not reasonable', async () => {
+    const details = createCardDetails({ ...overridesForNormalDetails, promo_types: ['universesbeyond', 'surgefoil'] });
+
+    expect(reasonableCard(details)).toBeFalsy();
+  });
+
   it('Non-english cards are not reasonable', async () => {
     const details = createCardDetails({ ...overridesForNormalDetails, language: 'fr' });
 


### PR DESCRIPTION
# Testing

## Context

Used jq to export all cards with universesbeyond in the promo_types: `jq '.[] | select(.promo_types | arrays and (contains(["univ
ersesbeyond"])))' cards.json > ../../ub-cards.json`

Grepped for the set name in those cards: `grep "set_name" ub-cards.json | sort | uniq -c`

Gives the following count of cards by set, where they have universesbeyond  promo types. Based on this it looks like all cards in UB type sets have this promo type now.
```
      1   "set_name": "2021 Heroes of the Realm",
      8   "set_name": "Assassin's Creed Tokens",
    309   "set_name": "Assassin's Creed",
    101   "set_name": "Avatar: The Last Airbender Eternal",
    110   "set_name": "Avatar: The Last Airbender",
     64   "set_name": "Doctor Who Tokens",
   1178   "set_name": "Doctor Who",
      3   "set_name": "FIN Asia WPN Promo Tokens",
      2   "set_name": "FIN Standard Showdown",
     22   "set_name": "Fallout Tokens",
   1068   "set_name": "Fallout",
     11   "set_name": "Final Fantasy Commander Tokens",
    486   "set_name": "Final Fantasy Commander",
     94   "set_name": "Final Fantasy Promos",
      2   "set_name": "Final Fantasy Regional Promos",
     37   "set_name": "Final Fantasy Tokens",
    594   "set_name": "Final Fantasy",
     65   "set_name": "Final Fantasy: Through the Ages",
      2   "set_name": "Jurassic World Collection Tokens",
     45   "set_name": "Jurassic World Collection",
      3   "set_name": "MagicFest 2023",
      4   "set_name": "MagicFest 2025",
     40   "set_name": "Marvel Universe",
     26   "set_name": "Marvel's Spider-Man Eternal",
     75   "set_name": "Marvel's Spider-Man Promos",
      7   "set_name": "Marvel's Spider-Man Tokens",
    286   "set_name": "Marvel's Spider-Man",
      8   "set_name": "Media and Collaboration Promos",
      2   "set_name": "Pro Tour Promos",
     21   "set_name": "Ravnica: Clue Edition",
    475   "set_name": "Secret Lair Drop",
      1   "set_name": "Spotlight Series",
      3   "set_name": "Store Championships",
     15   "set_name": "Tales of Middle-earth Commander Tokens",
    591   "set_name": "Tales of Middle-earth Commander",
      4   "set_name": "Tales of Middle-earth Deluxe Commander Kit",
     86   "set_name": "Tales of Middle-earth Promos",
     25   "set_name": "Tales of Middle-earth Tokens",
    856   "set_name": "The Lord of the Rings: Tales of Middle-earth",
      2   "set_name": "Transformers Tokens",
     29   "set_name": "Transformers",
      2   "set_name": "URL/Convention Promos",
    617   "set_name": "Warhammer 40,000 Commander",
     31   "set_name": "Warhammer 40,000 Tokens",
      1   "set_name": "Wizards Play Network 2023",
      4   "set_name": "Wizards Play Network 2025",
```

## Before

From debugging, all 3 versions of the infiltrator are not reasonable. So it chooses the first item in the sorted afterwards, which happens to be the token because they all have the same release date.
![old-infiltrator-token](https://github.com/user-attachments/assets/7084d8f9-305b-41aa-9af6-f2440a3ad973)

## After

Now the token and surgefoil are not reasonable, and the regular print is so its selected by the filtering.
![new-infiltrator-card](https://github.com/user-attachments/assets/362f5975-df09-4a6a-b1ae-a3f934e4ee72)

