### PR TITLE
fixed small cube search bug

### DIFF
--- a/packages/server/src/dynamo/dao/CubeDynamoDao.ts
+++ b/packages/server/src/dynamo/dao/CubeDynamoDao.ts
@@ -1614,21 +1614,21 @@ export class CubeDynamoDao extends BaseDynamoDao<Cube, UnhydratedCube> {
         const filteredCubes = this.filterByCardCount(cubes, cardCountFilter);
 
         matchingCubes.push(...filteredCubes);
-
-        // Return with pagination key for next query
-        // Note: Results are already sorted by the GSI query
-        return {
-          items: matchingCubes,
-          lastKey: candidatesResult.lastKey,
-        };
       }
 
-      // No matches in this page, continue to next page
       currentLastKey = candidatesResult.lastKey;
 
       if (!currentLastKey) {
         // No more pages to check
         break;
+      }
+
+      // If we have results, return them
+      if (matchingCubes.length > 0) {
+        return {
+          items: matchingCubes,
+          lastKey: currentLastKey,
+        };
       }
     }
 
@@ -1643,7 +1643,7 @@ export class CubeDynamoDao extends BaseDynamoDao<Cube, UnhydratedCube> {
     // Return whatever we found (might be empty)
     return {
       items: matchingCubes,
-      lastKey: undefined,
+      lastKey: currentLastKey,
     };
   }
 
@@ -1719,42 +1719,62 @@ export class CubeDynamoDao extends BaseDynamoDao<Cube, UnhydratedCube> {
         gsiPK = 'GSI1PK';
     }
 
-    const params: QueryCommandInput = {
-      TableName: this.tableName,
-      IndexName: indexName,
-      KeyConditionExpression: `${gsiPK} = :hash`,
-      ExpressionAttributeValues: {
-        ':hash': hash,
-      },
-      ScanIndexForward: ascending,
-      Limit: limit,
-      ExclusiveStartKey: lastKey,
-    };
+    const targetLimit = limit || 36;
+    const matchingCubes: Cube[] = [];
+    let currentLastKey = lastKey;
+    const MAX_PAGES = 10;
+    let pagesChecked = 0;
 
-    // Query hash rows
-    const queryResult = await this.dynamoClient.send(new QueryCommand(params));
+    // When filtering by card count, we need to loop through DynamoDB pages
+    // until we accumulate enough matching results, since the filter is applied
+    // after fetching and may discard most items from each page.
+    while (matchingCubes.length < targetLimit && pagesChecked < MAX_PAGES) {
+      pagesChecked += 1;
 
-    if (!queryResult.Items || queryResult.Items.length === 0) {
-      return { items: [] };
+      const params: QueryCommandInput = {
+        TableName: this.tableName,
+        IndexName: indexName,
+        KeyConditionExpression: `${gsiPK} = :hash`,
+        ExpressionAttributeValues: {
+          ':hash': hash,
+        },
+        ScanIndexForward: ascending,
+        Limit: cardCountFilter ? targetLimit * 3 : targetLimit,
+        ExclusiveStartKey: currentLastKey,
+      };
+
+      const queryResult = await this.dynamoClient.send(new QueryCommand(params));
+
+      if (!queryResult.Items || queryResult.Items.length === 0) {
+        // No more results in DynamoDB
+        return { items: matchingCubes };
+      }
+
+      const cubeIds = queryResult.Items.map((item) => {
+        const pk = item.PK as string;
+        return pk.replace('HASH#CUBE#', '');
+      });
+
+      const cubes = await this.batchGet(cubeIds);
+      const filteredCubes = this.filterByCardCount(cubes, cardCountFilter);
+      matchingCubes.push(...filteredCubes);
+
+      currentLastKey = queryResult.LastEvaluatedKey;
+
+      if (!currentLastKey) {
+        // No more pages available
+        return { items: matchingCubes };
+      }
+
+      // If no card count filter, one page is sufficient
+      if (!cardCountFilter) {
+        break;
+      }
     }
 
-    // Extract cube IDs from hash rows
-    const cubeIds = queryResult.Items.map((item) => {
-      // PK contains the cube partition key: HASH#CUBE#{id}
-      const pk = item.PK as string;
-      // Remove 'HASH#CUBE#' prefix to get the cube ID
-      return pk.replace('HASH#CUBE#', '');
-    });
-
-    // Fetch cubes
-    const cubes = await this.batchGet(cubeIds);
-
-    // Apply card count filter if provided
-    const filteredCubes = this.filterByCardCount(cubes, cardCountFilter);
-
     return {
-      items: filteredCubes,
-      lastKey: queryResult.LastEvaluatedKey || undefined,
+      items: matchingCubes.slice(0, targetLimit),
+      lastKey: currentLastKey,
     };
   }
 


### PR DESCRIPTION
searching by size had buggy implementation: rather than returning all cubes regardless of size, size=# returns matching cubes, but the results only display by page.                        
                                                                                
For example Size=180, sorted by popularity, only returns the 180 card cubes on the first page of all popular cubes (3 in this case). Clicking Next Page adds the matching cubes from the next page, and so forth. The larger problem is that, if a cube size isn't on the front page (such as with Size=96), it will return no results with no option to go to the next page.     

**Root Cause**:
                                                                                
In queryByHashWithSort (CubeDynamoDao.ts:1689), the size filter (filterByCardCount) was applied after fetching a fixed page of results from DynamoDB. The flow was:                                                       
                                                                  
1. DynamoDB returns 36 items (the Limit)
2. filterByCardCount removes non-matching cubes, potentially leaving 0-3 results                                                                       
3. The lastKey cursor still advances past those 36 items        
4. The client receives few/no results per page, explaining both symptoms:
- Size=180: Only 3 matching cubes on the first DynamoDB page are returned, more appear when clicking "Next" (which fetches the next DynamoDB page)       
- Size=96: Zero matching cubes on the first DynamoDB page → "No Results" with no pagination                                                            
                                                                  
**Fix (two changes in CubeDynamoDao.ts)**:
                                                                  
1. queryByHashWithSort now loops through multiple DynamoDB pages when a cardCountFilter is active, accumulating results until it has enough (up to limit) or exhausts the data. Also fetches 3x the limit per DynamoDB page when filtering to reduce round trips

2. queryByMultipleHashes now has a fix for an early-return bug where the method would return immediately after finding hash-matching cubes even if filterByCardCount eliminated all of them. Now continues paging when the card count filter is active and no results have accumulated yet