### PR TITLE
feat: use brief description for embed metadata

### DIFF
--- a/packages/server/src/router/routes/cube.ts
+++ b/packages/server/src/router/routes/cube.ts
@@ -125,7 +125,7 @@ export const listHandler = async (req: Request, res: Response) => {
         title: `${abbreviate(cube.name)} - List`,
         metadata: generateMeta(
           `Cube Cobra List: ${cube.name}`,
-          cube.description,
+          cube.brief,
           cube.image.uri,
           `${baseUrl}/cube/list/${req.params.id}`,
         ),
@@ -160,7 +160,7 @@ export const historyHandler = async (req: Request, res: Response) => {
         title: `${abbreviate(cube.name)} - List`,
         metadata: generateMeta(
           `Cube Cobra List: ${cube.name}`,
-          cube.description,
+          cube.brief,
           cube.image.uri,
           `${baseUrl}/cube/list/${req.params.id}`,
         ),

--- a/packages/server/src/router/routes/cube/about.ts
+++ b/packages/server/src/router/routes/cube/about.ts
@@ -105,7 +105,7 @@ export const aboutHandler = async (req: Request, res: Response) => {
         title: `${abbreviate(cube.name)} - About`,
         metadata: generateMeta(
           `Cube Cobra: ${cube.name}`,
-          cube.description,
+          cube.brief,
           cube.image.uri,
           `${baseUrl}/cube/about/${req.params.id}`,
         ),

--- a/packages/server/src/router/routes/cube/deck.ts
+++ b/packages/server/src/router/routes/cube/deck.ts
@@ -808,7 +808,7 @@ export const getDeckHandler = async (req: Request, res: Response) => {
         title: `Draft deck of ${abbreviate(cube.name)}`,
         metadata: generateMeta(
           `Cube Cobra Deck: ${cube.name}`,
-          cube.description,
+          cube.brief,
           cube.image.uri,
           `${baseUrl}/cube/deck/${req.params.id}`,
         ),

--- a/packages/server/src/router/routes/cube/griddraft.ts
+++ b/packages/server/src/router/routes/cube/griddraft.ts
@@ -41,7 +41,7 @@ export const gridDraftHandler = async (req: Request, res: Response) => {
         title: `${abbreviate(cube.name)} - Grid Draft`,
         metadata: generateMeta(
           `Cube Cobra Grid Draft: ${cube.name}`,
-          cube.description,
+          cube.brief,
           cube.image.uri,
           `${baseUrl}/cube/griddraft/${req.params.id}`,
         ),

--- a/packages/server/src/router/routes/cube/playtest.ts
+++ b/packages/server/src/router/routes/cube/playtest.ts
@@ -46,7 +46,7 @@ export const playtestHandler = async (req: Request, res: Response) => {
         title: `${abbreviate(cube.name)} - Playtest`,
         metadata: generateMeta(
           `Cube Cobra Playtest: ${cube.name}`,
-          cube.description,
+          cube.brief,
           cube.image.uri,
           `${baseUrl}/cube/playtest/${req.params.id}`,
         ),

--- a/packages/server/src/router/routes/cube/records.ts
+++ b/packages/server/src/router/routes/cube/records.ts
@@ -40,7 +40,7 @@ export const recordsPageHandler = async (req: Request, res: Response) => {
         title: `${abbreviate(cube.name)} - Records`,
         metadata: generateMeta(
           `Cube Cobra Records: ${cube.name}`,
-          cube.description,
+          cube.brief,
           cube.image.uri,
           `${baseUrl}/cube/records/${req.params.id}`,
         ),

--- a/packages/server/src/router/routes/cube/records/create.ts
+++ b/packages/server/src/router/routes/cube/records/create.ts
@@ -46,7 +46,7 @@ export const createRecordPageHandler = async (req: Request, res: Response) => {
         title: `${abbreviate(cube.name)} - Create Record`,
         metadata: generateMeta(
           `Cube Cobra Create Record: ${cube.name}`,
-          cube.description,
+          cube.brief,
           cube.image.uri,
           `${req.protocol}://${req.get('host')}/cube/records/create/${cube.id}`,
         ),

--- a/packages/server/src/router/routes/draft.ts
+++ b/packages/server/src/router/routes/draft.ts
@@ -40,7 +40,7 @@ const handler = async (req: Request, res: Response) => {
         title: `${abbreviate(cube.name)} - Draft`,
         metadata: generateMeta(
           `Cube Cobra Draft: ${cube.name}`,
-          cube.description,
+          cube.brief,
           cube.image.uri,
           `${baseUrl}/draft/${encodeURIComponent(req.params.id!)}`,
         ),

--- a/packages/server/src/router/routes/draft/deckbuilder.ts
+++ b/packages/server/src/router/routes/draft/deckbuilder.ts
@@ -52,7 +52,7 @@ const handler = async (req: Request, res: Response) => {
         title: `${abbreviate(cube.name)} - Deckbuilder`,
         metadata: generateMeta(
           `Cube Cobra Draft: ${cube.name}`,
-          cube.description,
+          cube.brief,
           cube.image.uri,
           `${baseUrl}/draft/deckbuilder/${req.params.id}`,
         ),

--- a/packages/server/src/serverutils/meta.ts
+++ b/packages/server/src/serverutils/meta.ts
@@ -5,7 +5,7 @@ interface MetaTag {
 
 const generateMeta = (
   title: string,
-  description: string,
+  description: string | undefined,
   image: string,
   url: string,
   width?: string | number,
@@ -18,7 +18,7 @@ const generateMeta = (
     },
     {
       property: 'og:description',
-      content: description,
+      content: description || '',
     },
     {
       property: 'og:image',
@@ -46,7 +46,7 @@ const generateMeta = (
     },
     {
       property: 'twitter:description',
-      content: description,
+      content: description || '',
     },
     {
       property: 'twitter:image',


### PR DESCRIPTION
Could maybe fallback to the original description for a while while people update their lists, but meh.

I didn't see any tests specifically related to this, but I'll check the CI logs and see if anything pops up.