### PR TITLE
Mix boards capability

### DIFF
--- a/packages/client/src/components/settings/BoardsAndViewsSettings.tsx
+++ b/packages/client/src/components/settings/BoardsAndViewsSettings.tsx
@@ -472,8 +472,32 @@ const BoardsAndViewsSettings: React.FC = () => {
                 )}
               </div>
 
-              {/* Board Order */}
+              {/* Mix boards rather than show separately */}
               {editingViewDraft.boards.length > 1 && (
+                <div>
+                  <Text sm className="font-medium mb-2">
+                    Mix boards
+                  </Text>
+                  <Text xs className="text-text-secondary">
+                    Show included boards as though it were one single board
+                  </Text>
+                  <div className="grid grid-cols-1 gap-2">
+                    <Checkbox
+                      key={'mix'}
+                      label="Mix"
+                      checked={editingViewDraft.mixBoards ?? false}
+                      setChecked={() =>
+                        setEditingViewDraft((view) => {
+                          return { ...view!, mixBoards: !view?.mixBoards };
+                        })
+                      }
+                    />
+                  </div>
+                </div>
+              )}
+
+              {/* Board Order */}
+              {editingViewDraft.boards.length > 1 && !editingViewDraft.mixBoards && (
                 <div>
                   <Flexbox direction="col" gap="1" className="mb-2">
                     <Text sm className="font-medium">

--- a/packages/client/src/pages/CubeListPage.tsx
+++ b/packages/client/src/pages/CubeListPage.tsx
@@ -167,6 +167,42 @@ const CubeListPageRaw: React.FC = () => {
           });
           const showBoardHeaders = activeBoards.length > 1;
 
+          if (currentView?.mixBoards) {
+            const boardname = activeBoards.flatMap((b) => b[0]).join('');
+            const boardcards = activeBoards.flatMap((b) => b[1]);
+            const displayBoardName = activeBoards
+              .flatMap((b) => b[0].charAt(0).toUpperCase() + b[0].slice(1))
+              .join(' & ');
+            return (
+              <ErrorBoundary key={boardname}>
+                <Flexbox direction="col" gap="2">
+                  {showBoardHeaders && boardcards.length > 0 && (
+                    <div className="mt-6 mb-4">
+                      <h2 className="text-3xl font-bold text-center mb-3">{displayBoardName}</h2>
+                      <hr className="border-t border-border w-full" />
+                    </div>
+                  )}
+                  {boardcards.length === 0 && !showAllBoards && (
+                    <Text semibold md className="text-center mt-4">
+                      This board appears to be empty!
+                    </Text>
+                  )}
+                  {
+                    {
+                      table: <TableView cards={boardcards} />,
+                      spoiler: <VisualSpoiler cards={boardcards} />,
+                      curve: <CurveView cards={boardcards} />,
+                      list: <ListView cards={boardcards} />,
+                      stacks: (
+                        <CardStacksView cards={boardcards} formatLabel={(label, count) => `${label} (${count})`} />
+                      ),
+                    }[cubeView]
+                  }
+                </Flexbox>
+              </ErrorBoundary>
+            );
+          }
+
           return Object.entries(changedCards)
             .sort(([a], [b]) => {
               const aIndex = viewBoards.indexOf(a.toLowerCase());

--- a/packages/utils/src/datatypes/Cube.ts
+++ b/packages/utils/src/datatypes/Cube.ts
@@ -37,6 +37,7 @@ export interface ViewDefinition {
   boards: string[]; // Array of board keys to display in this view
   displayView: CubeDisplayView; // Default display mode
   defaultSorts: string[]; // 4 sort options
+  mixBoards?: boolean; // Mix the boards in the view rather than show them separately
   defaultFilter?: string; // Optional default filter query
 }
 


### PR DESCRIPTION
My cubes are 180 cards each, with the ability to put both halves together. I'd like to view them as though they were one single list or as individual lists. This PR adds the ability to view them as one single list.  
I'm not sure if this will cause issues with saving or selecting cards on the now-combined board, or if there's some other reason this wasn't done.