### PR TITLE
misc: reduce /tool/card page size by stripping unused card details

### DIFF
--- a/packages/server/src/router/routes/tool/card.ts
+++ b/packages/server/src/router/routes/tool/card.ts
@@ -1,5 +1,5 @@
 import cardutil from '@utils/cardutil';
-import { PrintingPreference } from '@utils/datatypes/Card';
+import { CardDetails, PrintingPreference } from '@utils/datatypes/Card';
 import { Period } from '@utils/datatypes/History';
 import { cardHistoryDao } from 'dynamo/daos';
 import carddb, {
@@ -17,6 +17,25 @@ import { getBaseUrl } from 'serverutils/util';
 import { validate as uuidValidate } from 'uuid';
 
 import { Request, Response } from '../../../types/express';
+
+// Strip unnecssary Card fields that are not used by this view.
+const trimRelatedCards = (related: Record<string, CardDetails[]>): Record<string, Partial<CardDetails>[]> => {
+  const trimCard = (card: CardDetails): Partial<CardDetails> => ({
+    scryfall_id: card.scryfall_id,
+    name: card.name,
+    image_normal: card.image_normal,
+    image_flip: card.image_flip,
+    image_small: card.image_small,
+    type: card.type,
+    cmc: card.cmc,
+    colorcategory: card.colorcategory,
+    rarity: card.rarity,
+  });
+
+  return Object.fromEntries(
+    Object.entries(related).map(([key, cards]) => [key, cards.map(trimCard)]),
+  );
+};
 
 const chooseIdFromInput = (req: Request): string => {
   //ID is scryfall id or a card name (eg. via Autocomplete hover)
@@ -100,9 +119,9 @@ export const getCardHandler = async (req: Request, res: Response) => {
         history: history.items ? history.items.reverse() : [],
         lastKey: history.lastKey,
         versions,
-        draftedWith: related.draftedWith,
-        cubedWith: related.cubedWith,
-        synergistic: related.synergistic,
+        draftedWith: related.draftedWith ? trimRelatedCards(related.draftedWith) : {},
+        cubedWith: related.cubedWith ? trimRelatedCards(related.cubedWith) : {},
+        synergistic: related.synergistic ? trimRelatedCards(related.synergistic) : {},
       },
       {
         title: `${card.name}`,

--- a/packages/server/src/router/routes/tool/card.ts
+++ b/packages/server/src/router/routes/tool/card.ts
@@ -32,9 +32,7 @@ const trimRelatedCards = (related: Record<string, CardDetails[]>): Record<string
     rarity: card.rarity,
   });
 
-  return Object.fromEntries(
-    Object.entries(related).map(([key, cards]) => [key, cards.map(trimCard)]),
-  );
+  return Object.fromEntries(Object.entries(related).map(([key, cards]) => [key, cards.map(trimCard)]));
 };
 
 const chooseIdFromInput = (req: Request): string => {

--- a/packages/server/src/router/routes/tool/cardjson.ts
+++ b/packages/server/src/router/routes/tool/cardjson.ts
@@ -83,6 +83,7 @@ export const getCardJsonHandler = async (req: Request, res: Response) => {
       ? oracleVersions.filter((cid) => cid !== card.scryfall_id).map((cardid) => cardFromId(cardid))
       : [];
 
+    // TODO: Consider adding a query param to allow consumers to opt in to a full vs trimmed response.
     return res.json({
       card,
       history: history.items ? history.items.reverse() : [],


### PR DESCRIPTION
This could be taken further - some of these fields are still probably unnecessary, but just in some local tests this was reducing the minified size of reactProps by about 75% and the page size by ~60%.

I didn't touch the `/tool/cardjson` endpoint, but left a note there in case that's something worth doing in the future. I'm not totally clear on what intended consumers of that might be doing.

There are also some other places where this kind of activity might be valuable too - The `user` props, for example, has all of the user's cubes, which while it doesn't contain the full card list does contain stuff like the cube's custom draft formats, custom tags, custom filters/sorts, etc even when there's not a benefit for the active page to have that information.

EDIT: Oh, just to jot it down, I was running into some issues with the newly upgraded `uuid@14` package. It looks like they dropped support for commonjs at some point, which is still used with how the local docker dev environment runs. I downgraded locally just to get around it, but that's not a real solution.