### PR TITLE
Allow custom card ids in the validation schemas.

### DIFF
--- a/src/router/routes/api/draftbots/batchpredict.ts
+++ b/src/router/routes/api/draftbots/batchpredict.ts
@@ -18,13 +18,14 @@ export interface PredictResponse {
 }
 
 const OracleIDSchema = Joi.string().uuid();
+const CustomCard = Joi.string().valid('custom-card');
 
 const PredictBodySchema = Joi.object({
   inputs: Joi.array()
     .items(
       Joi.object({
-        pack: Joi.array().items(OracleIDSchema).required(),
-        picks: Joi.array().items(OracleIDSchema).required(),
+        pack: Joi.array().items(OracleIDSchema, CustomCard).required(),
+        picks: Joi.array().items(OracleIDSchema, CustomCard).required(),
       }),
     )
     .required()

--- a/src/router/routes/api/draftbots/predict.ts
+++ b/src/router/routes/api/draftbots/predict.ts
@@ -9,10 +9,11 @@ interface PredictBody {
 }
 
 const OracleIDSchema = Joi.string().uuid();
+const CustomCard = Joi.string().valid('custom-card');
 
 const PredictBodySchema = Joi.object({
-  pack: Joi.array().items(OracleIDSchema).required(),
-  picks: Joi.array().items(OracleIDSchema).required(),
+  pack: Joi.array().items(OracleIDSchema, CustomCard).required(),
+  picks: Joi.array().items(OracleIDSchema, CustomCard).required(),
 });
 
 const validatePredictBody = (req: Request, res: Response, next: NextFunction) => {

--- a/src/router/routes/api/draftmancer/publish.ts
+++ b/src/router/routes/api/draftmancer/publish.ts
@@ -15,6 +15,7 @@ import { buildBotDeck, formatMainboard, formatSideboard, getPicksFromPlayer } fr
 import { setupPicks } from '../../../../util/draftutil';
 import { bodyValidation } from '../../../middleware/bodyValidation';
 
+//Don't expect DraftMancer to handle custom cards
 const OracleIDSchema = Joi.string().uuid();
 
 export const PublishDraftBodySchema = Joi.object({


### PR DESCRIPTION
Discord thread: https://discord.com/channels/592787488523943937/1423402360218189987

Fix validation causing the batch predict to fail. Because custom cards have no data, a bot will randomly choose a card froma pack full of custom cards.

Also because all custom cards have the same id, the deckbuilding goes wonky and only puts a single card into the bots mainboard and then adds lands just for that. Also records the color as C because the assessColors function uses the details color_identity, which is not customizable for custom cards.

# Testing

## Before

Bot predictions immediately fail
<img width="1837" height="715" alt="image" src="https://github.com/user-attachments/assets/89a699c6-2a6e-4b7a-905e-d25859dfcc30" />

## After

Able to complete draft
![new-custom-cards-draft-works](https://github.com/user-attachments/assets/c69e3983-b2cb-4926-892e-73e96b592b15)

Can see pick by pick breakdown
![new-custom-cards-pick-breakdown-works](https://github.com/user-attachments/assets/179c140a-0093-4f3d-9699-5aaf2aa2271f)

Bot
![new-bot-deck-only-one-card-mainboard](https://github.com/user-attachments/assets/38bf3abd-aff3-411c-8b5b-fb1c8c95e1b7)
