### PR TITLE
fix: adjust reasonable printing determination for Final Fantasy

### DIFF
--- a/packages/server/test/cards/deckutil.test.ts
+++ b/packages/server/test/cards/deckutil.test.ts
@@ -307,13 +307,19 @@ describe('reasonableCard', () => {
     expect(reasonableCard(details)).toBeFalsy();
   });
 
-  it('Unless the only promo is universes beyond', async () => {
+  it('Universes beyond promo type is reasonable', async () => {
     const details = createCardDetails({ ...overridesForNormalDetails, promo_types: ['universesbeyond'] });
 
     expect(reasonableCard(details)).toBeTruthy();
   });
 
-  it('More promo types on top of UB are not reasonable', async () => {
+  it('UB cards with source-material promo types are reasonable', async () => {
+    const details = createCardDetails({ ...overridesForNormalDetails, promo_types: ['ffiii', 'sourcematerial', 'universesbeyond'] });
+
+    expect(reasonableCard(details)).toBeTruthy();
+  });
+
+  it('UB cards with unreasonable promo types are not reasonable', async () => {
     const details = createCardDetails({ ...overridesForNormalDetails, promo_types: ['universesbeyond', 'surgefoil'] });
 
     expect(reasonableCard(details)).toBeFalsy();

--- a/packages/utils/src/cardutil.ts
+++ b/packages/utils/src/cardutil.ts
@@ -638,13 +638,15 @@ export const isManaFixingLand = (details: CardDetailsType): boolean => {
   return BASIC_LAND_TYPE_NAMES.some((name) => text.includes(name));
 };
 
+const UNREASONABLE_PROMO_TYPES = [
+  'surgefoil', 'galaxyfoil', 'textured', 'serialized', 'gilded',
+  'neonink', 'oilslick', 'rainbowfoil', 'confettifoil', 'embossed',
+  'boosterfun', 'promopack', 'prerelease', 'datestamped',
+];
+
 const arePromoTypesReasonable = (card: CardDetailsType): boolean => {
-  return (
-    card.promo_types === undefined ||
-    //Post Omenpaths support (https://scryfall.com/blog/through-the-omenpaths-added-plus-english-printed-text-support-235) ll
-    //UB cards have this promo type
-    (Array.isArray(card.promo_types) && card.promo_types.length === 1 && card.promo_types[0] === 'universesbeyond')
-  );
+  if (!card.promo_types || card.promo_types.length === 0) return true;
+  return !card.promo_types.some((type) => UNREASONABLE_PROMO_TYPES.includes(type));
 };
 
 export function reasonableCard(card: CardDetailsType): boolean {


### PR DESCRIPTION
I'm not totally confident in this because I'm not sure you can do this Reasonable check in isolation, it might rely on knowing that there isn't a _more_ reasonable printing of a card sometimes to avoid fully eliminating a card.