### PR TITLE
Update Playtest data page to match cube analytic format.

### DIFF
--- a/packages/client/src/analytics/PlaytestData.tsx
+++ b/packages/client/src/analytics/PlaytestData.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useMemo } from 'react';
 
 import { cardName, cardNameLower, cardOracleId, encodeName, mainboardRate, pickRate } from '@utils/cardutil';
 import Card, { DefaultElo } from '@utils/datatypes/Card';
+import CubeAnalytic from '@utils/datatypes/CubeAnalytic';
 import { fromEntries } from '@utils/Util';
 
 import { Flexbox } from '../components/base/Layout';
@@ -10,18 +11,8 @@ import { SortableTable } from '../components/SortableTable';
 import withAutocard from '../components/WithAutocard';
 import CubeContext from '../contexts/CubeContext';
 
-interface CubeAnalytics {
-  [oracle_id: string]: {
-    elo: number;
-    mainboards: number;
-    sideboards: number;
-    picks: number;
-    passes: number;
-  };
-}
-
 interface PlaytestDataProps {
-  cubeAnalytics: CubeAnalytics;
+  cubeAnalytics: CubeAnalytic;
 }
 
 const AutocardItem = withAutocard('div');
@@ -53,12 +44,12 @@ const PlaytestData: React.FC<PlaytestDataProps> = ({ cubeAnalytics }) => {
 
   const data = useMemo(
     () =>
-      Object.entries(cubeAnalytics)
-        .filter(([oracle]) => cardDict[oracle])
-        .map(([oracle, { elo, mainboards, sideboards, picks, passes }]) => ({
+      cubeAnalytics.cards
+        .filter(({ cardName: oracle }) => cardDict[oracle!])
+        .map(({ cardName: oracle, elo, mainboards, sideboards, picks, passes }) => ({
           card: {
-            exportValue: cardName(cardDict[oracle]),
-            ...cardDict[oracle],
+            exportValue: cardName(cardDict[oracle!]),
+            ...cardDict[oracle!],
           },
           elo: Math.round(elo || DefaultElo),
           mainboard: mainboardRate({ mainboards: mainboards || 0, sideboards: sideboards || 0 }),


### PR DESCRIPTION
# Problem

The cube analytic format changed. No longer a map of oracle id to object, now is an array of objects where the value has cardName which is actually the oracle id.

# Testing

I exported the cubeAnalyticsfrom https://cubecobra.com/cube/analysis/kvatchstart?view=playtest-data (randomly selected) using `JSON.stringify(window.reactProps.cubeAnalytics)`. Then uploaded that to my local s3 bucket for a cube that had no analytics (all my existing analytics are in the old format with oracle id as the map key)

## Before

Nothing displayed from the data
<img width="1367" height="564" alt="image" src="https://github.com/user-attachments/assets/ee380f46-0863-40a8-b017-eed3ef4a602d" />

## After

Can see and filter data
<img width="1788" height="592" alt="image" src="https://github.com/user-attachments/assets/d820e4c0-bc8b-4cbc-9a3a-8004f8a702cb" />

Can download the CSV
<img width="718" height="305" alt="image" src="https://github.com/user-attachments/assets/2ce0004a-bdf0-4e82-8ec6-cced329f6f3b" />
