### PR TITLE
fix: reduce complexity of isReasonable check

### DIFF
--- a/packages/client/src/components/cube/CubeListEditSidebar.tsx
+++ b/packages/client/src/components/cube/CubeListEditSidebar.tsx
@@ -473,11 +473,7 @@ const CubeListEditSidebar: React.FC<CubeListEditSidebarProps> = ({ isHorizontal 
                 checked={specifyEdition}
                 setChecked={(value) => setSpecifyEdition(value)}
               />
-              <Checkbox
-                label="Show Extras"
-                checked={showExtras}
-                setChecked={(value) => setShowExtras(value)}
-              />
+              <Checkbox label="Show Extras" checked={showExtras} setChecked={(value) => setShowExtras(value)} />
             </div>
 
             {/* Create Blog Post */}

--- a/packages/client/src/components/cube/CubeListEditSidebar.tsx
+++ b/packages/client/src/components/cube/CubeListEditSidebar.tsx
@@ -72,11 +72,11 @@ const CubeListEditSidebar: React.FC<CubeListEditSidebarProps> = ({ isHorizontal 
   const [postContent, setPostContent] = useLocalStorage(`${cube.id}-blogpost`, '');
   const [postTitle, setPostTitle] = useLocalStorage(`${cube.id}-blogtitle`, DEFAULT_BLOG_TITLE);
   const [specifyEdition, setSpecifyEdition] = useLocalStorage(`${cube.id}-specifyEdition`, false);
-  const [includeExtras, setIncludeExtras] = useLocalStorage(`${cube.id}-includeExtras`, false);
+  const [showExtras, setShowExtras] = useLocalStorage(`${cube.id}-showExtras`, false);
   const [boardToEdit, setBoardToEdit] = useLocalStorage<BoardType>(`${cube.id}-editBoard`, 'mainboard');
 
   // Memoize so AutocompleteInput's cache is only invalidated when options change
-  const addCardMatches = useMemo(() => cardNameMatches(specifyEdition, includeExtras), [specifyEdition, includeExtras]);
+  const addCardMatches = useMemo(() => cardNameMatches(specifyEdition, showExtras), [specifyEdition, showExtras]);
 
   // Get board options from cube's board definitions
   const boardOptions = useMemo(() => {
@@ -313,7 +313,7 @@ const CubeListEditSidebar: React.FC<CubeListEditSidebarProps> = ({ isHorizontal 
               checked={specifyEdition}
               setChecked={(value) => setSpecifyEdition(value)}
             />
-            <Checkbox label="Include Extras" checked={includeExtras} setChecked={(value) => setIncludeExtras(value)} />
+            <Checkbox label="Show Extras" checked={showExtras} setChecked={(value) => setShowExtras(value)} />
             <Flexbox direction="row" gap="2" alignItems="center">
               <Checkbox label="Create Blog Post" checked={useBlog} setChecked={(value) => setUseBlog(value)} />
               <Tooltip text="The last checked status for 'Create Blog Post' will be remembered per Cube. The default can be set in your display preferences now.">
@@ -474,9 +474,9 @@ const CubeListEditSidebar: React.FC<CubeListEditSidebarProps> = ({ isHorizontal 
                 setChecked={(value) => setSpecifyEdition(value)}
               />
               <Checkbox
-                label="Include Extras"
-                checked={includeExtras}
-                setChecked={(value) => setIncludeExtras(value)}
+                label="Show Extras"
+                checked={showExtras}
+                setChecked={(value) => setShowExtras(value)}
               />
             </div>
 

--- a/packages/jobs/src/update_cards.ts
+++ b/packages/jobs/src/update_cards.ts
@@ -522,11 +522,12 @@ function convertCard(
   newcard.popularity = 0;
   newcard.cubeCount = 0;
   newcard.pickCount = 0;
-  
+
   // Mark component=meld_result as extra.
-  const isMeldResult = card.layout === 'meld' && card.all_parts?.some((part) => part.id === card.id && part.component === 'meld_result');
+  const isMeldResult =
+    card.layout === 'meld' && card.all_parts?.some((part) => part.id === card.id && part.component === 'meld_result');
   newcard.isExtra = !!preflipped || !!isMeldResult;
-  
+
   if (metadata) {
     newcard.elo = metadata.elo;
     newcard.popularity = metadata.popularity;

--- a/packages/jobs/src/update_cards.ts
+++ b/packages/jobs/src/update_cards.ts
@@ -522,7 +522,11 @@ function convertCard(
   newcard.popularity = 0;
   newcard.cubeCount = 0;
   newcard.pickCount = 0;
-  newcard.isExtra = !!preflipped;
+  
+  // Mark component=meld_result as extra.
+  const isMeldResult = card.layout === 'meld' && card.all_parts?.some((part) => part.id === card.id && part.component === 'meld_result');
+  newcard.isExtra = !!preflipped || !!isMeldResult;
+  
   if (metadata) {
     newcard.elo = metadata.elo;
     newcard.popularity = metadata.popularity;
@@ -542,16 +546,7 @@ function convertCard(
   newcard.released_at = card.released_at;
   newcard.reprint = card.reprint;
 
-  newcard.promo =
-    card.promo ||
-    (card.frame_effects && card.frame_effects.includes('extendedart')) ||
-    (card.frame_effects && card.frame_effects.includes('showcase')) ||
-    card.textless ||
-    card.frame === 'art_series' ||
-    card.set.toLowerCase() === 'mps' || // kaladesh masterpieces
-    card.set.toLowerCase() === 'mp2' || // invocations
-    card.set.toLowerCase() === 'exp' || // expeditions
-    card.set.toLowerCase() === 'amh1'; // mh1 art cards
+  newcard.promo = card.promo;
   newcard.prices = {
     usd: card.prices.usd ? parseFloat(card.prices.usd) : undefined,
     usd_foil: card.prices.usd_foil ? parseFloat(card.prices.usd_foil) : undefined,

--- a/packages/server/test/cards/deckutil.test.ts
+++ b/packages/server/test/cards/deckutil.test.ts
@@ -257,10 +257,11 @@ describe('reasonableCard', () => {
     promo: false,
     digital: false,
     isToken: false,
+    set: 'dom',
+    set_type: 'expansion',
     border_color: 'black',
     promo_types: undefined,
     language: 'en',
-    tcgplayer_id: '12345',
     collector_number: '270',
     layout: 'normal',
   };
@@ -277,10 +278,10 @@ describe('reasonableCard', () => {
     expect(reasonableCard(details)).toBeFalsy();
   });
 
-  it('Promos are not reasonable', async () => {
+  it('Promos are reasonable if not excluded by set_type', async () => {
     const details = createCardDetails({ ...overridesForNormalDetails, promo: true });
 
-    expect(reasonableCard(details)).toBeFalsy();
+    expect(reasonableCard(details)).toBeTruthy();
   });
 
   it('Digital cards are not reasonable', async () => {
@@ -295,47 +296,8 @@ describe('reasonableCard', () => {
     expect(reasonableCard(details)).toBeFalsy();
   });
 
-  it('Gold borders are not reasonable', async () => {
-    const details = createCardDetails({ ...overridesForNormalDetails, border_color: 'gold' });
-
-    expect(reasonableCard(details)).toBeFalsy();
-  });
-
-  it('Promo variants are not reasonable', async () => {
-    const details = createCardDetails({ ...overridesForNormalDetails, promo_types: ['boosterfun'] });
-
-    expect(reasonableCard(details)).toBeFalsy();
-  });
-
-  it('Universes beyond promo type is reasonable', async () => {
-    const details = createCardDetails({ ...overridesForNormalDetails, promo_types: ['universesbeyond'] });
-
-    expect(reasonableCard(details)).toBeTruthy();
-  });
-
-  it('UB cards with source-material promo types are reasonable', async () => {
-    const details = createCardDetails({
-      ...overridesForNormalDetails,
-      promo_types: ['ffiii', 'sourcematerial', 'universesbeyond'],
-    });
-
-    expect(reasonableCard(details)).toBeTruthy();
-  });
-
-  it('UB cards with unreasonable promo types are not reasonable', async () => {
-    const details = createCardDetails({ ...overridesForNormalDetails, promo_types: ['universesbeyond', 'surgefoil'] });
-
-    expect(reasonableCard(details)).toBeFalsy();
-  });
-
   it('Non-english cards are not reasonable', async () => {
     const details = createCardDetails({ ...overridesForNormalDetails, language: 'fr' });
-
-    expect(reasonableCard(details)).toBeFalsy();
-  });
-
-  it('Must have TGC player ID to be reasonable', async () => {
-    const details = createCardDetails({ ...overridesForNormalDetails, tcgplayer_id: undefined });
 
     expect(reasonableCard(details)).toBeFalsy();
   });
@@ -346,10 +308,144 @@ describe('reasonableCard', () => {
     expect(reasonableCard(details)).toBeFalsy();
   });
 
-  it('Must not be an art series card to be reasonable', async () => {
-    const details = createCardDetails({ ...overridesForNormalDetails, layout: 'art_series' });
+  it('Cards with flavor name are not reasonable', async () => {
+    const details = createCardDetails({ ...overridesForNormalDetails, hasFlavorName: true });
 
     expect(reasonableCard(details)).toBeFalsy();
+  });
+
+  describe('set_type', () => {
+    it('Masterpiece is not reasonable', async () => {
+      const details = createCardDetails({ ...overridesForNormalDetails, set_type: 'masterpiece' });
+
+      expect(reasonableCard(details)).toBeFalsy();
+    });
+
+    it('Memorabilia is not reasonable', async () => {
+      const details = createCardDetails({ ...overridesForNormalDetails, set_type: 'memorabilia' });
+
+      expect(reasonableCard(details)).toBeFalsy();
+    });
+
+    it('Undefined is reasonable', async () => {
+      const details = createCardDetails({ ...overridesForNormalDetails, set_type: undefined });
+
+      expect(reasonableCard(details)).toBeTruthy();
+    });
+
+    it('Token is not reasonable', async () => {
+      const details = createCardDetails({ ...overridesForNormalDetails, set_type: 'token' });
+
+      expect(reasonableCard(details)).toBeFalsy();
+    });
+
+    it('Promo set_type is not reasonable', async () => {
+      const details = createCardDetails({ ...overridesForNormalDetails, set_type: 'promo' });
+
+      expect(reasonableCard(details)).toBeFalsy();
+    });
+
+    it('Funny is reasonable', async () => {
+      const details = createCardDetails({ ...overridesForNormalDetails, set_type: 'funny' });
+
+      expect(reasonableCard(details)).toBeTruthy();
+    });
+  });
+
+  describe('set', () => {
+    it('The List (plst) is not reasonable', async () => {
+      const details = createCardDetails({ ...overridesForNormalDetails, set: 'plst' });
+
+      expect(reasonableCard(details)).toBeFalsy();
+    });
+  });
+
+  describe('promo_types', () => {
+    it('Boosterfun is reasonable', async () => {
+      const details = createCardDetails({ ...overridesForNormalDetails, promo_types: ['boosterfun'] });
+
+      expect(reasonableCard(details)).toBeTruthy();
+    });
+
+    it('Promopack is not reasonable', async () => {
+      const details = createCardDetails({ ...overridesForNormalDetails, promo_types: ['promopack'] });
+
+      expect(reasonableCard(details)).toBeFalsy();
+    });
+
+    it('Universes beyond is reasonable', async () => {
+      const details = createCardDetails({ ...overridesForNormalDetails, promo_types: ['universesbeyond'] });
+
+      expect(reasonableCard(details)).toBeTruthy();
+    });
+
+    it('UB with source-material promo types is reasonable', async () => {
+      const details = createCardDetails({
+        ...overridesForNormalDetails,
+        promo_types: ['ffiii', 'sourcematerial', 'universesbeyond'],
+      });
+
+      expect(reasonableCard(details)).toBeTruthy();
+    });
+
+    it('UB with unreasonable promo types is not reasonable', async () => {
+      const details = createCardDetails({
+        ...overridesForNormalDetails,
+        promo_types: ['universesbeyond', 'prerelease'],
+      });
+
+      expect(reasonableCard(details)).toBeFalsy();
+    });
+
+    it('Surgefoil is reasonable', async () => {
+      const details = createCardDetails({ ...overridesForNormalDetails, promo_types: ['surgefoil'] });
+
+      expect(reasonableCard(details)).toBeTruthy();
+    });
+  });
+
+  describe('layout', () => {
+    it('Art series is not reasonable', async () => {
+      const details = createCardDetails({ ...overridesForNormalDetails, layout: 'art_series' });
+
+      expect(reasonableCard(details)).toBeFalsy();
+    });
+
+    it('Double faced tokens are not reasonable', async () => {
+      const details = createCardDetails({ ...overridesForNormalDetails, layout: 'double_faced_token' });
+
+      expect(reasonableCard(details)).toBeFalsy();
+    });
+
+    it('Scheme is not reasonable', async () => {
+      const details = createCardDetails({ ...overridesForNormalDetails, layout: 'scheme' });
+
+      expect(reasonableCard(details)).toBeFalsy();
+    });
+
+    it('Planar is not reasonable', async () => {
+      const details = createCardDetails({ ...overridesForNormalDetails, layout: 'planar' });
+
+      expect(reasonableCard(details)).toBeFalsy();
+    });
+
+    it('Vanguard is not reasonable', async () => {
+      const details = createCardDetails({ ...overridesForNormalDetails, layout: 'vanguard' });
+
+      expect(reasonableCard(details)).toBeFalsy();
+    });
+
+    it('Token is not reasonable', async () => {
+      const details = createCardDetails({ ...overridesForNormalDetails, layout: 'token' });
+
+      expect(reasonableCard(details)).toBeFalsy();
+    });
+
+    it('Emblem is not reasonable', async () => {
+      const details = createCardDetails({ ...overridesForNormalDetails, layout: 'emblem' });
+
+      expect(reasonableCard(details)).toBeFalsy();
+    });
   });
 });
 

--- a/packages/utils/src/cardutil.ts
+++ b/packages/utils/src/cardutil.ts
@@ -638,21 +638,17 @@ export const isManaFixingLand = (details: CardDetailsType): boolean => {
   return BASIC_LAND_TYPE_NAMES.some((name) => text.includes(name));
 };
 
-const UNREASONABLE_PROMO_TYPES = [
-  'surgefoil',
-  'galaxyfoil',
-  'textured',
-  'serialized',
-  'gilded',
-  'neonink',
-  'oilslick',
-  'rainbowfoil',
-  'confettifoil',
-  'embossed',
-  'boosterfun',
-  'promopack',
-  'prerelease',
-  'datestamped',
+const UNREASONABLE_PROMO_TYPES = ['promopack', 'prerelease', 'datestamped', 'firstplacefoil', 'serialized'];
+const UNREASONABLE_SET_TYPES = ['masterpiece', 'memorabilia', 'token', 'promo'];
+const UNREASONABLE_SETS = ['plst'];
+const UNREASONABLE_LAYOUTS = [
+  'scheme',
+  'planar',
+  'vanguard',
+  'token',
+  'double_faced_token',
+  'art_series',
+  'emblem',
 ];
 
 const arePromoTypesReasonable = (card: CardDetailsType): boolean => {
@@ -660,20 +656,20 @@ const arePromoTypesReasonable = (card: CardDetailsType): boolean => {
   return !card.promo_types.some((type) => UNREASONABLE_PROMO_TYPES.includes(type));
 };
 
+// This is fairly arbitrary. Some of the foilings could be considered okay.
+// I think ultimately the goal here should be to filter down to cards/printings that people are reasonably likely to put in a cube.
 export function reasonableCard(card: CardDetailsType): boolean {
   return (
-    !card.isExtra &&
-    !card.promo &&
     !card.digital &&
-    !card.isToken &&
-    card.border_color !== 'gold' &&
+    !card.isExtra &&
+    !UNREASONABLE_SET_TYPES.includes(card.set_type ?? '') &&
+    !UNREASONABLE_LAYOUTS.includes(card.layout) &&
+    !UNREASONABLE_SETS.includes(card.set) &&
     arePromoTypesReasonable(card) &&
     card.language === 'en' &&
-    card.tcgplayer_id !== undefined &&
     card.collector_number.indexOf('★') === -1 &&
-    card.layout !== 'art_series' &&
-    card.layout !== 'double_faced_token' &&
-    !card?.hasFlavorName
+    !card?.hasFlavorName &&
+    !card.isToken
   );
 }
 

--- a/packages/utils/src/cardutil.ts
+++ b/packages/utils/src/cardutil.ts
@@ -641,15 +641,7 @@ export const isManaFixingLand = (details: CardDetailsType): boolean => {
 const UNREASONABLE_PROMO_TYPES = ['promopack', 'prerelease', 'datestamped', 'firstplacefoil', 'serialized'];
 const UNREASONABLE_SET_TYPES = ['masterpiece', 'memorabilia', 'token', 'promo'];
 const UNREASONABLE_SETS = ['plst'];
-const UNREASONABLE_LAYOUTS = [
-  'scheme',
-  'planar',
-  'vanguard',
-  'token',
-  'double_faced_token',
-  'art_series',
-  'emblem',
-];
+const UNREASONABLE_LAYOUTS = ['scheme', 'planar', 'vanguard', 'token', 'double_faced_token', 'art_series', 'emblem'];
 
 const arePromoTypesReasonable = (card: CardDetailsType): boolean => {
   if (!card.promo_types || card.promo_types.length === 0) return true;


### PR DESCRIPTION
I think it's probably preferable to have promo match scryfall where possible, that'll be more intuitive. From there that lets isReasonable have more control over defining its own conditions. I still think the primary issue here, though, is that you can't do this in isolation. It's possible to have an unreasonable card be the _only_ option. We might instead just need to rely on filtering out known bad things, like tokens and art_series cards, since those should never be normal cube inclusions.