### PR TITLE
fix: revert card grid sizing changes for small displays

### DIFF
--- a/packages/client/src/components/Pack.tsx
+++ b/packages/client/src/components/Pack.tsx
@@ -69,7 +69,7 @@ const Pack: React.FC<PackProps> = ({
                 <div className="spinner" />
               </div>
             ) : (
-              <Row className="g-0" xs={2} sm={3} md={4} lg={5} xl={6} xxl={8}>
+              <Row className="g-0" md={4} lg={5} xl={6} xxl={8}>
                 {pack.map((card, index) => {
                   const isHighestRated = ratings && ratings[index] === maxRating;
                   return (

--- a/packages/client/src/components/p1p1/P1P1PackDisplay.tsx
+++ b/packages/client/src/components/p1p1/P1P1PackDisplay.tsx
@@ -130,8 +130,6 @@ const P1P1PackDisplay: React.FC<P1P1PackDisplayProps> = ({ pack, votes, showBotW
       {/* When showing bot weights, don't highlight user selection - only show top bot pick in blue */}
       <CardGrid
         cards={cards}
-        xs={2}
-        sm={3}
         md={4}
         lg={5}
         xl={6}

--- a/packages/client/src/pages/DailyP1P1HistoryPage.tsx
+++ b/packages/client/src/pages/DailyP1P1HistoryPage.tsx
@@ -107,8 +107,7 @@ const DailyP1P1HistoryPage: React.FC<DailyP1P1HistoryPageProps> = ({
 
                       <CardGrid
                         cards={cards}
-                        xs={2}
-                        sm={3}
+                        xs={3}
                         md={4}
                         lg={5}
                         xl={6}


### PR DESCRIPTION
Pack was using sm=4 so this just gets back to that, but defined at the medium breakpoint.
See original changes in #2830