### PR TITLE
Don't fallback to the Scryfall image URLs in the CSV export.

### DIFF
--- a/src/routes/cube/helper.js
+++ b/src/routes/cube/helper.js
@@ -187,8 +187,9 @@ function writeCard(res, card, maybe) {
   if (!card.type_line) {
     card.type_line = cardFromId(card.cardID).type;
   }
-  let imgUrl = cardutil.cardImageUrl(card);
-  let imgBackUrl = cardutil.cardImageBackUrl(card);
+  //Explicitly not using cardutil functions here so that we get override images or nothing.
+  //Using cardutil would default to the Scryfall image URLs
+  let { imgUrl, imgBackUrl } = card;
   if (imgUrl) {
     imgUrl = `"${imgUrl}"`;
   } else {


### PR DESCRIPTION
Causes unexpected behaviour after import when changing card versions doesn't change the URL because it is overridden.

Unintended consequence of https://github.com/dekkerglen/CubeCobra/pull/2758

# Testing

## Before

Cards without explicit image overrides have the scryfall image URls printed
<img width="1627" height="139" alt="image" src="https://github.com/user-attachments/assets/84c67911-2617-42e6-975f-8c6dea71b0c7" />

## After

Only explicit image overrides, such as for +2 mace, are in the CSV
<img width="1212" height="141" alt="new-export-image-urls-only-if-override" src="https://github.com/user-attachments/assets/368697cc-dc48-4eee-b760-d6a84d675f02" />
