### PR TITLE
Limit workflows to run only on dekkerglen/CubeCobra.

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   lint:
+    if: github.repository == 'dekkerglen/CubeCobra'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -37,6 +38,7 @@ jobs:
         run: npm run lint:check
 
   test:
+    if: github.repository == 'dekkerglen/CubeCobra'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/build-card-update-monitor-lambda.yml
+++ b/.github/workflows/build-card-update-monitor-lambda.yml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   build-card-update-monitor-lambda:
+    if: github.repository == 'dekkerglen/CubeCobra'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/build-cdk.yml
+++ b/.github/workflows/build-cdk.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   build-cdk:
+    if: github.repository == 'dekkerglen/CubeCobra'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   build-client:
+    if: github.repository == 'dekkerglen/CubeCobra'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/build-daily-jobs-lambda.yml
+++ b/.github/workflows/build-daily-jobs-lambda.yml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   build-daily-jobs-lambda:
+    if: github.repository == 'dekkerglen/CubeCobra'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/build-recommender-service.yml
+++ b/.github/workflows/build-recommender-service.yml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   build-recommender-service:
+    if: github.repository == 'dekkerglen/CubeCobra'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/build-server.yml
+++ b/.github/workflows/build-server.yml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   build-server:
+    if: github.repository == 'dekkerglen/CubeCobra'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -14,6 +14,7 @@ jobs:
   comment:
     # Only run on pull requests and when the test job succeeded
     if: >
+      github.repository == 'dekkerglen/CubeCobra' &&
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Mainly annoying that pulling to sync on my fork triggers a workflow that often will fail. Plus all the builds are not useful.

Workflows used to have this condition