### PR TITLE
Show settings nav on mobile for collaborators

### DIFF
--- a/packages/client/src/components/cube/CubeBottomNav.tsx
+++ b/packages/client/src/components/cube/CubeBottomNav.tsx
@@ -93,7 +93,16 @@ const CubeBottomNav: React.FC<CubeBottomNavProps> = ({ cube, activeLink }) => {
       ].includes(activeLink);
     }
     if (key === 'settings') {
-      return ['settings', 'overview', 'options', 'collaborators', 'boards-and-views', 'custom-sorts', 'draft-formats', 'restore'].includes(activeLink);
+      return [
+        'settings',
+        'overview',
+        'options',
+        'collaborators',
+        'boards-and-views',
+        'custom-sorts',
+        'draft-formats',
+        'restore',
+      ].includes(activeLink);
     }
     return activeLink === key;
   };

--- a/packages/client/src/components/cube/MobileSubNav.tsx
+++ b/packages/client/src/components/cube/MobileSubNav.tsx
@@ -87,7 +87,16 @@ const MobileSubNav: React.FC<MobileSubNavProps> = ({ cube: _cubeProp, activeLink
       { key: 'combos', label: 'Combos' },
     ];
   } else if (
-    ['settings', 'overview', 'options', 'collaborators', 'boards-and-views', 'custom-sorts', 'draft-formats', 'restore'].includes(activeLink)
+    [
+      'settings',
+      'overview',
+      'options',
+      'collaborators',
+      'boards-and-views',
+      'custom-sorts',
+      'draft-formats',
+      'restore',
+    ].includes(activeLink)
   ) {
     parentKey = 'settings';
     subItems = [
@@ -172,7 +181,16 @@ const MobileSubNav: React.FC<MobileSubNavProps> = ({ cube: _cubeProp, activeLink
     // Special handling for Settings sub-items
     if (parentKey === 'settings' && settingsViewContext) {
       if (
-        ['settings', 'overview', 'options', 'collaborators', 'boards-and-views', 'custom-sorts', 'draft-formats', 'restore'].includes(activeLink)
+        [
+          'settings',
+          'overview',
+          'options',
+          'collaborators',
+          'boards-and-views',
+          'custom-sorts',
+          'draft-formats',
+          'restore',
+        ].includes(activeLink)
       ) {
         e.preventDefault();
         settingsViewContext.setView(subItem.key);


### PR DESCRIPTION
- CubeBottomNav: show gear icon for canEdit users (not just owners)
- CubeBottomNav: add collaborators/draft-formats to settings active-check
- MobileSubNav: add collaborators/draft-formats to sub-nav items and click handler