### PR TITLE
Fix deck build save

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,5 +39,7 @@ Since 1.6.0
 - Fixed list view selections persisting incorrectly after removing cards — when cards were removed via "Edit Selected" → "Remove all" → "Save Changes," the checked state used stale card indices, causing a different card to appear selected after the commit
 - Improved draft creation error messages — instead of the generic "no cards in board" message, errors now distinguish between a board having no cards at all, running out of cards mid-draft (with the original count and a suggestion to add more cards or reduce players/packs), and having remaining cards that don't match a slot filter (with the filter text and card counts)
 - Improved date display — dates within the last 7 days now show relative time (e.g. "3 hours ago"), while older dates show an absolute format (e.g. "Feb 7, 2026")
+- Fixed Cube card count not updating in the hero as mainboard changes were saved
+- Fixed problem selecting cards with accented charcters (eg Lórien) when adding to a draft record for cards in the cube
 
 # Technical Changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,5 +41,6 @@ Since 1.6.0
 - Improved date display — dates within the last 7 days now show relative time (e.g. "3 hours ago"), while older dates show an absolute format (e.g. "Feb 7, 2026")
 - Fixed Cube card count not updating in the hero as mainboard changes were saved
 - Fixed problem selecting cards with accented charcters (eg Lórien) when adding to a draft record for cards in the cube
+- Fixed deckbuild limits not saving
 
 # Technical Changes

--- a/packages/client/src/pages/CubeDraftPage.tsx
+++ b/packages/client/src/pages/CubeDraftPage.tsx
@@ -176,7 +176,10 @@ const CubeDraftPage: React.FC<CubeDraftPageProps> = ({ cube, draft }) => {
       }
     } catch (err) {
       console.error('endDraft error caught:', err);
-      addAlert('danger', 'Error finishing draft, please reach out to the Discord');
+      addAlert(
+        'danger',
+        'Error finishing draft, please reach out to the Discord linking the cube, draft, and a screenshot',
+      );
       setDraftStatus((prev) => ({ ...prev, loading: false, draftCompleted: false }));
     }
   }, [csrfFetch, draft.id, mainboard, userPicksInOrder, sideboard, state, setDraftStatus, trashboard, addAlert]);

--- a/packages/server/src/dynamo/dao/CubeDynamoDao.ts
+++ b/packages/server/src/dynamo/dao/CubeDynamoDao.ts
@@ -118,6 +118,8 @@ export interface UnhydratedCube {
   disableGrid?: boolean; // Disable grid draft format
   disableMultiplayer?: boolean; // Disable multiplayer draft format
   basicsBoard?: string; // Board to use for basics in draft (default: 'Basics', or 'None' for no basics)
+  deckbuildSpells?: number; // Max non-land cards in bot-built decks (default 23)
+  deckbuildLands?: number; // Max non-basic lands in bot-built decks (default 17)
   tags: any[];
   keywords: string[];
   cardCount: number;
@@ -247,6 +249,8 @@ export class CubeDynamoDao extends BaseDynamoDao<Cube, UnhydratedCube> {
       disableGrid: item.disableGrid,
       disableMultiplayer: item.disableMultiplayer,
       basicsBoard: item.basicsBoard,
+      deckbuildSpells: item.deckbuildSpells,
+      deckbuildLands: item.deckbuildLands,
       tags: item.tags,
       keywords: item.keywords,
       cardCount: item.cardCount,


### PR DESCRIPTION
Probably causing myself rebase issues by not being able to stack this on top of https://github.com/dekkerglen/CubeCobra/pull/2888 =(

# Testing

## Before

Cube doesn't have deck build limit settings on page load. Then modify and save
<img width="639" height="679" alt="old-before-save" src="https://github.com/user-attachments/assets/7441b468-097e-4fea-bf33-9bb3a8cf662d" />

Save successful, but still no limit settings persisted
<img width="523" height="910" alt="old-after-save" src="https://github.com/user-attachments/assets/b07bfdd2-2690-49da-ab8b-0e63a6fdb135" />

## After

Values are persisted
<img width="537" height="488" alt="new-deckbuild-items-saved" src="https://github.com/user-attachments/assets/6e212780-5000-4e04-9205-5aa2d83ec8e2" />
