### PR TITLE
Feature - Add Artist to the cube and tokens CSV exports.

### DIFF
--- a/packages/client/src/analytics/Tokens.tsx
+++ b/packages/client/src/analytics/Tokens.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useContext, useMemo } from 'react';
 
 import { CopyIcon, DownloadIcon } from '@primer/octicons-react';
 import {
+  cardArtist,
   cardCmc,
   cardCollectorNumber,
   cardColorCategory,
@@ -32,7 +33,7 @@ import CubeContext from '../contexts/CubeContext';
 import useAlerts, { Alerts } from '../hooks/UseAlerts';
 
 const CSV_HEADER =
-  'name,CMC,Type,Color,Set,Collector Number,Rarity,Color Category,status,Finish,board,maybeboard,image URL,image Back URL,tags,Notes,MTGO ID,Custom';
+  'name,CMC,Type,Color,Set,Collector Number,Rarity,Color Category,status,Finish,board,maybeboard,image URL,image Back URL,tags,Notes,MTGO ID,Custom,Artist';
 
 function escapeCSV(value: string): string {
   return `"${value.replace(/"/g, '""')}"`;
@@ -58,6 +59,7 @@ function tokenToCSVRow(token: CardType, creatorNames: string[]): string {
     '""', // Notes
     String(cardMtgoId(token)),
     isCustomCard(token) ? 'true' : 'false',
+    escapeCSV(cardArtist(token)),
   ];
   return cols.join(',');
 }

--- a/packages/server/src/serverutils/cube.ts
+++ b/packages/server/src/serverutils/cube.ts
@@ -14,7 +14,7 @@ import { handleRouteError, redirect, render } from './render';
 const CARD_HEIGHT = 680;
 const CARD_WIDTH = 488;
 const CSV_HEADER =
-  'name,CMC,Type,Color,Set,Collector Number,Rarity,Color Category,status,Finish,board,maybeboard,image URL,image Back URL,tags,Notes,MTGO ID,Custom,Voucher';
+  'name,CMC,Type,Color,Set,Collector Number,Rarity,Color Category,status,Finish,board,maybeboard,image URL,image Back URL,tags,Notes,MTGO ID,Custom,Voucher,Artist';
 
 interface Cube {
   id: string;
@@ -279,7 +279,8 @@ function writeCard(res: Response, card: Card, boardName: string) {
   res.write(`","${cardutil.cardNotes(card)}",`);
   res.write(`${cardutil.cardMtgoId(card)},`);
   res.write(`${cardutil.isCustomCard(card) ? 'true' : 'false'},`);
-  res.write(`${cardutil.isVoucher(card) ? 'true' : 'false'}`);
+  res.write(`${cardutil.isVoucher(card) ? 'true' : 'false'},`);
+  res.write(`"${cardutil.cardArtist(card).replace(/"/g, '""')}"`);
   res.write('\r\n');
 }
 

--- a/packages/server/test/serverutils/cubefn.csv.test.ts
+++ b/packages/server/test/serverutils/cubefn.csv.test.ts
@@ -13,6 +13,8 @@ import { Response } from 'express';
 import { CSV_HEADER, writeCard } from 'serverutils/cube';
 import { CSVtoCards } from 'serverutils/cubefn';
 
+import { createCardDetails } from '../test-utils/data';
+
 jest.mock('serverutils/carddb', () => {
   const placeholder = {
     name: 'placeholder',
@@ -56,6 +58,35 @@ function makeResStub() {
     body: () => chunks.join(''),
   };
 }
+
+describe('CSVtoCards — writing details fields (not importable)', () => {
+  it('preserves artist field through writeCard + CSVtoCards round-trip', () => {
+    const cardWithArtist = {
+      cardID: 'custom-card',
+      name: 'custom-card',
+      custom_name: 'Test Card',
+      cmc: 3,
+      type_line: 'Creature',
+      colors: ['W'],
+      colorCategory: 'White',
+      status: 'Not Owned',
+      finish: 'Non-foil',
+      tags: [],
+      notes: '',
+      details: createCardDetails({ artist: 'Jackson Pollock' }),
+    };
+
+    const { res, body } = makeResStub();
+    res.write(`${CSV_HEADER}\r\n`);
+    writeCard(res, cardWithArtist as any, 'mainboard');
+
+    const output = body();
+    const lines = output.split('\n').filter((l) => l.length > 0);
+
+    expect(lines.length).toBe(2);
+    expect(lines[1]).toContain('"Jackson Pollock"');
+  });
+});
 
 describe('CSVtoCards — custom cards', () => {
   it('imports multiple custom cards, each with its own attributes', () => {


### PR DESCRIPTION
# Notes

Does not import Artist from the CSV as that is part of the Card Details which is not a configurable set. I guess we should think about supporting this when people provide custom images.

# Test

## After

Exporting cube board with Artist
<img width="1309" height="154" alt="image" src="https://github.com/user-attachments/assets/9e8c91c1-7744-4744-a985-3353d0778bab" />

Exporting cube tokens with Artist
<img width="1505" height="170" alt="image" src="https://github.com/user-attachments/assets/0f453808-f388-48e2-a262-9c3b336e9857" />

One unit test to check writeCard includes double-quoted artist names