### PR TITLE
Correct spelling of 'GitHub' in footer

### DIFF
--- a/packages/client/src/layouts/Footer.tsx
+++ b/packages/client/src/layouts/Footer.tsx
@@ -111,7 +111,7 @@ const Footer: React.FC = () => {
                   <FooterLink href="/help/donate">Donate</FooterLink>
                 </li>
                 <li className="mb-2">
-                  <FooterLink href="https://github.com/dekkerglen/CubeCobra">Github</FooterLink>
+                  <FooterLink href="https://github.com/dekkerglen/CubeCobra">GitHub</FooterLink>
                 </li>
                 <li className="mb-2">
                   <FooterLink href="/help/apidocs">API Docs</FooterLink>


### PR DESCRIPTION
Just a tiny spelling (capitalization) tweak to match how GitHub should be written.