### PR TITLE
fix: don't show button loading spinner when opening new tab

### DIFF
--- a/packages/client/src/components/base/Button.tsx
+++ b/packages/client/src/components/base/Button.tsx
@@ -41,6 +41,12 @@ const ButtonLink: React.FC<ButtonLinkProps> = ({
       return;
     }
 
+    // Don't show spinner when opening in a new tab (modifier keys)
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) {
+      onClick?.(e);
+      return;
+    }
+
     setLoading(true); // Set loading state to true to prevent further clicks
     onClick?.(e); // Fire side effects (e.g. analytics) before navigation
     //Allow default anchor behaviour to take effect


### PR DESCRIPTION
Buttons apply a spinner while waiting on the router, but that shouldn't be applied when leaving the page. There might be a few more places where this applies, need to check if external links work