### PR TITLE
fix: add extras toggles to card name search fields

### DIFF
--- a/packages/client/src/components/DeckbuilderNavbar.tsx
+++ b/packages/client/src/components/DeckbuilderNavbar.tsx
@@ -240,7 +240,7 @@ const DeckbuilderNavbar: React.FC<DeckbuilderNavbarProps> = ({
           <PlusIcon size={16} className="text-text-secondary" />
           <AutocompleteInput
             cubeId={cubeID}
-            getMatches={cardNameMatches(false)}
+            getMatches={cardNameMatches(false, true)}
             type="text"
             innerRef={addCardRef}
             name="add-card"

--- a/packages/client/src/components/content/EditArticle.tsx
+++ b/packages/client/src/components/content/EditArticle.tsx
@@ -85,7 +85,7 @@ const EditArticle: React.FC<EditArticleProps> = ({
                 Thumbnail:
               </Text>
               <AutocompleteInput
-                getMatches={cardNameMatches(true)}
+                getMatches={cardNameMatches(true, true)}
                 type="text"
                 className="me-2"
                 name="remove"

--- a/packages/client/src/components/content/EditVideo.tsx
+++ b/packages/client/src/components/content/EditVideo.tsx
@@ -92,7 +92,7 @@ const EditVideo: React.FC<EditVideoProps> = ({
                 Thumbnail:
               </Text>
               <AutocompleteInput
-                getMatches={cardNameMatches(true)}
+                getMatches={cardNameMatches(true, true)}
                 type="text"
                 className="me-2"
                 name="remove"

--- a/packages/client/src/components/cube/CubeListEditSidebar.tsx
+++ b/packages/client/src/components/cube/CubeListEditSidebar.tsx
@@ -35,6 +35,13 @@ import { getCard } from 'utils/cards/getCard';
 
 const DEFAULT_BLOG_TITLE = 'Cube Updated – Automatic Post';
 
+const TOOLTIP_SPECIFY_VERSIONS =
+  'When enabled, searches include set codes and collector numbers in addition to card names (all lowercase). eg "lightning bolt [lea-161]"';
+const TOOLTIP_SHOW_EXTRAS =
+  "When enabled, search includes promos, tokens, digital versions, non-standard layouts, non-English cards, 'flavour' names, special editions, and more.";
+const TOOLTIP_CREATE_BLOG_POST =
+  "The last checked status for 'Create Blog Post' will be remembered per Cube. The default can be set in your display preferences now.";
+
 const PasteBulkButton = withModal(Button, PasteBulkModal);
 const UploadBulkButton = withModal(Button, UploadBulkModal);
 const UploadBulkReplaceButton = withModal(Button, UploadBulkReplaceModal);
@@ -308,15 +315,25 @@ const CubeListEditSidebar: React.FC<CubeListEditSidebarProps> = ({ isHorizontal 
           </Flexbox>
 
           <Flexbox direction="col" gap="2">
-            <Checkbox
-              label="Specify Versions"
-              checked={specifyEdition}
-              setChecked={(value) => setSpecifyEdition(value)}
-            />
-            <Checkbox label="Show Extras" checked={showExtras} setChecked={(value) => setShowExtras(value)} />
+            <Flexbox direction="row" gap="2" alignItems="center">
+              <Checkbox
+                label="Specify Versions"
+                checked={specifyEdition}
+                setChecked={(value) => setSpecifyEdition(value)}
+              />
+              <Tooltip text={TOOLTIP_SPECIFY_VERSIONS}>
+                <QuestionIcon size={16} className="hidden md:inline" />
+              </Tooltip>
+            </Flexbox>
+            <Flexbox direction="row" gap="2" alignItems="center">
+              <Checkbox label="Show Extras" checked={showExtras} setChecked={(value) => setShowExtras(value)} />
+              <Tooltip text={TOOLTIP_SHOW_EXTRAS}>
+                <QuestionIcon size={16} className="hidden md:inline" />
+              </Tooltip>
+            </Flexbox>
             <Flexbox direction="row" gap="2" alignItems="center">
               <Checkbox label="Create Blog Post" checked={useBlog} setChecked={(value) => setUseBlog(value)} />
-              <Tooltip text="The last checked status for 'Create Blog Post' will be remembered per Cube. The default can be set in your display preferences now.">
+              <Tooltip text={TOOLTIP_CREATE_BLOG_POST}>
                 <QuestionIcon size={16} className="hidden md:inline" />
               </Tooltip>
             </Flexbox>
@@ -468,18 +485,28 @@ const CubeListEditSidebar: React.FC<CubeListEditSidebarProps> = ({ isHorizontal 
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mt-4">
             {/* Specify Versions */}
             <div className="flex items-center gap-4">
-              <Checkbox
-                label="Specify Versions"
-                checked={specifyEdition}
-                setChecked={(value) => setSpecifyEdition(value)}
-              />
-              <Checkbox label="Show Extras" checked={showExtras} setChecked={(value) => setShowExtras(value)} />
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  label="Specify Versions"
+                  checked={specifyEdition}
+                  setChecked={(value) => setSpecifyEdition(value)}
+                />
+                <Tooltip text={TOOLTIP_SPECIFY_VERSIONS}>
+                  <QuestionIcon size={16} />
+                </Tooltip>
+              </div>
+              <div className="flex items-center gap-2">
+                <Checkbox label="Show Extras" checked={showExtras} setChecked={(value) => setShowExtras(value)} />
+                <Tooltip text={TOOLTIP_SHOW_EXTRAS}>
+                  <QuestionIcon size={16} />
+                </Tooltip>
+              </div>
             </div>
 
             {/* Create Blog Post */}
             <div className="flex items-center gap-2">
               <Checkbox label="Create Blog Post" checked={useBlog} setChecked={(value) => setUseBlog(value)} />
-              <Tooltip text="The last checked status for 'Create Blog Post' will be remembered per Cube. The default can be set in your display preferences now.">
+              <Tooltip text={TOOLTIP_CREATE_BLOG_POST}>
                 <QuestionIcon size={16} />
               </Tooltip>
             </div>

--- a/packages/client/src/pages/BulkUploadPage.tsx
+++ b/packages/client/src/pages/BulkUploadPage.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useContext, useMemo, useRef, useState } from 'react';
 
+import { QuestionIcon } from '@primer/octicons-react';
+
 import CardType, { Changes } from '@utils/datatypes/Card';
 import Cube from '@utils/datatypes/Cube';
 
@@ -9,6 +11,7 @@ import { Card, CardBody, CardHeader } from 'components/base/Card';
 import Checkbox from 'components/base/Checkbox';
 import { Col, Flexbox, Row } from 'components/base/Layout';
 import Text from 'components/base/Text';
+import Tooltip from 'components/base/Tooltip';
 import Changelist from 'components/Changelist';
 import DynamicFlash from 'components/DynamicFlash';
 import LoadingButton from 'components/LoadingButton';
@@ -24,6 +27,9 @@ import { cardNameMatches } from 'utils/cardAutocomplete';
 import { getCard } from 'utils/cards/getCard';
 
 const DEFAULT_BLOG_TITLE = 'Cube Updated - Automatic Post';
+
+const TOOLTIP_SHOW_EXTRAS =
+  "When enabled, search includes promos, tokens, digital versions, non-standard layouts, non-English cards, 'flavour' names, special editions, and more.";
 
 interface BulkUploadPageRawProps {
   missing: string[];
@@ -202,7 +208,12 @@ const BulkUploadPageRaw: React.FC<BulkUploadPageRawProps> = ({ missing, addedByB
                       </LoadingButton>
                     </Col>
                     <Col xs={12}>
-                      <Checkbox label="Show Extras" checked={showExtras} setChecked={setShowExtras} />
+                      <Flexbox direction="row" gap="2" alignItems="center">
+                        <Checkbox label="Show Extras" checked={showExtras} setChecked={setShowExtras} />
+                        <Tooltip text={TOOLTIP_SHOW_EXTRAS}>
+                          <QuestionIcon size={16} />
+                        </Tooltip>
+                      </Flexbox>
                     </Col>
                   </Row>
                 )}

--- a/packages/client/src/pages/BulkUploadPage.tsx
+++ b/packages/client/src/pages/BulkUploadPage.tsx
@@ -207,7 +207,7 @@ const BulkUploadPageRaw: React.FC<BulkUploadPageRawProps> = ({ missing, addedByB
                         Add
                       </LoadingButton>
                     </Col>
-                    <Col xs={12}>
+                    <Col xs={12} className="mb-2">
                       <Flexbox direction="row" gap="2" alignItems="center">
                         <Checkbox label="Show Extras" checked={showExtras} setChecked={setShowExtras} />
                         <Tooltip text={TOOLTIP_SHOW_EXTRAS}>

--- a/packages/client/src/pages/BulkUploadPage.tsx
+++ b/packages/client/src/pages/BulkUploadPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useRef, useState } from 'react';
+import React, { useCallback, useContext, useMemo, useRef, useState } from 'react';
 
 import CardType, { Changes } from '@utils/datatypes/Card';
 import Cube from '@utils/datatypes/Cube';
@@ -6,6 +6,7 @@ import Cube from '@utils/datatypes/Cube';
 import AutocompleteInput from 'components/base/AutocompleteInput';
 import Button from 'components/base/Button';
 import { Card, CardBody, CardHeader } from 'components/base/Card';
+import Checkbox from 'components/base/Checkbox';
 import { Col, Flexbox, Row } from 'components/base/Layout';
 import Text from 'components/base/Text';
 import Changelist from 'components/Changelist';
@@ -34,6 +35,9 @@ interface BulkUploadPageRawProps {
 const BulkUploadPageRaw: React.FC<BulkUploadPageRawProps> = ({ missing, addedByBoard, changelog }) => {
   const { csrfFetch } = useContext(CSRFContext);
   const [addValue, setAddValue] = useState('');
+  const [showExtras, setShowExtras] = useState(false);
+
+  const addCardMatches = useMemo(() => cardNameMatches(false, showExtras), [showExtras]);
 
   const { alerts, setAlerts, cube, loading, addCard, commitChanges, clearChanges } = useContext(CubeContext);
   const { changes, setChanges } = useContext(ChangesContext);
@@ -177,7 +181,7 @@ const BulkUploadPageRaw: React.FC<BulkUploadPageRawProps> = ({ missing, addedByB
                   <Row>
                     <Col xs={8}>
                       <AutocompleteInput
-                        getMatches={cardNameMatches(false)}
+                        getMatches={addCardMatches}
                         type="text"
                         innerRef={addInput}
                         value={addValue}
@@ -196,6 +200,9 @@ const BulkUploadPageRaw: React.FC<BulkUploadPageRawProps> = ({ missing, addedByB
                       >
                         Add
                       </LoadingButton>
+                    </Col>
+                    <Col xs={12}>
+                      <Checkbox label="Show Extras" checked={showExtras} setChecked={setShowExtras} />
                     </Col>
                   </Row>
                 )}

--- a/packages/client/src/pages/CreatePackagePage.tsx
+++ b/packages/client/src/pages/CreatePackagePage.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
 
 import { AlertIcon } from '@primer/octicons-react';
 
@@ -6,6 +6,7 @@ import Alert from 'components/base/Alert';
 import AutocompleteInput from 'components/base/AutocompleteInput';
 import Button from 'components/base/Button';
 import { Card, CardBody, CardHeader } from 'components/base/Card';
+import Checkbox from 'components/base/Checkbox';
 import Container from 'components/base/Container';
 import Input from 'components/base/Input';
 import { Col, Flexbox, Row } from 'components/base/Layout';
@@ -26,6 +27,9 @@ const CreatePackagePage: React.FC = () => {
   // doesn't resolve. Gates the Add button (replaces the old in-memory imagedict).
   const [resolvedId, setResolvedId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [showExtras, setShowExtras] = useState(true);
+
+  const addCardMatches = useMemo(() => cardNameMatches(true, showExtras), [showExtras]);
 
   useEffect(() => {
     if (!cardName) {
@@ -114,7 +118,7 @@ const CreatePackagePage: React.FC = () => {
                 />
 
                 <AutocompleteInput
-                  getMatches={cardNameMatches(true, true)}
+                  getMatches={addCardMatches}
                   type="text"
                   className="me-2"
                   name="add-card"
@@ -128,6 +132,7 @@ const CreatePackagePage: React.FC = () => {
                   autoComplete="off"
                   data-lpignore
                 />
+                <Checkbox label="Show Extras" checked={showExtras} setChecked={setShowExtras} />
                 <Button color="primary" block onClick={submitCard} disabled={!resolvedId}>
                   Add Card
                 </Button>

--- a/packages/client/src/pages/CreatePackagePage.tsx
+++ b/packages/client/src/pages/CreatePackagePage.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useMemo, useState } from 'react';
 
-import { AlertIcon } from '@primer/octicons-react';
+import { AlertIcon, QuestionIcon } from '@primer/octicons-react';
 
 import Alert from 'components/base/Alert';
 import AutocompleteInput from 'components/base/AutocompleteInput';
@@ -11,12 +11,16 @@ import Container from 'components/base/Container';
 import Input from 'components/base/Input';
 import { Col, Flexbox, Row } from 'components/base/Layout';
 import Text from 'components/base/Text';
+import Tooltip from 'components/base/Tooltip';
 import DynamicFlash from 'components/DynamicFlash';
 import LoadingButton from 'components/LoadingButton';
 import RenderToRoot from 'components/RenderToRoot';
 import { CSRFContext } from 'contexts/CSRFContext';
 import MainLayout from 'layouts/MainLayout';
 import { cardNameMatches, fetchCardImage } from 'utils/cardAutocomplete';
+
+const TOOLTIP_SHOW_EXTRAS =
+  "When enabled, search includes promos, tokens, digital versions, non-standard layouts, non-English cards, 'flavour' names, special editions, and more.";
 
 const CreatePackagePage: React.FC = () => {
   const { csrfFetch } = useContext(CSRFContext);
@@ -132,7 +136,12 @@ const CreatePackagePage: React.FC = () => {
                   autoComplete="off"
                   data-lpignore
                 />
-                <Checkbox label="Show Extras" checked={showExtras} setChecked={setShowExtras} />
+                <Flexbox direction="row" gap="2" alignItems="center">
+                  <Checkbox label="Show Extras" checked={showExtras} setChecked={setShowExtras} />
+                  <Tooltip text={TOOLTIP_SHOW_EXTRAS}>
+                    <QuestionIcon size={16} />
+                  </Tooltip>
+                </Flexbox>
                 <Button color="primary" block onClick={submitCard} disabled={!resolvedId}>
                   Add Card
                 </Button>

--- a/packages/client/src/records/UploadDeck.tsx
+++ b/packages/client/src/records/UploadDeck.tsx
@@ -182,7 +182,7 @@ const UploadDeck: React.FC<UploadDeckProps> = ({
       <Flexbox direction="row" justify="start" gap="2">
         <AutocompleteInput
           cubeId={cubeId}
-          getMatches={allowCardsOutsideOfCube ? cardNameMatches(false) : cubeCardNameMatches(cubeId, 'mainboard')}
+          getMatches={allowCardsOutsideOfCube ? cardNameMatches(false, true) : cubeCardNameMatches(cubeId, 'mainboard')}
           type="text"
           innerRef={removeRef}
           name="remove"

--- a/packages/client/src/utils/cardAutocomplete.ts
+++ b/packages/client/src/utils/cardAutocomplete.ts
@@ -46,7 +46,7 @@ export const cubeThenAllCardNameMatches =
   async (query, signal) => {
     const [cube, all] = await Promise.all([
       cubeCardNameMatches(cubeId, board)(query, signal),
-      cardNameMatches()(query, signal),
+      cardNameMatches(false, true)(query, signal),
     ]);
     const seen = new Set(cube.map((n) => n.toLowerCase()));
     return [...cube, ...all.filter((n) => !seen.has(n.toLowerCase()))];


### PR DESCRIPTION
This incorporates #2941 (without from the changes.md additions).