### PR TITLE
feat: enhance changelog point-in-time behavior

### DIFF
--- a/packages/client/src/components/blog/BlogPost.tsx
+++ b/packages/client/src/components/blog/BlogPost.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 
-import { PencilIcon, TrashIcon } from '@primer/octicons-react';
+import { EyeIcon, PencilIcon, TrashIcon } from '@primer/octicons-react';
 import BlogPostData from '@utils/datatypes/BlogPost';
 import User from '@utils/datatypes/User';
 
@@ -10,6 +10,7 @@ import Datetime from 'components/base/Datetime';
 import { Col, Flexbox, Row } from 'components/base/Layout';
 import Link from 'components/base/Link';
 import Text from 'components/base/Text';
+import Tooltip from 'components/base/Tooltip';
 import BlogPostChangelog from 'components/blog/BlogPostChangelog';
 import CommentsSection from 'components/comments/CommentsSection';
 import EditBlogModal from 'components/EditBlogModal';
@@ -46,6 +47,15 @@ const BlogPost: React.FC<BlogPostProps> = ({ post, className, noScroll = false }
               </Flexbox>
             </Text>
             <Flexbox direction="row" gap="2">
+              {post.changelist && (
+                <Tooltip text="View cube at this point in time" wrapperTag="span">
+                  <Link href={`/cube/changelog/${post.cube}/${post.changelist}/list`}>
+                    <Button color="accent">
+                      <EyeIcon size={16} />
+                    </Button>
+                  </Link>
+                </Tooltip>
+              )}
               {canEdit && (
                 <>
                   <EditBlogButton color="primary" modalprops={{ cubeID: post.cube, post }}>

--- a/packages/client/src/components/cube/CubeHistory.tsx
+++ b/packages/client/src/components/cube/CubeHistory.tsx
@@ -5,6 +5,7 @@ import { EyeIcon } from '@primer/octicons-react';
 import Button from 'components/base/Button';
 import { Card, CardBody, CardHeader } from 'components/base/Card';
 import { Col, Flexbox, Row } from 'components/base/Layout';
+import Input from 'components/base/Input';
 import Link from 'components/base/Link';
 import Spinner from 'components/base/Spinner';
 import Text from 'components/base/Text';
@@ -95,6 +96,17 @@ const CubeHistory: React.FC<CubeHistoryProps> = ({ changes, lastKey }) => {
     setLoading(false);
   }, [currentLastKey, safeItems, page, csrfFetch]);
 
+  const [dateValue, setDateValue] = useState(() => {
+    const now = new Date();
+    return now.toISOString().split('T')[0];
+  });
+
+  const handleDateJump = useCallback(() => {
+    if (!dateValue || !cube?.id) return;
+    const dateMs = new Date(dateValue).getTime();
+    window.location.href = `/cube/changelog/${cube.id}/at?date=${dateMs}`;
+  }, [dateValue, cube?.id]);
+
   const pager = (
     <Pagination
       count={pageCount}
@@ -125,6 +137,21 @@ const CubeHistory: React.FC<CubeHistoryProps> = ({ changes, lastKey }) => {
 
   return (
     <Flexbox direction="col" gap="2">
+      <Flexbox direction="row" justify="end" alignItems="center" className="w-full" gap="2">
+        <Text sm className="text-text-secondary">
+          Jump to a Point in Time
+        </Text>
+        <div className="max-w-32">
+          <Input
+            type="date"
+            value={dateValue}
+            onChange={(e) => setDateValue(e.target.value)}
+          />
+        </div>
+        <Button color="accent" type="button" onClick={handleDateJump}>
+          Go
+        </Button>
+      </Flexbox>
       <Flexbox direction="row" justify="between" alignItems="center" className="w-full">
         <Text lg semibold>
           Changes ({safeItems.length}

--- a/packages/client/src/components/cube/CubeHistory.tsx
+++ b/packages/client/src/components/cube/CubeHistory.tsx
@@ -1,10 +1,14 @@
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
+import { EyeIcon } from '@primer/octicons-react';
+
+import Button from 'components/base/Button';
 import { Card, CardBody, CardHeader } from 'components/base/Card';
 import { Col, Flexbox, Row } from 'components/base/Layout';
 import Link from 'components/base/Link';
 import Spinner from 'components/base/Spinner';
 import Text from 'components/base/Text';
+import Tooltip from 'components/base/Tooltip';
 import BlogPostChangelog from 'components/blog/BlogPostChangelog';
 import { CSRFContext } from 'contexts/CSRFContext';
 import CubeContext from 'contexts/CubeContext';
@@ -133,11 +137,18 @@ const CubeHistory: React.FC<CubeHistoryProps> = ({ changes, lastKey }) => {
           safeItems.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE).map((changelog) => (
             <Card className="mb-2" key={changelog.date}>
               <CardHeader>
-                <Link href={`/cube/changelog/${changelog.cubeId}/${changelog.id}`}>
-                  <Text semibold sm>
-                    {formatDateTime(new Date(changelog.date))}
-                  </Text>
-                </Link>
+                <Flexbox direction="row" justify="between" alignItems="center">
+                  <Link href={`/cube/changelog/${changelog.cubeId}/${changelog.id}`}>
+                    <Text semibold sm>
+                      {formatDateTime(new Date(changelog.date))}
+                    </Text>
+                  </Link>
+                  <Tooltip text="View cube at this point in time" wrapperTag="span">
+                    <Button color="accent" type="link" href={`/cube/changelog/${changelog.cubeId}/${changelog.id}/list`}>
+                      <EyeIcon size={14} />
+                    </Button>
+                  </Tooltip>
+                </Flexbox>
               </CardHeader>
               <div style={{ overflow: 'auto', maxHeight: '20vh' }}>
                 <CardBody>
@@ -156,12 +167,19 @@ const CubeHistory: React.FC<CubeHistoryProps> = ({ changes, lastKey }) => {
             {safeItems.length > 0 ? (
               evens.map((changelog) => (
                 <Card className="my-2" key={changelog.date}>
-                  <CardHeader className="text-right">
-                    <Link href={`/cube/changelog/${changelog.cubeId}/${changelog.id}`}>
-                      <Text semibold sm>
-                        {formatDateTime(new Date(changelog.date))}
-                      </Text>
-                    </Link>
+                  <CardHeader>
+                    <Flexbox direction="row" justify="between" alignItems="center">
+                      <Link href={`/cube/changelog/${changelog.cubeId}/${changelog.id}`}>
+                        <Text semibold sm>
+                          {formatDateTime(new Date(changelog.date))}
+                        </Text>
+                      </Link>
+                      <Tooltip text="View cube at this point in time" wrapperTag="span">
+                        <Button color="accent" type="link" href={`/cube/changelog/${changelog.cubeId}/${changelog.id}/list`}>
+                          <EyeIcon size={14} />
+                        </Button>
+                      </Tooltip>
+                    </Flexbox>
                   </CardHeader>
                   <div style={{ overflow: 'auto', height: '15vh' }}>
                     <CardBody>
@@ -179,11 +197,18 @@ const CubeHistory: React.FC<CubeHistoryProps> = ({ changes, lastKey }) => {
             {odds.map((changelog) => (
               <Card className="my-2" key={changelog.date}>
                 <CardHeader>
-                  <Link href={`/cube/changelog/${changelog.cubeId}/${changelog.id}`}>
-                    <Text semibold sm>
-                      {formatDateTime(new Date(changelog.date))}
-                    </Text>
-                  </Link>
+                  <Flexbox direction="row" justify="between" alignItems="center">
+                    <Link href={`/cube/changelog/${changelog.cubeId}/${changelog.id}`}>
+                      <Text semibold sm>
+                        {formatDateTime(new Date(changelog.date))}
+                      </Text>
+                    </Link>
+                    <Tooltip text="View cube at this point in time" wrapperTag="span">
+                      <Button color="accent" type="link" href={`/cube/changelog/${changelog.cubeId}/${changelog.id}/list`}>
+                        <EyeIcon size={14} />
+                      </Button>
+                    </Tooltip>
+                  </Flexbox>
                 </CardHeader>
                 <div style={{ overflow: 'auto', height: '15vh' }}>
                   <CardBody>

--- a/packages/client/src/pages/ApiDocsPage.tsx
+++ b/packages/client/src/pages/ApiDocsPage.tsx
@@ -267,6 +267,11 @@ const ApiDocsPage: React.FC = () => (
                   <Param name=":id" type="path" required>
                     Cube UUID or short ID / custom slug
                   </Param>
+                  <Param name="date" type="query">
+                    Unix timestamp in milliseconds. When provided, returns the cube as it was at the nearest
+                    changelog at or before this date. Response includes a <InlineCode>changelog</InlineCode> field
+                    with the resolved changelog ID and date.
+                  </Param>
                 </>
               }
               responseExample={`{
@@ -292,6 +297,7 @@ const ApiDocsPage: React.FC = () => (
     ],
     "maybeboard": [ ... ]
   },
+  "changelog": { "id": "abc123", "date": 1710460800000 },
   "maybe": [ ... ],
   "tag_colors": [ ... ],
   "default_sorts": ["Color Category", "Types-Multicolor", "Mana Value", "Alphabetical"]
@@ -299,7 +305,9 @@ const ApiDocsPage: React.FC = () => (
               notes={
                 <Text sm className="text-text-secondary">
                   Cards are sorted by the default sort (Color Category → Types-Multicolor → Mana Value → Alphabetical).
-                  All boards are always returned regardless of cube visibility settings.
+                  All boards are always returned regardless of cube visibility settings. The{' '}
+                  <InlineCode>changelog</InlineCode> field is only present when the <InlineCode>date</InlineCode>{' '}
+                  query parameter is used.
                 </Text>
               }
             />
@@ -315,6 +323,10 @@ const ApiDocsPage: React.FC = () => (
                 <>
                   <Param name=":id" type="path" required>
                     Cube UUID or short ID
+                  </Param>
+                  <Param name="date" type="query">
+                    Unix timestamp in milliseconds. When provided, returns card names from the cube at the nearest
+                    changelog at or before this date.
                   </Param>
                 </>
               }

--- a/packages/client/src/pages/CubeChangelogPage.tsx
+++ b/packages/client/src/pages/CubeChangelogPage.tsx
@@ -47,27 +47,28 @@ const CubeChangelogPage: React.FC<CubeChangelogPageProps> = ({ cube, changelog }
             </Flexbox>
             <Card>
               <CardHeader>
-                <Text lg semibold>
-                  Changes &mdash; {formatDateTime(new Date(changelog.date))}
-                </Text>
+                <Flexbox direction="row" justify="between" alignItems="center" wrap="wrap" gap="2">
+                  <Text lg semibold>
+                    Changes &mdash; {formatDateTime(new Date(changelog.date))}
+                  </Text>
+                  <Flexbox direction="row" gap="2" wrap="wrap">
+                    <Button color="accent" type="link" href={`/cube/changelog/${cube.id}/${changelog.id}/list`}>
+                      View Cube
+                    </Button>
+                    <Button color="primary" type="button" onClick={handleDownload} disabled={downloading}>
+                      {downloading ? 'Downloading...' : 'Download Cube'}
+                    </Button>
+                    <Button
+                      color="secondary"
+                      type="link"
+                      href={`/cube/changelog/${cube.id}/${changelog.id}/compare`}
+                    >
+                      Compare with Present
+                    </Button>
+                  </Flexbox>
+                </Flexbox>
               </CardHeader>
               <CardBody>
-                <Flexbox direction="row" gap="2" className="mb-4" alignItems="center" wrap="wrap">
-                  <Button color="accent" outline type="link" href={`/cube/changelog/${cube.id}/${changelog.id}/list`}>
-                    View Point in Time Cube List
-                  </Button>
-                  <Button color="primary" outline type="button" onClick={handleDownload} disabled={downloading}>
-                    {downloading ? 'Downloading...' : 'Download Point in Time Cube'}
-                  </Button>
-                  <Button
-                    color="secondary"
-                    outline
-                    type="link"
-                    href={`/cube/changelog/${cube.id}/${changelog.id}/compare`}
-                  >
-                    Compare Point in Time Cube with Present
-                  </Button>
-                </Flexbox>
                 <BlogPostChangelog changelog={changelog.changelog} />
               </CardBody>
             </Card>

--- a/packages/client/src/pages/CubeChangelogPage.tsx
+++ b/packages/client/src/pages/CubeChangelogPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React from 'react';
 
 import { CubeChangeLog } from '@utils/datatypes/ChangeLog';
 import Cube from '@utils/datatypes/Cube';
@@ -22,18 +22,6 @@ interface CubeChangelogPageProps {
 }
 
 const CubeChangelogPage: React.FC<CubeChangelogPageProps> = ({ cube, changelog }) => {
-  const [downloading, setDownloading] = useState(false);
-
-  const handleDownload = useCallback(async () => {
-    setDownloading(true);
-    try {
-      window.location.href = `/cube/changelog/${cube.id}/${changelog.id}/download`;
-    } finally {
-      // Give the browser a moment to start the download before clearing state
-      setTimeout(() => setDownloading(false), 3000);
-    }
-  }, [cube.id, changelog.id]);
-
   return (
     <MainLayout useContainer={false}>
       <DisplayContextProvider cubeID={cube.id}>
@@ -53,10 +41,7 @@ const CubeChangelogPage: React.FC<CubeChangelogPageProps> = ({ cube, changelog }
                   </Text>
                   <Flexbox direction="row" gap="2" wrap="wrap">
                     <Button color="accent" type="link" href={`/cube/changelog/${cube.id}/${changelog.id}/list`}>
-                      View Cube
-                    </Button>
-                    <Button color="primary" type="button" onClick={handleDownload} disabled={downloading}>
-                      {downloading ? 'Downloading...' : 'Download Cube'}
+                      View List
                     </Button>
                     <Button
                       color="secondary"

--- a/packages/client/src/pages/CubePITListPage.tsx
+++ b/packages/client/src/pages/CubePITListPage.tsx
@@ -1,9 +1,11 @@
-import React, { useContext, useMemo } from 'react';
+import React, { useCallback, useContext, useMemo, useState } from 'react';
 
 import Card from '@utils/datatypes/Card';
 import Cube from '@utils/datatypes/Cube';
 
+import Button from 'components/base/Button';
 import Container from 'components/base/Container';
+import Input from 'components/base/Input';
 import { Flexbox } from 'components/base/Layout';
 import Link from 'components/base/Link';
 import Text from 'components/base/Text';
@@ -41,9 +43,27 @@ const CubePITListInner: React.FC<{ date: string; changelogId: string }> = ({ dat
 
   const [cubeView, setCubeView] = useQueryParam('display', 'table');
 
+  // Date picker state — default to the active snapshot's date
+  const [dateValue, setDateValue] = useState(() => {
+    // The `date` prop is a localized date string (e.g. "5/22/2026"); parse it back to YYYY-MM-DD
+    const parsed = new Date(date);
+    if (!isNaN(parsed.getTime())) {
+      return parsed.toISOString().split('T')[0];
+    }
+    return new Date().toISOString().split('T')[0];
+  });
+
+  const handleDateJump = useCallback(() => {
+    if (!dateValue || !cube?.id) return;
+    const dateMs = new Date(dateValue).getTime();
+    window.location.href = `/cube/changelog/${cube.id}/at?date=${dateMs}`;
+  }, [dateValue, cube?.id]);
+
   // Override canEdit to false — this is a read-only point-in-time view
   const readOnlyContext = useMemo(() => ({ ...cubeContext, canEdit: false }), [cubeContext]);
 
+  // FIXME: The Download button here only supports CSV and appears to only support the Mainboard.
+  //  Rather than continuing to improve on that, though, the better solve would be to make the cube's Export dropdown in the header apply to the changelog.
   return (
     <CubeContext.Provider value={readOnlyContext}>
       <div
@@ -72,6 +92,21 @@ const CubePITListInner: React.FC<{ date: string; changelogId: string }> = ({ dat
                 Download Cube
               </Text>
             </Link>
+          </Flexbox>
+          <Flexbox direction="row" gap="2" alignItems="center">
+            <Text sm className="text-text-secondary">
+              Jump to a Point in Time
+            </Text>
+            <div className="max-w-32">
+              <Input
+                type="date"
+                value={dateValue}
+                onChange={(e) => setDateValue(e.target.value)}
+              />
+            </div>
+            <Button color="accent" type="button" onClick={handleDateJump}>
+              Go
+            </Button>
           </Flexbox>
         </Flexbox>
       </div>

--- a/packages/client/src/pages/CubePITListPage.tsx
+++ b/packages/client/src/pages/CubePITListPage.tsx
@@ -50,11 +50,11 @@ const CubePITListInner: React.FC<{ date: string; changelogId: string }> = ({ dat
         className="bg-bg-accent border-y border-border py-3 px-4 text-center"
         style={{ marginLeft: '-0.5rem', marginRight: '-0.5rem', width: 'calc(100% + 1rem)' }}
       >
-        <Flexbox direction="row" alignItems="center" justify="center" gap="4" className="flex-wrap">
+        <Flexbox direction="col" alignItems="center" gap="1">
           <Text semibold md className="text-text">
             You are viewing a point-in-time snapshot of {cube.name} ({date})
           </Text>
-          <Flexbox direction="row" gap="2">
+          <Flexbox direction="row" gap="2" alignItems="center">
             <Link href={`/cube/changelog/${cube.id}/${changelogId}`}>
               <Text sm className="text-link underline">
                 Back to changelog entry
@@ -64,6 +64,12 @@ const CubePITListInner: React.FC<{ date: string; changelogId: string }> = ({ dat
             <Link href={`/cube/changelog/${cube.id}/${changelogId}/compare`}>
               <Text sm className="text-link underline">
                 Compare with Present
+              </Text>
+            </Link>
+            <Text sm className="text-text-secondary">|</Text>
+            <Link href={`/cube/changelog/${cube.id}/${changelogId}/download`}>
+              <Text sm className="text-link underline">
+                Download Cube
               </Text>
             </Link>
           </Flexbox>

--- a/packages/client/src/pages/CubePITListPage.tsx
+++ b/packages/client/src/pages/CubePITListPage.tsx
@@ -50,15 +50,23 @@ const CubePITListInner: React.FC<{ date: string; changelogId: string }> = ({ dat
         className="bg-bg-accent border-y border-border py-3 px-4 text-center"
         style={{ marginLeft: '-0.5rem', marginRight: '-0.5rem', width: 'calc(100% + 1rem)' }}
       >
-        <Flexbox direction="row" alignItems="center" justify="center" gap="2" className="flex-wrap">
+        <Flexbox direction="row" alignItems="center" justify="center" gap="4" className="flex-wrap">
           <Text semibold md className="text-text">
             You are viewing a point-in-time snapshot of {cube.name} ({date})
           </Text>
-          <Link href={`/cube/changelog/${cube.id}/${changelogId}`}>
-            <Text sm className="text-link underline">
-              Back to changelog entry &rarr;
-            </Text>
-          </Link>
+          <Flexbox direction="row" gap="2">
+            <Link href={`/cube/changelog/${cube.id}/${changelogId}`}>
+              <Text sm className="text-link underline">
+                Back to changelog entry
+              </Text>
+            </Link>
+            <Text sm className="text-text-secondary">|</Text>
+            <Link href={`/cube/changelog/${cube.id}/${changelogId}/compare`}>
+              <Text sm className="text-link underline">
+                Compare with Present
+              </Text>
+            </Link>
+          </Flexbox>
         </Flexbox>
       </div>
       <Container xl>

--- a/packages/server/src/dynamo/dao/ChangelogDynamoDao.ts
+++ b/packages/server/src/dynamo/dao/ChangelogDynamoDao.ts
@@ -332,6 +332,47 @@ export class ChangelogDynamoDao extends BaseDynamoDao<Changelog, UnhydratedChang
   }
 
   /**
+   * Finds the nearest changelog at or before a given date for a cube.
+   * Falls back to the earliest changelog if none exist at/before the date.
+   * Returns undefined if the cube has no changelogs at all.
+   */
+  public async getNearest(cubeId: string, date: number): Promise<Changelog | undefined> {
+    // Query for the most recent changelog at or before the given date
+    const params: QueryCommandInput = {
+      TableName: this.tableName,
+      IndexName: 'GSI1',
+      KeyConditionExpression: 'GSI1PK = :cube AND GSI1SK <= :date',
+      ExpressionAttributeValues: {
+        ':cube': `${this.itemType()}#CUBE#${cubeId}`,
+        ':date': `DATE#${date}`,
+      },
+      ScanIndexForward: false,
+      Limit: 1,
+    };
+
+    const result = await this.query(params);
+
+    if (result.items.length > 0) {
+      return result.items[0];
+    }
+
+    // No changelog at/before this date — fall back to the earliest
+    const earliestParams: QueryCommandInput = {
+      TableName: this.tableName,
+      IndexName: 'GSI1',
+      KeyConditionExpression: 'GSI1PK = :cube',
+      ExpressionAttributeValues: {
+        ':cube': `${this.itemType()}#CUBE#${cubeId}`,
+      },
+      ScanIndexForward: true,
+      Limit: 1,
+    };
+
+    const earliestResult = await this.query(earliestParams);
+    return earliestResult.items[0];
+  }
+
+  /**
    * Creates a new changelog and stores it in both DynamoDB and S3.
    */
   public async createChangelog(changelog: Changes, cubeId: string): Promise<string> {

--- a/packages/server/src/router/routes/cube/api/cubeJSON.ts
+++ b/packages/server/src/router/routes/cube/api/cubeJSON.ts
@@ -1,8 +1,9 @@
 import Card from '@utils/datatypes/Card';
 import { sortForDownload } from '@utils/sorting/Sort';
-import { changelogDao, cubeDao } from 'dynamo/daos';
+import { cubeDao } from 'dynamo/daos';
 import rateLimit from 'express-rate-limit';
-import { isCubeViewable, reconstructCubeAtChangelog } from 'serverutils/cubefn';
+import { parseDateParam, resolveCubeCards } from 'serverutils/cubeCards';
+import { isCubeViewable } from 'serverutils/cubefn';
 
 import { NextFunction, Request, Response } from '../../../../types/express';
 
@@ -35,24 +36,12 @@ export const cubeJSONHandler = async (req: Request, res: Response) => {
       return res.status(404).send('Cube not found.');
     }
 
-    const dateParam = req.query.date as string | undefined;
-    let cubeCards = await cubeDao.getCards(cube.id);
-    let changelogMeta: { id: string; date: number } | undefined;
-
-    if (dateParam) {
-      const dateMs = parseInt(dateParam, 10);
-      if (isNaN(dateMs)) {
-        return res.status(400).send('Invalid date parameter. Must be a unix timestamp in milliseconds.');
-      }
-
-      const changelog = await changelogDao.getNearest(cube.id, dateMs);
-      if (!changelog) {
-        return res.status(404).send('No changelogs found for this cube.');
-      }
-
-      cubeCards = await reconstructCubeAtChangelog(cube.id, changelog.date, cubeCards, changelogDao);
-      changelogMeta = { id: changelog.id, date: changelog.date };
+    const dateMs = parseDateParam(req.query.date as string | undefined);
+    if (dateMs !== undefined && isNaN(dateMs)) {
+      return res.status(400).send('Invalid date parameter. Must be a unix timestamp in milliseconds.');
     }
+
+    const { cards: cubeCards, changelog: changelogMeta } = await resolveCubeCards(cube.id, dateMs);
 
     // Sort every board using the default ordered sort
     for (const boardName of Object.keys(cubeCards)) {

--- a/packages/server/src/router/routes/cube/api/cubeJSON.ts
+++ b/packages/server/src/router/routes/cube/api/cubeJSON.ts
@@ -1,8 +1,8 @@
 import Card from '@utils/datatypes/Card';
 import { sortForDownload } from '@utils/sorting/Sort';
-import { cubeDao } from 'dynamo/daos';
+import { changelogDao, cubeDao } from 'dynamo/daos';
 import rateLimit from 'express-rate-limit';
-import { isCubeViewable } from 'serverutils/cubefn';
+import { isCubeViewable, reconstructCubeAtChangelog } from 'serverutils/cubefn';
 
 import { NextFunction, Request, Response } from '../../../../types/express';
 
@@ -35,9 +35,26 @@ export const cubeJSONHandler = async (req: Request, res: Response) => {
       return res.status(404).send('Cube not found.');
     }
 
-    const cubeCards = await cubeDao.getCards(cube.id);
+    const dateParam = req.query.date as string | undefined;
+    let cubeCards = await cubeDao.getCards(cube.id);
+    let changelogMeta: { id: string; date: number } | undefined;
 
-    // Sort every board using the default ordered sort (no longer depends on cube.defaultSorts, which moved to views)
+    if (dateParam) {
+      const dateMs = parseInt(dateParam, 10);
+      if (isNaN(dateMs)) {
+        return res.status(400).send('Invalid date parameter. Must be a unix timestamp in milliseconds.');
+      }
+
+      const changelog = await changelogDao.getNearest(cube.id, dateMs);
+      if (!changelog) {
+        return res.status(404).send('No changelogs found for this cube.');
+      }
+
+      cubeCards = await reconstructCubeAtChangelog(cube.id, changelog.date, cubeCards, changelogDao);
+      changelogMeta = { id: changelog.id, date: changelog.date };
+    }
+
+    // Sort every board using the default ordered sort
     for (const boardName of Object.keys(cubeCards)) {
       const board = cubeCards[boardName];
       if (Array.isArray(board)) {
@@ -45,8 +62,13 @@ export const cubeJSONHandler = async (req: Request, res: Response) => {
       }
     }
 
+    const response: Record<string, any> = { ...cube, cards: cubeCards };
+    if (changelogMeta) {
+      response.changelog = changelogMeta;
+    }
+
     res.contentType('application/json');
-    return res.status(200).send(JSON.stringify({ ...cube, cards: cubeCards }));
+    return res.status(200).send(JSON.stringify(response));
   } catch (err) {
     const error = err as Error;
     req.logger.error(error.message, error.stack);

--- a/packages/server/src/router/routes/cube/api/cubelist.ts
+++ b/packages/server/src/router/routes/cube/api/cubelist.ts
@@ -1,5 +1,6 @@
 import { cubeDao } from 'dynamo/daos';
 import { cardFromId } from 'serverutils/carddb';
+import { parseDateParam, resolveCubeCards } from 'serverutils/cubeCards';
 import { isCubeViewable } from 'serverutils/cubefn';
 
 import { Request, Response } from '../../../../types/express';
@@ -16,7 +17,12 @@ export const cubelistHandler = async (req: Request, res: Response) => {
       return res.status(404).send('Cube not found.');
     }
 
-    const cubeCards = await cubeDao.getCards(cube.id);
+    const dateMs = parseDateParam(req.query.date as string | undefined);
+    if (dateMs !== undefined && isNaN(dateMs)) {
+      return res.status(400).send('Invalid date parameter. Must be a unix timestamp in milliseconds.');
+    }
+
+    const { cards: cubeCards } = await resolveCubeCards(cube.id, dateMs);
 
     const names = cubeCards.mainboard.map((card: any) => cardFromId(card.cardID).name);
     res.contentType('text/plain');

--- a/packages/server/src/router/routes/cube/changelog.ts
+++ b/packages/server/src/router/routes/cube/changelog.ts
@@ -222,7 +222,46 @@ export const pitListHandler = async (req: Request, res: Response) => {
   }
 };
 
+export const dateResolveHandler = async (req: Request, res: Response) => {
+  try {
+    const cubeId = req.params.cubeId!;
+    const dateParam = req.query.date as string | undefined;
+
+    if (!dateParam) {
+      req.flash('danger', 'Date parameter is required.');
+      return redirect(req, res, `/cube/about/${cubeId}?view=changelog`);
+    }
+
+    const dateMs = parseInt(dateParam, 10);
+    if (isNaN(dateMs)) {
+      req.flash('danger', 'Invalid date parameter.');
+      return redirect(req, res, `/cube/about/${cubeId}?view=changelog`);
+    }
+
+    const cube = await cubeDao.getById(cubeId);
+    if (!isCubeViewable(cube, req.user) || !cube) {
+      req.flash('danger', 'Cube not found');
+      return redirect(req, res, '/404');
+    }
+
+    const changelog = await changelogDao.getNearest(cube.id, dateMs);
+    if (!changelog) {
+      req.flash('danger', 'No changelogs found for this cube.');
+      return redirect(req, res, `/cube/about/${cubeId}?view=changelog`);
+    }
+
+    return redirect(req, res, `/cube/changelog/${cube.id}/${changelog.id}/list`);
+  } catch (err) {
+    return handleRouteError(req, res, err as Error, `/cube/about/${req.params.cubeId}?view=changelog`);
+  }
+};
+
 export const routes = [
+  {
+    path: '/:cubeId/at',
+    method: 'get',
+    handler: [dateResolveHandler],
+  },
   {
     path: '/:cubeId/:changelogId/download',
     method: 'get',

--- a/packages/server/src/serverutils/cubeCards.ts
+++ b/packages/server/src/serverutils/cubeCards.ts
@@ -1,0 +1,38 @@
+import { CubeCards } from '@utils/datatypes/Cube';
+import { changelogDao, cubeDao } from 'dynamo/daos';
+import { reconstructCubeAtChangelog } from 'serverutils/cubefn';
+
+export interface ResolvedCubeCards {
+  cards: CubeCards;
+  changelog?: { id: string; date: number };
+}
+
+/**
+ * Resolves cube cards, optionally at a point in time.
+ * When dateMs is provided, reconstructs the cube state at the nearest changelog at or before that date.
+ * Returns the cards and optional changelog metadata for the resolved snapshot.
+ */
+export async function resolveCubeCards(cubeId: string, dateMs?: number): Promise<ResolvedCubeCards> {
+  let cards = await cubeDao.getCards(cubeId);
+
+  if (dateMs === undefined) {
+    return { cards };
+  }
+
+  const changelog = await changelogDao.getNearest(cubeId, dateMs);
+  if (!changelog) {
+    return { cards };
+  }
+
+  cards = await reconstructCubeAtChangelog(cubeId, changelog.date, cards, changelogDao);
+  return { cards, changelog: { id: changelog.id, date: changelog.date } };
+}
+
+/**
+ * Parses a date query parameter string into milliseconds.
+ * Returns undefined if param is absent, or NaN if invalid.
+ */
+export function parseDateParam(dateParam: string | undefined): number | undefined {
+  if (!dateParam) return undefined;
+  return parseInt(dateParam, 10);
+}


### PR DESCRIPTION
There's a couple things rolled into this PR, I can break them back out if desired.

- Add button to the Changelog History Page and to Blog Posts to allow jumping directly to the PIT List view.
- Modify how the View/Compare buttons are displayed on individual Changelog entries.
- Add a "Jump to Date" input that allows going to the PIT list that was active at the given date.
- Rearrange some elements on the PIT List page; adding Compare + Download links here as well as the "Jump to Date" behavior.
- Enhance the public API `/cubeJSON` and `/cubelist` endpoints to allow sending in an optional date query param that performs that same "Jump to Date" functionality.

Future notes:
- It may be worth adding another param that allows specifying a changelog id.
- The Cube Header on the PIT page does not respect the active changelog. I think ultimately you'd want to eliminate the "Download Cube" link and instead just make the header's Export menu work.

<img width="834" height="326" alt="Screenshot 2026-05-22 at 6 04 44 PM" src="https://github.com/user-attachments/assets/b2d3e4da-0471-42f7-a6cb-49d81c173c47" />

<img width="650" height="298" alt="Screenshot 2026-05-22 at 6 04 56 PM" src="https://github.com/user-attachments/assets/cbaf9e72-bc1b-4823-9105-e123c83dd99e" />
