### PR TITLE
Postcss prettier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cubecobra",
-  "version": "1.4.60",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cubecobra",
-      "version": "1.4.60",
+      "version": "1.5.0",
       "license": "ISC",
       "workspaces": [
         "packages/*"
@@ -13219,6 +13219,20 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@blakeembrey/deque": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@blakeembrey/deque/-/deque-1.0.5.tgz",
+      "integrity": "sha512-6xnwtvp9DY1EINIKdTfvfeAtCYw4OqBZJhtiqkT3ivjnEfa25VQ3TsKvaFfKm8MyGIEfE95qLe+bNEt3nB0Ylg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@blakeembrey/template": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@blakeembrey/template/-/template-1.2.0.tgz",
+      "integrity": "sha512-w/63nURdkRPpg3AXbNr7lPv6HgOuVDyefTumiXsbXxtIwcuk5EXayWR5OpSwDjsQPgaYsfUSedMduaNOjAYY8A==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@clinic/bubbleprof": {
       "version": "10.0.0",
@@ -44186,6 +44200,32 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onchange": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/onchange/-/onchange-7.1.0.tgz",
+      "integrity": "sha512-ZJcqsPiWUAUpvmnJri5TPBooqJOPmC0ttN65juhN15Q8xA+Nbg3BaxBHXQ45EistKKlKElb0edmbPWnKSBkvMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@blakeembrey/deque": "^1.0.5",
+        "@blakeembrey/template": "^1.0.0",
+        "arg": "^4.1.3",
+        "chokidar": "^3.3.1",
+        "cross-spawn": "^7.0.1",
+        "ignore": "^5.1.4",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "onchange": "dist/bin.js"
+      }
+    },
+    "node_modules/onchange/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -53245,6 +53285,16 @@
         "tslib": "2"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/treeverse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/treeverse/-/treeverse-3.0.0.tgz",
@@ -59508,6 +59558,7 @@
         "file-loader": "^6.2.0",
         "mini-css-extract-plugin": "^2.9.0",
         "mocha": "^10.4.0",
+        "onchange": "^7.1.0",
         "postcss-cli": "^11.0.1",
         "postcss-loader": "^8.1.1",
         "style-loader": "^4.0.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -51,7 +51,7 @@
     "uuid": "^9.0.1"
   },
   "scripts": {
-    "tailwind": "npx postcss ./src/css/stylesheet.css -o ../server/public/css/stylesheet.css --watch",
+    "tailwind": "onchange -a -i './src/css/stylesheet.css' -- npm run tailwind:build",
     "tailwind:build": "npx postcss ./src/css/stylesheet.css -o ../server/public/css/stylesheet.css && npx prettier --write ../server/public/css/stylesheet.css",
     "start": "npm run tailwind & webpack serve",
     "build": "cross-env NODE_ENV=production npm run tailwind:build && cross-env NODE_ENV=production webpack && node generate-manifest.js",
@@ -94,6 +94,7 @@
     "file-loader": "^6.2.0",
     "mini-css-extract-plugin": "^2.9.0",
     "mocha": "^10.4.0",
+    "onchange": "^7.1.0",
     "postcss-cli": "^11.0.1",
     "postcss-loader": "^8.1.1",
     "style-loader": "^4.0.0",

--- a/packages/server/public/css/stylesheet.css
+++ b/packages/server/public/css/stylesheet.css
@@ -833,6 +833,9 @@ a:not(.block):not([class*='block']):not(.flex):not([class*='flex']) {
 .bottom-\[5\%\] {
   bottom: 5%;
 }
+.bottom-full {
+  bottom: 100%;
+}
 .left-0 {
   left: 0px;
 }
@@ -856,6 +859,9 @@ a:not(.block):not([class*='block']):not(.flex):not([class*='flex']) {
 }
 .top-4 {
   top: 1rem;
+}
+.top-full {
+  top: 100%;
 }
 .isolate {
   isolation: isolate;
@@ -1732,6 +1738,9 @@ a:not(.block):not([class*='block']):not(.flex):not([class*='flex']) {
 .rounded-br-none {
   border-bottom-right-radius: 0px;
 }
+.rounded-tr-none {
+  border-top-right-radius: 0px;
+}
 .border {
   border-width: 1px;
 }
@@ -2137,9 +2146,6 @@ a:not(.block):not([class*='block']):not(.flex):not([class*='flex']) {
   padding-top: 3px;
   padding-bottom: 3px;
 }
-.pb-0 {
-  padding-bottom: 0px;
-}
 .pb-1 {
   padding-bottom: 0.25rem;
 }
@@ -2303,10 +2309,6 @@ a:not(.block):not([class*='block']):not(.flex):not([class*='flex']) {
 .\!text-link {
   --tw-text-opacity: 1 !important;
   color: rgb(var(--link) / var(--tw-text-opacity)) !important;
-}
-.\!text-link-active {
-  --tw-text-opacity: 1 !important;
-  color: rgb(var(--link-active) / var(--tw-text-opacity)) !important;
 }
 .\!text-text {
   --tw-text-opacity: 1 !important;


### PR DESCRIPTION
Use onchange instead of postcss watch, so that we can run prettier right away on the generated CSS.

I was annoyed that each time I ran my dev environment the public CSS had changes because it wasn't prettiered.