### PR TITLE
Use S3 clients with no creds or request signing, in order to access the public buckets.

### DIFF
--- a/packages/server/src/serverutils/downloadModel.ts
+++ b/packages/server/src/serverutils/downloadModel.ts
@@ -1,13 +1,14 @@
-import { S3 } from '@aws-sdk/client-s3';
 import fs from 'fs';
 import path from 'path';
 import { Readable } from 'stream';
 
 import 'dotenv/config';
 
+import { getPublicS3Client } from './s3';
+
 export const downloadModelsFromS3 = async (basePath: string = '', bucket: string, region: string): Promise<void> => {
   // Create S3 client with provided region
-  const s3: S3 = new S3({ region });
+  const s3 = getPublicS3Client(region);
 
   // list all from s3 under s3://{bucket}/model
   const listResult = await s3.listObjectsV2({ Bucket: bucket, Prefix: 'model/' });

--- a/packages/server/src/serverutils/s3.ts
+++ b/packages/server/src/serverutils/s3.ts
@@ -1,0 +1,13 @@
+import { S3 } from '@aws-sdk/client-s3';
+
+export const getPublicS3Client = (region: string): S3 => {
+  //Must set no credentials and disable signing to make anonymous requests to the public bucket
+  //Reference https://github.com/aws/aws-sdk-js-v3/issues/4093#issuecomment-2364084415
+  return new S3({
+    region,
+    // No credentials
+    credentials: { accessKeyId: '', secretAccessKey: '' },
+    // No signing of requests
+    signer: { sign: async (req) => req },
+  });
+};

--- a/packages/server/src/serverutils/updatecards.ts
+++ b/packages/server/src/serverutils/updatecards.ts
@@ -1,9 +1,9 @@
-import { S3 } from '@aws-sdk/client-s3';
 import fs from 'fs';
 
 import 'dotenv/config';
 
 import { fileToAttribute, loadAllFiles } from './cardCatalog';
+import { getPublicS3Client } from './s3';
 
 interface CardManifest {
   checksum: string;
@@ -17,7 +17,7 @@ const getManifestPath = (basePath: string): string => `${basePath}/manifest.json
 
 const downloadManifestFromS3 = async (bucket: string, region: string): Promise<CardManifest | null> => {
   try {
-    const s3 = new S3({ region });
+    const s3 = getPublicS3Client(region);
     const res = await s3.getObject({
       Bucket: bucket,
       Key: 'cards/manifest.json',
@@ -81,7 +81,7 @@ const shouldUpdateCards = (localManifest: CardManifest | null, remoteManifest: C
 const downloadFromS3 = async (basePath: string = 'private', bucket: string, region: string): Promise<void> => {
   console.log('Downloading card database files from S3...');
 
-  const s3 = new S3({ region });
+  const s3 = getPublicS3Client(region);
   await Promise.all(
     Object.keys(fileToAttribute).map(async (file: string) => {
       try {


### PR DESCRIPTION
Without these changes I was still getting credentials errors:
```
Downloading card definitions...
Downloading card database files from S3...
❌ Error downloading data files: CredentialsProviderError: Could not load credentials from any providers
```
All I have in my ~/.aws directory is a config setting default region to us-east-2, so pretty confident those weren't causing an auth issue.

# Testing

## Before

<img width="1223" height="340" alt="image" src="https://github.com/user-attachments/assets/f97bce4c-d745-44ec-8276-72620c418d16" />

## After

<img width="725" height="364" alt="image" src="https://github.com/user-attachments/assets/82075b81-e910-4b66-b8f6-2837c059cd3d" />

Loaded up the site, saw I had the new Turtles cards. Also doing a playtest draft the bot picks made sense (eg fetches first)
