### PR TITLE
Blog post links need `rel="nofollow"` to stop spam

### DIFF
--- a/packages/client/src/components/Markdown.tsx
+++ b/packages/client/src/components/Markdown.tsx
@@ -76,6 +76,7 @@ const renderLink: React.FC<RenderLinkProps> = (node) => {
     <ExternalLink
       className="font-medium text-link hover:text-link-active"
       href={`/leave?url=${encodeURIComponent(ref)}`}
+      rel="nofollow"
       modalprops={{ link: ref }}
     >
       {node.children}


### PR DESCRIPTION
Fixes https://github.com/dekkerglen/CubeCobra/issues/2846