### PR TITLE
Add newline at the end of the manifests so they pass lint.

### DIFF
--- a/packages/client/generate-manifest.js
+++ b/packages/client/generate-manifest.js
@@ -26,8 +26,8 @@ if (fs.existsSync(distDir)) {
   });
 
   // Write to both dist and server/public directories
-  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
-  fs.writeFileSync(serverPublicManifestPath, JSON.stringify(manifest, null, 2));
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+  fs.writeFileSync(serverPublicManifestPath, JSON.stringify(manifest, null, 2) + '\n');
   console.log('Generated manifest.json with', Object.keys(manifest).length, 'entries');
 
   // Also copy the JS files to server/public/js


### PR DESCRIPTION
Testing

Manifest in branch didn't pass lint, ran generation, and now it passes. I am not committing the manifest changes since it also had a bunch of hash updates and I am not sure why
<img width="1215" height="308" alt="image" src="https://github.com/user-attachments/assets/82b996ef-3e51-4173-9923-4d016ce544ce" />
