### PR TITLE
feat: add an Include Extras filter for Add Cards

### DIFF
--- a/packages/client/src/components/base/AutocompleteInput.tsx
+++ b/packages/client/src/components/base/AutocompleteInput.tsx
@@ -61,6 +61,16 @@ const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
   const getMatchesRef = useRef(getMatches);
   getMatchesRef.current = getMatches;
 
+  // Clear cache when the fetcher changes (e.g., toggling filter options).
+  // Callers should memoize getMatches so identity only changes when params do.
+  const prevGetMatches = useRef(getMatches);
+  useEffect(() => {
+    if (prevGetMatches.current !== getMatches) {
+      cache.current.clear();
+      prevGetMatches.current = getMatches;
+    }
+  }, [getMatches]);
+
   const normalizedValue = normalize(value);
 
   // Debounced async lookup. Fires only once the user has typed enough and the

--- a/packages/client/src/components/cube/CubeListEditSidebar.tsx
+++ b/packages/client/src/components/cube/CubeListEditSidebar.tsx
@@ -72,6 +72,7 @@ const CubeListEditSidebar: React.FC<CubeListEditSidebarProps> = ({ isHorizontal 
   const [postContent, setPostContent] = useLocalStorage(`${cube.id}-blogpost`, '');
   const [postTitle, setPostTitle] = useLocalStorage(`${cube.id}-blogtitle`, DEFAULT_BLOG_TITLE);
   const [specifyEdition, setSpecifyEdition] = useLocalStorage(`${cube.id}-specifyEdition`, false);
+  const [includeExtras, setIncludeExtras] = useLocalStorage(`${cube.id}-includeExtras`, false);
   const [boardToEdit, setBoardToEdit] = useLocalStorage<BoardType>(`${cube.id}-editBoard`, 'mainboard');
 
   // Get board options from cube's board definitions
@@ -259,7 +260,7 @@ const CubeListEditSidebar: React.FC<CubeListEditSidebarProps> = ({ isHorizontal 
               Add Card
             </Text>
             <AutocompleteInput
-              getMatches={cardNameMatches(specifyEdition)}
+              getMatches={cardNameMatches(specifyEdition, includeExtras)}
               type="text"
               innerRef={addRef}
               name="add"
@@ -308,6 +309,11 @@ const CubeListEditSidebar: React.FC<CubeListEditSidebarProps> = ({ isHorizontal 
               label="Specify Versions"
               checked={specifyEdition}
               setChecked={(value) => setSpecifyEdition(value)}
+            />
+            <Checkbox
+              label="Include Extras"
+              checked={includeExtras}
+              setChecked={(value) => setIncludeExtras(value)}
             />
             <Flexbox direction="row" gap="2" alignItems="center">
               <Checkbox label="Create Blog Post" checked={useBlog} setChecked={(value) => setUseBlog(value)} />
@@ -411,7 +417,7 @@ const CubeListEditSidebar: React.FC<CubeListEditSidebarProps> = ({ isHorizontal 
               <div className="flex gap-2">
                 <div className="flex-1">
                   <AutocompleteInput
-                    getMatches={cardNameMatches(specifyEdition)}
+                    getMatches={cardNameMatches(specifyEdition, includeExtras)}
                     type="text"
                     innerRef={addRef}
                     name="add"
@@ -462,11 +468,16 @@ const CubeListEditSidebar: React.FC<CubeListEditSidebarProps> = ({ isHorizontal 
           {/* Second Row: Specify Versions, Create Blog Post, Import */}
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mt-4">
             {/* Specify Versions */}
-            <div className="flex items-center">
+            <div className="flex items-center gap-4">
               <Checkbox
                 label="Specify Versions"
                 checked={specifyEdition}
                 setChecked={(value) => setSpecifyEdition(value)}
+              />
+              <Checkbox
+                label="Include Extras"
+                checked={includeExtras}
+                setChecked={(value) => setIncludeExtras(value)}
               />
             </div>
 

--- a/packages/client/src/components/cube/CubeListEditSidebar.tsx
+++ b/packages/client/src/components/cube/CubeListEditSidebar.tsx
@@ -75,6 +75,9 @@ const CubeListEditSidebar: React.FC<CubeListEditSidebarProps> = ({ isHorizontal 
   const [includeExtras, setIncludeExtras] = useLocalStorage(`${cube.id}-includeExtras`, false);
   const [boardToEdit, setBoardToEdit] = useLocalStorage<BoardType>(`${cube.id}-editBoard`, 'mainboard');
 
+  // Memoize so AutocompleteInput's cache is only invalidated when options change
+  const addCardMatches = useMemo(() => cardNameMatches(specifyEdition, includeExtras), [specifyEdition, includeExtras]);
+
   // Get board options from cube's board definitions
   const boardOptions = useMemo(() => {
     const boards = getBoardDefinitions(cube, changedCards);
@@ -260,7 +263,7 @@ const CubeListEditSidebar: React.FC<CubeListEditSidebarProps> = ({ isHorizontal 
               Add Card
             </Text>
             <AutocompleteInput
-              getMatches={cardNameMatches(specifyEdition, includeExtras)}
+              getMatches={addCardMatches}
               type="text"
               innerRef={addRef}
               name="add"
@@ -417,7 +420,7 @@ const CubeListEditSidebar: React.FC<CubeListEditSidebarProps> = ({ isHorizontal 
               <div className="flex gap-2">
                 <div className="flex-1">
                   <AutocompleteInput
-                    getMatches={cardNameMatches(specifyEdition, includeExtras)}
+                    getMatches={addCardMatches}
                     type="text"
                     innerRef={addRef}
                     name="add"

--- a/packages/client/src/utils/cardAutocomplete.ts
+++ b/packages/client/src/utils/cardAutocomplete.ts
@@ -21,10 +21,10 @@ const getJson = async (url: string, signal?: AbortSignal): Promise<any | null> =
 // Global card-name autocomplete. `full` switches between bare names and
 // name-with-set strings (printing-specific suggestions).
 export const cardNameMatches =
-  (full: boolean = false): MatchFetcher =>
+  (full: boolean = false, includeExtras: boolean = false): MatchFetcher =>
   async (query, signal) => {
     const json = await getJson(
-      `/tool/api/cardnames?q=${encodeURIComponent(query)}&full=${full ? '1' : '0'}`,
+      `/tool/api/cardnames?q=${encodeURIComponent(query)}&full=${full ? '1' : '0'}&extras=${includeExtras ? '1' : '0'}`,
       signal,
     );
     return json?.success === 'true' ? json.names : [];

--- a/packages/jobs/src/update_cards.ts
+++ b/packages/jobs/src/update_cards.ts
@@ -547,7 +547,7 @@ function convertCard(
   newcard.promo_types = card.promo_types || undefined;
 
   newcard.digital = card.digital;
-  newcard.isToken = card.layout === 'token';
+  newcard.isToken = card.layout === 'token' || card.layout === 'double_faced_token';
   newcard.border_color = card.border_color as 'black' | 'white' | 'silver' | 'gold' | undefined;
   newcard.name = name;
   newcard.name_lower = cardutil.normalizeName(name);

--- a/packages/server/src/router/routes/tool/api/cardnames.ts
+++ b/packages/server/src/router/routes/tool/api/cardnames.ts
@@ -31,7 +31,19 @@ export const cardNamesHandler = async (req: Request, res: Response) => {
       return res.status(200).send({ success: 'true', names: [] });
     }
 
-    const source = full ? catalog.full_names : catalog.cardnames;
+    const includeExtras = req.query.extras === '1' || req.query.extras === 'true';
+
+    let source: string[];
+    if (full && includeExtras) {
+      source = catalog.full_names;
+    } else if (full) {
+      source = catalog.reasonable_full_names;
+    } else if (includeExtras) {
+      source = catalog.cardnames;
+    } else {
+      source = catalog.reasonable_names;
+    }
+
     const names = prefixMatches(source, query, limit);
 
     return res.status(200).send({ success: 'true', names });

--- a/packages/server/src/serverutils/cardCatalog.ts
+++ b/packages/server/src/serverutils/cardCatalog.ts
@@ -100,12 +100,16 @@ export async function initializeCardDb(basePath: string = 'private') {
 
   catalog.printedCardList = Object.values(catalog._carddict).filter((card) => !card.digital && !card.isToken);
 
+  // CubeCobra synthetic cards that should always appear in autocomplete
+  const ALWAYS_ALLOW_IDS = new Set(['custom-card', 'voucher']);
+
   // Build filtered name arrays for autocomplete — include only names with at
   // least one "reasonable" printing (excludes tokens, digital, art series, promos, etc.)
   catalog.reasonable_names = catalog.cardnames.filter((name) => {
     const ids = catalog.nameToId[name];
     if (!ids) return false;
     return ids.some((id) => {
+      if (ALWAYS_ALLOW_IDS.has(id)) return true;
       const card = catalog._carddict[id];
       return card && reasonableCard(card);
     });
@@ -114,6 +118,7 @@ export async function initializeCardDb(basePath: string = 'private') {
   catalog.reasonable_full_names = catalog.full_names.filter((fullName) => {
     const image = catalog.imagedict[fullName];
     if (!image || !image.id) return false;
+    if (ALWAYS_ALLOW_IDS.has(image.id)) return true;
     const card = catalog._carddict[image.id];
     return card && reasonableCard(card);
   });

--- a/packages/server/src/serverutils/cardCatalog.ts
+++ b/packages/server/src/serverutils/cardCatalog.ts
@@ -1,5 +1,5 @@
 // import missing types from @utils/datatypes/Catalog
-import { normalizeName } from '@utils/cardutil';
+import { normalizeName, reasonableCard } from '@utils/cardutil';
 import { Catalog } from '@utils/datatypes/CardCatalog';
 import json from 'big-json';
 import fs from 'fs';
@@ -18,6 +18,8 @@ const catalog: Catalog = {
   oracleToIndex: {},
   metadatadict: {},
   printedCardList: [], // for card filters
+  reasonable_names: [],
+  reasonable_full_names: [],
   comboOracleToIndex: {}, // Combo-specific mapping saved with comboTree
 };
 
@@ -97,6 +99,25 @@ export async function initializeCardDb(basePath: string = 'private') {
   }
 
   catalog.printedCardList = Object.values(catalog._carddict).filter((card) => !card.digital && !card.isToken);
+
+  // Build filtered name arrays for autocomplete — include only names with at
+  // least one "reasonable" printing (excludes tokens, digital, art series, promos, etc.)
+  catalog.reasonable_names = catalog.cardnames.filter((name) => {
+    const ids = catalog.nameToId[name];
+    if (!ids) return false;
+    return ids.some((id) => {
+      const card = catalog._carddict[id];
+      return card && reasonableCard(card);
+    });
+  });
+
+  catalog.reasonable_full_names = catalog.full_names.filter((fullName) => {
+    const image = catalog.imagedict[fullName];
+    if (!image || !image.id) return false;
+    const card = catalog._carddict[image.id];
+    return card && reasonableCard(card);
+  });
+
   catalog.oracleToIndex = Object.fromEntries(
     catalog.indexToOracle.map((oracleId: string, index: number) => [oracleId, index]),
   );

--- a/packages/server/test/cards/carddb.test.ts
+++ b/packages/server/test/cards/carddb.test.ts
@@ -17,6 +17,8 @@ const mockCardCatalog: Catalog = {
   metadatadict: {},
   printedCardList: [], // for card filters
   comboOracleToIndex: {}, // for combo lookups
+  reasonable_names: [],
+  reasonable_full_names: [],
 };
 
 jest.mock('serverutils/cardCatalog', () => {

--- a/packages/server/test/routes/tool/api/cardnames.test.ts
+++ b/packages/server/test/routes/tool/api/cardnames.test.ts
@@ -1,0 +1,95 @@
+import { Catalog } from '@utils/datatypes/CardCatalog';
+
+const mockCardCatalog: Catalog = {
+  imagedict: {},
+  cardimages: {},
+  cardnames: ['angel token', 'lightning bolt', 'treasure token'],
+  comboTree: {},
+  full_names: ['angel token [TKHM-1]', 'lightning bolt [2XM-117]', 'treasure token [TKHM-2]'],
+  nameToId: {},
+  oracleToId: {},
+  english: {},
+  _carddict: {},
+  indexToOracle: [],
+  oracleToIndex: {},
+  metadatadict: {},
+  printedCardList: [],
+  comboOracleToIndex: {},
+  reasonable_names: ['lightning bolt'],
+  reasonable_full_names: ['lightning bolt [2XM-117]'],
+};
+
+jest.mock('serverutils/cardCatalog', () => ({
+  __esModule: true,
+  default: mockCardCatalog,
+}));
+
+import { Request, Response } from 'express';
+import { cardNamesHandler } from 'router/routes/tool/api/cardnames';
+
+const createMockReq = (query: Record<string, string>) =>
+  ({
+    query,
+    logger: { error: jest.fn() },
+  }) as unknown as Request;
+
+const createMockRes = () => {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+  } as unknown as Response;
+  return res;
+};
+
+describe('cardNamesHandler', () => {
+  it('returns filtered results by default (no extras param)', async () => {
+    const req = createMockReq({ q: 'lig' });
+    const res = createMockRes();
+    await cardNamesHandler(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.send).toHaveBeenCalledWith({
+      success: 'true',
+      names: ['lightning bolt'],
+    });
+  });
+
+  it('excludes tokens from results when extras=0', async () => {
+    const req = createMockReq({ q: 'angel', extras: '0' });
+    const res = createMockRes();
+    await cardNamesHandler(req, res);
+    expect(res.send).toHaveBeenCalledWith({
+      success: 'true',
+      names: [],
+    });
+  });
+
+  it('includes tokens when extras=1', async () => {
+    const req = createMockReq({ q: 'angel', extras: '1' });
+    const res = createMockRes();
+    await cardNamesHandler(req, res);
+    expect(res.send).toHaveBeenCalledWith({
+      success: 'true',
+      names: ['angel token'],
+    });
+  });
+
+  it('uses reasonable_full_names when full=1 and extras not set', async () => {
+    const req = createMockReq({ q: 'lig', full: '1' });
+    const res = createMockRes();
+    await cardNamesHandler(req, res);
+    expect(res.send).toHaveBeenCalledWith({
+      success: 'true',
+      names: ['lightning bolt [2XM-117]'],
+    });
+  });
+
+  it('uses full_names when full=1 and extras=1', async () => {
+    const req = createMockReq({ q: 'angel', full: '1', extras: '1' });
+    const res = createMockRes();
+    await cardNamesHandler(req, res);
+    expect(res.send).toHaveBeenCalledWith({
+      success: 'true',
+      names: ['angel token [TKHM-1]'],
+    });
+  });
+});

--- a/packages/utils/src/cardutil.ts
+++ b/packages/utils/src/cardutil.ts
@@ -659,6 +659,7 @@ export function reasonableCard(card: CardDetailsType): boolean {
     card.tcgplayer_id !== undefined &&
     card.collector_number.indexOf('★') === -1 &&
     card.layout !== 'art_series' &&
+    card.layout !== 'double_faced_token' &&
     !card?.hasFlavorName
   );
 }

--- a/packages/utils/src/datatypes/CardCatalog.ts
+++ b/packages/utils/src/datatypes/CardCatalog.ts
@@ -119,6 +119,8 @@ export interface Catalog {
   indexToOracle: string[];
   metadatadict: Record<string, CardMetadata>;
   printedCardList: any[];
+  reasonable_names: string[];
+  reasonable_full_names: string[];
   comboTree: ComboTree;
   oracleToIndex: Record<string, number>;
   // Combo-specific oracle index mapping - saved alongside comboTree to ensure index consistency


### PR DESCRIPTION
From Discord:
https://discord.com/channels/592787488523943937/1507524910056996875/1507524910056996875

- Defaults to includeExtras=false
- This is using Cobra's existing "Reasonable Printing" evaluation, so maybe it'd be better if the terminology is a bit different to differentiate that from Scryfall `include:extras`.

There's also two bug fixes in here.
- Cards with `layout:double_faced_token` weren't being flagged as a token (L662 in cardutil can get removed after a carddict update).
- The UI calls to this autocomplete endpoint were using a cache/memoization pattern that didn't account for the existing Specify Versions query param. This change just triggers a clear so there's some room to improve that further by just extending the key generation.