### PR TITLE
Fix featured queue duplicates on replace

### DIFF
--- a/packages/server/src/dynamo/dao/FeaturedQueueDynamoDao.ts
+++ b/packages/server/src/dynamo/dao/FeaturedQueueDynamoDao.ts
@@ -155,8 +155,14 @@ export class FeaturedQueueDynamoDao extends BaseDynamoDao<FeaturedQueueItem, Unh
       TableName: this.tableName,
       IndexName: 'GSI1',
       KeyConditionExpression: 'GSI1PK = :status',
-      FilterExpression: '#owner = :owner',
+      // Stored items nest their fields under the top-level `item` map (see
+      // BaseDynamoDao.toDynamoItem), so the owner attribute lives at
+      // `item.owner`, not top-level `owner`. Filtering on the bare `owner`
+      // attribute always matched nothing, so owner-scoped lookups silently
+      // returned an empty list.
+      FilterExpression: '#item.#owner = :owner',
       ExpressionAttributeNames: {
+        '#item': 'item',
         '#owner': 'owner',
       },
       ExpressionAttributeValues: {

--- a/packages/server/src/serverutils/featuredQueue.ts
+++ b/packages/server/src/serverutils/featuredQueue.ts
@@ -44,7 +44,9 @@ export async function rotateFeatured(): Promise<RotateResult> {
     const patron = patronMap[cube.owner];
     if (!canBeFeatured(patron)) {
       removedCubes.push(cube);
-      cleanupOperations.push(featuredQueueDao.delete(cube.cube));
+      // delete() keys off the item object (item.cube); passing the bare id
+      // string would derive PK `FEATURED_QUEUE#undefined` and silently no-op.
+      cleanupOperations.push(featuredQueueDao.delete(cube));
     }
   }
 
@@ -125,48 +127,48 @@ export async function doesUserHaveFeaturedCube(userid: string) {
 }
 
 export async function replaceForUser(userid: string, cubeid: string) {
-  // Use the owner-filtered query instead of fetching entire queue
+  // Use the owner-filtered query instead of fetching entire queue. Items come
+  // back ascending by date, so cubes[0] holds the user's earliest (current)
+  // queue slot. A user is only supposed to have one row, but earlier bugs could
+  // leave several behind — handle all of them so the queue self-heals.
   const cubes = await getFeaturedQueueForUser(userid);
 
   if (cubes.length === 0) {
     throw new Error('Cannot replace cube that is not in queue');
   }
 
-  const item = cubes[0]; // User should only have one cube in queue
-
-  if (!item) {
-    throw new Error('Cannot replace cube that is not in queue');
-  }
-
-  // Check if cube is currently featured (in first 2 positions)
+  // Check if any of the user's cubes is currently featured (first 2 positions);
+  // a live-featured cube can't be replaced out from under the rotation.
   const queueResult = await featuredQueueDao.querySortedByDate(undefined, 2);
-  const isFeatured = queueResult.items?.some((queueItem) => queueItem.cube === item?.cube);
-
-  if (isFeatured) {
+  const featuredCubeIds = new Set((queueResult.items ?? []).map((queueItem) => queueItem.cube));
+  if (cubes.some((cube) => featuredCubeIds.has(cube.cube))) {
     throw new Error('Cannot replace cube that is currently featured');
   }
 
+  // Preserve the user's existing spot by reusing their earliest queue date.
+  const date = cubes[0]!.date;
+
   // Queue rows are keyed by cube id, so adding a cube that already has a row
-  // would fail the conditional put (ConditionalCheckFailedException). Detect
-  // that up front: surface a clear error if someone else holds the slot, and
-  // clear a stale self-owned duplicate so the create below can succeed.
-  if (cubeid !== item.cube) {
-    const existing = await featuredQueueDao.getByCube(cubeid);
-    if (existing) {
-      if (existing.owner !== userid) {
-        throw new Error('That cube is already in the featured queue');
-      }
-      await featuredQueueDao.delete(existing);
-    }
+  // would fail the conditional put (ConditionalCheckFailedException). If the
+  // target cube already sits in the queue under another owner, refuse; if it's
+  // one of this user's own rows it'll be cleared by the cleanup below.
+  const existing = await featuredQueueDao.getByCube(cubeid);
+  if (existing && existing.owner !== userid) {
+    throw new Error('That cube is already in the featured queue');
   }
 
-  // remove cube from queue
-  await featuredQueueDao.delete(item);
+  // Remove every row this user currently holds (collapses any stale duplicates),
+  // plus the target cube's own row if it wasn't already one of them.
+  const toDelete = [...cubes];
+  if (existing && !toDelete.some((cube) => cube.cube === existing.cube)) {
+    toDelete.push(existing);
+  }
+  await Promise.all(toDelete.map((cube) => featuredQueueDao.delete(cube)));
 
   // add new cube to queue
   await featuredQueueDao.createFeaturedQueueItem({
     cube: cubeid,
-    date: item.date,
+    date,
     owner: userid,
     featuredOn: null,
   });

--- a/packages/server/test/featuredQueue/rotation.test.ts
+++ b/packages/server/test/featuredQueue/rotation.test.ts
@@ -122,9 +122,9 @@ describe('Featured Queue Rotation', () => {
     expect(result.removed.find((c: any) => c.cube === 'cube5')).toBeTruthy();
     expect(result.messages).toContain('Removed 2 cubes due to patron status');
 
-    // Verify ineligible cubes were deleted
-    expect(featuredQueueDao.delete).toHaveBeenCalledWith('cube3');
-    expect(featuredQueueDao.delete).toHaveBeenCalledWith('cube5');
+    // Verify ineligible cubes were deleted (delete() keys off the item object)
+    expect(featuredQueueDao.delete).toHaveBeenCalledWith(expect.objectContaining({ cube: 'cube3' }));
+    expect(featuredQueueDao.delete).toHaveBeenCalledWith(expect.objectContaining({ cube: 'cube5' }));
 
     // Verify rotation happened with remaining eligible cubes
     expect(result.added).toHaveLength(2);
@@ -160,7 +160,7 @@ describe('Featured Queue Rotation', () => {
     expect(result.success).toBe('true');
     expect(result.removed).toHaveLength(1);
     expect(result.removed[0].cube).toBe('cube1');
-    expect(featuredQueueDao.delete).toHaveBeenCalledWith('cube1');
+    expect(featuredQueueDao.delete).toHaveBeenCalledWith(expect.objectContaining({ cube: 'cube1' }));
 
     // Verify rotation still happened with remaining cubes
     // After removing cube1, the queue is [cube2, cube3, cube4, cube5]
@@ -214,10 +214,10 @@ describe('Featured Queue Rotation', () => {
     expect(result.messages).toContain('Not enough cubes in queue after patron check (need 4, have 2)');
     expect(result.removed).toHaveLength(3);
 
-    // Verify ineligible cubes were still removed
-    expect(featuredQueueDao.delete).toHaveBeenCalledWith('cube3');
-    expect(featuredQueueDao.delete).toHaveBeenCalledWith('cube4');
-    expect(featuredQueueDao.delete).toHaveBeenCalledWith('cube5');
+    // Verify ineligible cubes were still removed (delete() keys off the item object)
+    expect(featuredQueueDao.delete).toHaveBeenCalledWith(expect.objectContaining({ cube: 'cube3' }));
+    expect(featuredQueueDao.delete).toHaveBeenCalledWith(expect.objectContaining({ cube: 'cube4' }));
+    expect(featuredQueueDao.delete).toHaveBeenCalledWith(expect.objectContaining({ cube: 'cube5' }));
   });
 
   it('should handle large queue with multiple user cubes and mixed patron statuses', async () => {
@@ -254,10 +254,10 @@ describe('Featured Queue Rotation', () => {
     expect(result.removed).toHaveLength(3);
     expect(result.messages).toContain('Removed 3 cubes due to patron status');
 
-    // Verify ineligible cubes were deleted
-    expect(featuredQueueDao.delete).toHaveBeenCalledWith('cube3');
-    expect(featuredQueueDao.delete).toHaveBeenCalledWith('cube6');
-    expect(featuredQueueDao.delete).toHaveBeenCalledWith('cube7');
+    // Verify ineligible cubes were deleted (delete() keys off the item object)
+    expect(featuredQueueDao.delete).toHaveBeenCalledWith(expect.objectContaining({ cube: 'cube3' }));
+    expect(featuredQueueDao.delete).toHaveBeenCalledWith(expect.objectContaining({ cube: 'cube6' }));
+    expect(featuredQueueDao.delete).toHaveBeenCalledWith(expect.objectContaining({ cube: 'cube7' }));
 
     // Verify patron data was fetched only once per unique owner
     const uniqueOwners = ['alice', 'bob', 'charlie', 'diana', 'eve', 'frank', 'grace'];
@@ -308,7 +308,7 @@ describe('Featured Queue Rotation', () => {
     expect(result.success).toBe('true');
     expect(result.removed).toHaveLength(1);
     expect(result.removed[0].cube).toBe('cube3');
-    expect(featuredQueueDao.delete).toHaveBeenCalledWith('cube3');
+    expect(featuredQueueDao.delete).toHaveBeenCalledWith(expect.objectContaining({ cube: 'cube3' }));
   });
 
   it('should correctly handle pagination when fetching queue', async () => {


### PR DESCRIPTION
The owner-scoped queue lookup filtered on a top-level `owner` attribute, but BaseDynamoDao stores fields nested under an `item` map. The filter matched nothing, so doesUserHaveFeaturedCube always returned false and "Replace in queue" appended the new cube without clearing the old row, accumulating duplicates.

- FeaturedQueueDynamoDao.queryWithOwnerFilter: filter on the nested document path `item.owner`
- replaceForUser: delete all of the user's rows (self-heals existing duplicates) and reuse their earliest date to preserve their slot
- rotateFeatured: pass the item object to delete() instead of the bare id string, which derived FEATURED_QUEUE#undefined and silently no-opped
- update rotation tests to assert delete() is called with the item object