### PR TITLE
Fix two errors with getversions

### DIFF
--- a/src/routes/cube/api.js
+++ b/src/routes/cube/api.js
@@ -371,7 +371,7 @@ router.post(
     );
 
     /* Build a map where every name from every version is a key. Necessary because now with printed name changes,
-     * all there can me multiple names across the versions of a card (when grouping by oracle id).
+     * there can be multiple names across the versions of a card (when grouping by oracle id).
      */
     const result = {};
     allVersions.forEach((versions) => {


### PR DESCRIPTION
# Problems

1. If there is a custom card in the cube, the validation rejects the API call because it expects all to be UUID not "custom-card"
2. With the Omenpaths printed name stuff, there can be more than one name for a card (when thinking in terms of all versions for a single oracle id). The response is a map keyed by name, so the alternate printed names were missing. Then when a user switches the card to that differently named version, the UI has no list of versions for that name to populate the UI

# Testing

## Before

With a custom card in my cube, getversions fails
<img width="1041" height="247" alt="old-get-versions-fails-with-custom-card" src="https://github.com/user-attachments/assets/0eb0165b-81b5-430d-bc10-96a9968a4621" />

Once switched to the alternate name version, the versions dropdown is empty
![old-alternate-printed-names-versions-are-missing](https://github.com/user-attachments/assets/c59e562b-9aee-45f7-bdb4-5c30b1685fb9)

## After

With a custom card in my cube, getversions passes
<img width="1212" height="324" alt="new-custom-cards-dont-break-get-versions" src="https://github.com/user-attachments/assets/8f10ba1a-60ac-4ebb-98e0-ddc740553091" />

Versions dropdown is fine after switching to the alternate name version
![new-alternate-printed-names-versions-are-found](https://github.com/user-attachments/assets/b5b43cb3-3b72-45a4-bbc4-3f685e2cd28d)

