### PR TITLE
feat: allow urls in cube compare input, fix submit behavior

### DIFF
--- a/packages/client/src/components/modals/CubeCompareModal.tsx
+++ b/packages/client/src/components/modals/CubeCompareModal.tsx
@@ -18,7 +18,11 @@ const CubeCompareModal: React.FC<CubeCompareModalProps> = ({ isOpen, setOpen }) 
 
   const handleCompare = () => {
     // Extract the Cube ID from the input, accounting for possible URL formats.
-    const [ input ] = compareID.split('?')[0].trim().match(/[^/]+(?=\/$|$)/) || [];
+    const [input] =
+      compareID
+        .split('?')[0]
+        .trim()
+        .match(/[^/]+(?=\/$|$)/) || [];
     if (input) {
       window.location.href = `/cube/compare/${cube.id}/to/${input}`;
     }


### PR DESCRIPTION
- `onKeyPress` is flagged as deprecated, so just swapping that out since it didn't seem to be working.
- Pattern extraction on the Compare field input to allow for copy/pasting entire Cube URLs instead of having to trim to just the identifier.

While poking around at this I also realized that there isn't any validation on what you can set your `shortId` to. Did a few tests just to see if I could get any kind of truly risky behavior out of it, but wasn't seeing anything _too_ bad.

Some special characters and stuff like `foo/bar` will just result in a broken url, which can be a bit difficult to correct if you don't have your full ID handy.