### PR TITLE
Apply filter to the comparison sets used by the export function of the comparison page.

### DIFF
--- a/packages/client/src/components/CompareView.tsx
+++ b/packages/client/src/components/CompareView.tsx
@@ -199,7 +199,7 @@ const CompareView: React.FC<CompareViewProps> = ({ cards, both, onlyA, onlyB }) 
     <Flexbox direction="col" gap="3" className="my-2">
       <Card>
         <CardBody>
-          <SummaryCard label="All Cards" both={both.length} onlyA={onlyA.length} onlyB={onlyB.length} />
+          <SummaryCard label="All Cards" both={bothCounts.total} onlyA={onlyACounts.total} onlyB={onlyBCounts.total} />
         </CardBody>
       </Card>
       {getLabels(cards, sortPrimary ?? 'Unsorted', cube?.showUnsorted, cube)

--- a/packages/client/src/components/cube/CubeCompareNavbar.tsx
+++ b/packages/client/src/components/cube/CubeCompareNavbar.tsx
@@ -42,6 +42,7 @@ const CubeCompareNavbar: React.FC<CubeCompareNavbarProps> = ({
   cubeBID,
   openCollapse,
   setOpenCollapse,
+  //Cards, both/onlyA/onlyB are already filtered
   cards,
   both,
   onlyA,

--- a/packages/client/src/pages/CubeComparePage.tsx
+++ b/packages/client/src/pages/CubeComparePage.tsx
@@ -35,6 +35,28 @@ const CubeComparePageInner: React.FC<CubeComparePageProps> = ({ cards, cube, cub
 
   const filteredCards = cardFilter ? cards.filter(cardFilter.filter) : cards;
 
+  // Map original indices to filtered indices
+  const createFilteredIndices = useMemo(() => {
+    const cardFilterFn = cardFilter?.filter;
+    if (!cardFilterFn) return (indices: number[]) => indices;
+
+    const indexMap = new Map<number, number>();
+    let filteredIndex = 0;
+
+    for (let i = 0; i < cards.length; i++) {
+      if (cardFilterFn(cards[i])) {
+        indexMap.set(i, filteredIndex);
+        filteredIndex += 1;
+      }
+    }
+
+    return (indices: number[]) => indices.map((i) => indexMap.get(i)).filter((i) => i !== undefined) as number[];
+  }, [cards, cardFilter]);
+
+  const filteredBoth = useMemo(() => createFilteredIndices(both), [both, createFilteredIndices]);
+  const filteredOnlyA = useMemo(() => createFilteredIndices(onlyA), [onlyA, createFilteredIndices]);
+  const filteredOnlyB = useMemo(() => createFilteredIndices(onlyB), [onlyB, createFilteredIndices]);
+
   return (
     <>
       <CubeCompareNavbar
@@ -45,9 +67,9 @@ const CubeComparePageInner: React.FC<CubeComparePageProps> = ({ cards, cube, cub
         openCollapse={openCollapse}
         setOpenCollapse={setOpenCollapse}
         cards={filteredCards}
-        both={both}
-        onlyA={onlyA}
-        onlyB={onlyB}
+        both={filteredBoth}
+        onlyA={filteredOnlyA}
+        onlyB={filteredOnlyB}
         pitDate={pitDate}
       />
       <DynamicFlash />


### PR DESCRIPTION
# Problem

Applying a filter to the cube comparison page applies to the export, but causes all the cards to be categorized as "In Both".

# Solution

Because both, onlyA, and onlyB contain the indices of the cards but "cards" is filtered, after the filter there is misalignment. To fix the indices must be reworked to match the filtered set of cards.

# Testing

## Before

Filtering applies to the UI, but on export the cards displayed within "Only in base cube" or "Only in comparison cube" are in the file under "In both". Also notice the counts in the All cards summary do not update.
<img width="1859" height="663" alt="old-export-mushes-all-into-both-category" src="https://github.com/user-attachments/assets/16e478b0-889b-44e1-9518-787191d877d2" />

## After

Filter applies to the UI and on export, with cards correctly displayed within "Only in base cube" or "Only in comparison cube" as matching the UI. Also the "All Cards" summary counts update as the filter applied.
<img width="1859" height="663" alt="new-export-splits2" src="https://github.com/user-attachments/assets/af1acf5f-c996-4fbf-8aa2-f7993c5b26cc" />
