### PR TITLE
Fix same paging math problem as in #2715

### DIFF
--- a/packages/client/src/pages/SearchPage.tsx
+++ b/packages/client/src/pages/SearchPage.tsx
@@ -63,9 +63,8 @@ const SearchPage: React.FC<SearchPageProps> = ({ cubes, lastKey, parsedQuery, qu
         setCurrentParsedQuery(json.parsedQuery);
 
         const numItemsShowOnLastPage = items.length % PAGE_SIZE;
-        const newItemsShowOnLastPage = newItems.length % PAGE_SIZE;
-
-        if (numItemsShowOnLastPage === 0 && newItemsShowOnLastPage > 0) {
+        //If current page is full and we just fetched more items, then move to next page
+        if (numItemsShowOnLastPage === 0 && json.cubes.length > 0) {
           setPage(page + 1);
         }
         setCurrentLastKey(json.lastKey);


### PR DESCRIPTION
Converting to IndefinitePaginatedList is not straightforward with the search features, so deferring to later.

Same fix was https://github.com/dekkerglen/CubeCobra/pull/2715/files

# Testing

Given the small # of cubes on my local, to test this I temporarily set the page size to 4 instead of 36.

## Before

Two clicks to get to the next page
![old-search-paging-requires-two-clicks](https://github.com/user-attachments/assets/b1b79913-d995-4876-a269-61c5a34cd2fb)

## After

One click
![new-search-paging-one-click](https://github.com/user-attachments/assets/c4f175b1-7877-4075-b168-c4c6783cad0a)
