### PR TITLE
fix: add User-Agent header for Scryfall image CDN requests

### DIFF
--- a/packages/server/src/serverutils/imageUtils.ts
+++ b/packages/server/src/serverutils/imageUtils.ts
@@ -74,7 +74,7 @@ export const generateSamplepackImage = async (
               //Imgur returns a 429 error using the default node-fetch useragent, but it is happy with curl!
               'User-Agent': 'curl/8.5.0',
             },
-          },
+          }
         : source.src.includes('scryfall')
         ? {
             headers: {

--- a/packages/server/src/serverutils/imageUtils.ts
+++ b/packages/server/src/serverutils/imageUtils.ts
@@ -74,6 +74,13 @@ export const generateSamplepackImage = async (
               //Imgur returns a 429 error using the default node-fetch useragent, but it is happy with curl!
               'User-Agent': 'curl/8.5.0',
             },
+          },
+        : source.src.includes('scryfall')
+        ? {
+            headers: {
+              // Scryfall image CDN rejects requests without a User-Agent (same policy as their API)
+              'User-Agent': 'CubeCobra/1.0.0 (+https://cubecobra.com)',
+            },
           }
         : {};
 


### PR DESCRIPTION
Bug

Clicking Get image on a sample pack page shows a flash error:

▎ Input buffer contains unsupported image format

and redirects back to the playtest page instead of serving the pack image.

Root Cause

generateSamplepackImage in imageUtils.ts fetches each card image by URL and composites them with sharp. It already sends a custom User-Agent for Imgur URLs (because Imgur rejects the default Node.js user-agent with a 429), but all other hosts, including Scryfall's image CDN (cards.scryfall.io), received requests with no User-Agent at all.

Scryfall's image CDN has started enforcing the same header policy as their API (documented in the earlier commit that added SCRYFALL_HEADERS to the jobs package: "Scryfall's API requires every request to send a descriptive User-Agent and an Accept header. Requests without them are rejected with HTTP 400"). Requests to cards.scryfall.io without a User-Agent now return a 4xx response whose body is HTML. The downstream call to sharp() then receives that HTML buffer and throws "Input buffer contains unsupported image format", which surfaces as the flash error.

Fix

In commit b8eb99187 add headers to scryfall calls (June 5, 2026), all Scryfall API calls in the jobs package were updated to include User-Agent and Accept: application/json headers. The commit message said explicitly:

▎ "Scryfall's API requires every request to send a descriptive User-Agent and an Accept header. Requests without them are rejected with HTTP 400."

That touched update_cards.ts, apply_scryfall_migrations.ts, and the Lambda monitoring functions essentially every place that calls api.scryfall.com.

So we just have to extend the existing fetchOptions ternary to include Scryfall URLs alongside Imgur, sending the same User-Agent string already used for the Scryfall API in the jobs package.