### PR TITLE
fix(ml): bot ratings show real spread on P1P1 + deck pick breakdown

### DIFF
--- a/packages/client/src/components/DecksPickBreakdown.tsx
+++ b/packages/client/src/components/DecksPickBreakdown.tsx
@@ -6,7 +6,7 @@ import { getDrafterState } from '@utils/draftutil';
 
 import useLocalStorage from '../hooks/useLocalStorage';
 import useQueryParam from '../hooks/useQueryParam';
-import { modelScoresToProbabilities } from '../utils/botRatings';
+import { normalizeProbabilities } from '../utils/botRatings';
 import Text from './base/Text';
 import DraftBreakdownDisplay from './draft/DraftBreakdownDisplay';
 
@@ -27,6 +27,43 @@ interface BreakdownProps {
 const CubeBreakdown: React.FC<BreakdownProps> = ({ draft, seatNumber, pickNumber, setPickNumber }) => {
   const [ratings, setRatings] = useState<number[]>([]);
   const [showRatings, setShowRatings] = useLocalStorage(`showDraftRatings-${draft.id}`, true);
+  const [cubeContext, setCubeContext] = useState<number[] | null>(null);
+
+  // Fetch the cube's 32-dim context embedding once per mount. The draft decoder needs
+  // pool[128] ⊕ cube_ctx[32] = 160 dims; without the cube context it silently returns
+  // empty predictions and bot ratings render as blank chips.
+  useEffect(() => {
+    let cancelled = false;
+    if (!draft.cube) {
+      setCubeContext(null);
+      return;
+    }
+    (async () => {
+      try {
+        const response = await fetch('/api/draftbots/cubecontext', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ cubeId: draft.cube }),
+        });
+        if (!response.ok) {
+          setCubeContext(null);
+          return;
+        }
+        const data = await response.json();
+        if (cancelled) return;
+        if (Array.isArray(data.embedding) && data.embedding.length > 0) {
+          setCubeContext(data.embedding);
+        } else {
+          setCubeContext(null);
+        }
+      } catch {
+        if (!cancelled) setCubeContext(null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [draft.cube]);
 
   // Handle both CubeCobra and Draftmancer drafts
   const {
@@ -162,6 +199,7 @@ const CubeBreakdown: React.FC<BreakdownProps> = ({ draft, seatNumber, pickNumber
           body: JSON.stringify({
             pack: packOracleIds,
             picks: picksOracleIds,
+            cubeContext: cubeContext ?? undefined,
           }),
         });
 
@@ -183,7 +221,7 @@ const CubeBreakdown: React.FC<BreakdownProps> = ({ draft, seatNumber, pickNumber
             return uniqueOracleIds.reduce((acc, oracleId) => acc + (oracleRatings.get(oracleId) || 0), 0);
           });
 
-          setRatings(modelScoresToProbabilities(rawRatings));
+          setRatings(normalizeProbabilities(rawRatings));
         }
       } catch (error) {
         console.error('Error fetching predictions:', error);
@@ -191,7 +229,7 @@ const CubeBreakdown: React.FC<BreakdownProps> = ({ draft, seatNumber, pickNumber
     };
 
     fetchPredictions();
-  }, [cardsInPack, draft.cards, pack, pick, picksList, getCardOracleIds]);
+  }, [cardsInPack, draft.cards, pack, pick, picksList, getCardOracleIds, cubeContext]);
 
   // Add keyboard navigation
   useEffect(() => {

--- a/packages/client/src/components/p1p1/P1P1PackDisplay.tsx
+++ b/packages/client/src/components/p1p1/P1P1PackDisplay.tsx
@@ -5,7 +5,7 @@ import { P1P1Pack, P1P1VoteSummary } from '@utils/datatypes/P1P1Pack';
 import { detailsToCard } from '../../../../utils/src/cardutil';
 import UserContext from '../../contexts/UserContext';
 import useP1P1Vote from '../../hooks/useP1P1Vote';
-import { modelScoresToProbabilities } from '../../utils/botRatings';
+import { normalizeProbabilities } from '../../utils/botRatings';
 import Alert from '../base/Alert';
 import { Flexbox } from '../base/Layout';
 import Spinner from '../base/Spinner';
@@ -56,7 +56,7 @@ const P1P1PackDisplay: React.FC<P1P1PackDisplayProps> = ({ pack, votes, showBotW
 
   const ratings = useMemo((): number[] | undefined => {
     if (showBotWeights && votes.botWeights && votes.botWeights.length > 0) {
-      return modelScoresToProbabilities(votes.botWeights);
+      return normalizeProbabilities(votes.botWeights);
     } else if (votes.userVote !== undefined) {
       // Show vote percentages after user has voted
       const totalVotesWithBot = votes.totalVotes + (votes.botPick !== undefined ? 1 : 0);

--- a/packages/client/src/utils/botRatings.ts
+++ b/packages/client/src/utils/botRatings.ts
@@ -1,3 +1,8 @@
+/** Softmax — for raw logit inputs (e.g., the client-side TF.js bot, which returns
+ *  the model's last-layer outputs directly). Don't use this on values that are
+ *  already normalized probabilities, since softmax-of-softmax collapses to nearly
+ *  uniform. For server-returned ratings (which already include a final-layer
+ *  softmax on the ML service side), use `normalizeProbabilities` instead. */
 export const modelScoresToProbabilities = (scores: number[]): number[] => {
   if (scores.length === 0) return [];
 
@@ -12,4 +17,15 @@ export const modelScoresToProbabilities = (scores: number[]): number[] => {
   const total = exps.reduce((acc, value) => acc + value, 0);
 
   return total > 0 ? exps.map((value) => value / total) : scores.map(() => 0);
+};
+
+/** Renormalize already-probability-shaped values to sum to 1. Use this for ratings
+ *  returned by the server ML service (`/api/draftbots/predict`, `getBotPrediction`,
+ *  etc.) — those come back as probabilities already, so a second softmax flattens
+ *  them. Defensive against voucher-style summed entries that may exceed 1. */
+export const normalizeProbabilities = (values: number[]): number[] => {
+  if (values.length === 0) return [];
+  const finite = values.map((v) => (Number.isFinite(v) && v > 0 ? v : 0));
+  const total = finite.reduce((acc, v) => acc + v, 0);
+  return total > 0 ? finite.map((v) => v / total) : values.map(() => 0);
 };

--- a/packages/server/src/router/routes/api/draftbots/predict.ts
+++ b/packages/server/src/router/routes/api/draftbots/predict.ts
@@ -7,15 +7,19 @@ import { NextFunction, Request, Response } from '../../../../types/express';
 interface PredictBody {
   pack: string[]; // oracle id
   picks: string[]; // oracle id
+  cubeContext?: number[]; // 32-dim cube context embedding
 }
 
 const OracleIDSchema = Joi.string().uuid();
 const CustomCard = Joi.string().valid('custom-card');
 const VoucherCard = Joi.string().valid('voucher');
 
+const CUBE_CONTEXT_DIM = 32;
+
 const PredictBodySchema = Joi.object({
   pack: Joi.array().items(OracleIDSchema, CustomCard, VoucherCard).required(),
   picks: Joi.array().items(OracleIDSchema, CustomCard, VoucherCard).required(),
+  cubeContext: Joi.array().items(Joi.number()).length(CUBE_CONTEXT_DIM).optional(),
 });
 
 // Sentinel oracle ids that aren't real cards in the ML vocabulary. We strip
@@ -54,7 +58,7 @@ const handler = async (req: Request, res: Response) => {
     const mlPack = predictBody.pack.filter(isMlOracle).map((o) => toMl[o] ?? o);
     const mlPicks = predictBody.picks.filter(isMlOracle).map((o) => toMl[o] ?? o);
 
-    const mlPrediction = await draft(mlPack, mlPicks);
+    const mlPrediction = await draft(mlPack, mlPicks, predictBody.cubeContext);
 
     // Map ML oracles back to ALL original oracle IDs that mapped to them
     const prediction = mlPrediction.flatMap((item) =>

--- a/packages/server/src/router/routes/tool/api/createp1p1frompack.ts
+++ b/packages/server/src/router/routes/tool/api/createp1p1frompack.ts
@@ -112,8 +112,21 @@ export const createP1P1FromPackHandler = async (req: Request, res: Response) => 
       return res.status(400).json({ error: 'No valid cards found' });
     }
 
+    // Collect the cube's mainboard oracle ids so the bot prediction can include the
+    // 32-dim cube context (draft decoder needs pool[128] ⊕ cube_ctx[32]). Without it
+    // the ML service silently returns empty predictions and botWeights end up zeros.
+    const cubeOracleIds: string[] = [];
+    const seenCubeOracles = new Set<string>();
+    for (const cubeCard of cubeCards.mainboard ?? []) {
+      const oid = cubeCard.details?.oracle_id;
+      if (oid && !seenCubeOracles.has(oid)) {
+        seenCubeOracles.add(oid);
+        cubeOracleIds.push(oid);
+      }
+    }
+
     // Get bot prediction for this pack using actual bot logic
-    const botResult = await getBotPrediction(oracleIds);
+    const botResult = await getBotPrediction(oracleIds, cubeOracleIds);
 
     // Create S3 data
     const s3Data = {

--- a/packages/server/src/serverutils/cubefn.ts
+++ b/packages/server/src/serverutils/cubefn.ts
@@ -9,7 +9,7 @@ import Papa from 'papaparse';
 import sanitizeHtml from 'sanitize-html';
 
 import { cardFromId, getAllVersionIds, reasonableId } from './carddb';
-import { batchDraft } from './ml';
+import { batchDraft, cubeContext as encodeCubeContext } from './ml';
 import * as util from './util';
 
 interface CubeCard {
@@ -649,8 +649,25 @@ async function generateBalancedPack(
     candidates.push({ packResult, oracleIds });
   }
 
+  // Compute the cube's 32-dim context embedding once and pass it to every batch input.
+  // Without it the draft decoder receives a 128-dim input where it expects 160 and the
+  // ML service returns empty predictions — bot weights all come back as zeros.
+  const cubeOraclesForContext: string[] = Array.from(
+    new Set<string>(
+      (cards.mainboard ?? [])
+        .map((card: any) => card.details?.oracle_id as string | undefined)
+        .filter((id: string | undefined): id is string => Boolean(id)),
+    ),
+  );
+  const cubeCtxEmbedding = await encodeCubeContext(cubeOraclesForContext);
+  const cubeCtx = cubeCtxEmbedding.length > 0 ? cubeCtxEmbedding : undefined;
+
   // Single batched ML call for all candidates (P1P1: pack=oracleIds, pool=[])
-  const batchInputs = candidates.map((c) => ({ pack: c.oracleIds, pool: [] as string[] }));
+  const batchInputs = candidates.map((c) => ({
+    pack: c.oracleIds,
+    pool: [] as string[],
+    cubeContext: cubeCtx,
+  }));
   const batchResults = await batchDraft(batchInputs);
 
   for (let i = 0; i < candidates.length; i++) {

--- a/packages/server/src/serverutils/userUtil.ts
+++ b/packages/server/src/serverutils/userUtil.ts
@@ -1,5 +1,5 @@
 import { getOracleForMl } from 'serverutils/carddb';
-import { draft } from 'serverutils/ml';
+import { cubeContext as encodeCubeContext, draft } from 'serverutils/ml';
 
 /**
  * Utility functions for handling user data in P1P1 packs
@@ -16,9 +16,14 @@ interface BotResult {
 }
 
 /**
- * Get bot prediction for a pack of oracle IDs
+ * Get bot prediction for a pack of oracle IDs.
+ *
+ * Pass the cube's oracle ids via `cubeOracles` so we can compute the 32-dim cube
+ * context the draft decoder needs (it expects pool[128] ⊕ cube_ctx[32] = 160 dims).
+ * Without it the ML service silently returns empty predictions and bot weights
+ * come back as all zeros — chips render uniformly in the P1P1 UI.
  */
-export const getBotPrediction = async (oracleIds: string[]): Promise<BotResult> => {
+export const getBotPrediction = async (oracleIds: string[], cubeOracles?: string[]): Promise<BotResult> => {
   try {
     const validOracleIds = oracleIds.filter(Boolean);
 
@@ -38,8 +43,15 @@ export const getBotPrediction = async (oracleIds: string[]): Promise<BotResult> 
 
     const mlOracleIds = validOracleIds.map((o) => toMl[o] ?? o);
 
+    let cubeCtx: number[] | undefined;
+    if (cubeOracles && cubeOracles.length > 0) {
+      const mlCubeOracles = Array.from(new Set(cubeOracles.map((o) => getOracleForMl(o, null))));
+      const embedding = await encodeCubeContext(mlCubeOracles);
+      if (embedding.length > 0) cubeCtx = embedding;
+    }
+
     // Call the draft function directly instead of making HTTP request
-    const mlPredictions: BotPrediction[] = await draft(mlOracleIds, []); // Empty picks for P1P1
+    const mlPredictions: BotPrediction[] = await draft(mlOracleIds, [], cubeCtx); // Empty picks for P1P1
 
     // Map ML oracles back to originals
     const predictions = mlPredictions.map((p) => ({

--- a/packages/server/test/utils/cubefn.test.ts
+++ b/packages/server/test/utils/cubefn.test.ts
@@ -9,6 +9,7 @@ import { createCardDetails, createChangelogCardAdd, createCube, createCustomCard
 // Mock dependencies
 jest.mock('serverutils/ml', () => ({
   batchDraft: jest.fn(),
+  cubeContext: jest.fn().mockResolvedValue([]),
 }));
 jest.mock('@utils/drafting/createdraft');
 jest.mock('serverutils/carddb');


### PR DESCRIPTION
Two bugs combined to make bot rating chips display as uniform 7% in the P1P1 view and the deck pick-by-pick view (both consumers of the server ML service via /api/draftbots/*).

1) Missing cube context

   The draft decoder needs a 160-dim input (pool[128] ⊕ cube_ctx[32]),
   but the predict route, getBotPrediction, and generateBalancedPack
   were all sending only the 128-dim pool. The ML service silently
   returned empty / zero predictions.

   - predict.ts: accept optional cubeContext on the body schema and forward it to draft(), matching the batchpredict route that already supported this.
   - generateBalancedPack (cubefn.ts): compute the cube's 32-dim context embedding once from the mainboard oracle ids and pass it to every batchDraft input.
   - getBotPrediction (userUtil.ts): accept an optional cubeOracles param, encode it via cubeContextEncoder, and forward to draft().
   - createp1p1frompack: collect mainboard oracle ids from the cube and pass them through.
   - DecksPickBreakdown.tsx: fetch /api/draftbots/cubecontext on mount using draft.cube, cache it, and pass it on every predict call.

2) Double-softmax

   With (1) fixed, the ML service returned real probabilities (e.g.,
   top picks at 16.5 / 15.5 / 14.0 %), but the UI then ran them
   through modelScoresToProbabilities — i.e., softmax of values
   already in a 0.06–0.17 range, which collapses to ~uniform 1/N
   (6.67% → 7% chips). The simulator pick view is unaffected because
   it consumes raw logits from the client-side TF.js bot, where
   softmax is the correct transformation.

   - New normalizeProbabilities helper in botRatings.ts — renormalizes already-probability-shaped values to sum to 1, defensive against voucher-style summed entries.
   - P1P1PackDisplay and DecksPickBreakdown switched to normalizeProbabilities for the server-rating path.
   - modelScoresToProbabilities kept and documented as "for raw logit inputs" for the TF.js bot path.