### PR TITLE
Fix Record paging errors, and consolidate into IndefinitePaginatedTable

### DIFF
--- a/packages/client/src/components/IndefinitePaginatedTable.tsx
+++ b/packages/client/src/components/IndefinitePaginatedTable.tsx
@@ -8,31 +8,27 @@ import {
   hasIndefiniteMore,
 } from '../utils/indefinitePagination';
 import { Card, CardBody, CardHeader } from './base/Card';
-import { Col, Flexbox, Row } from './base/Layout';
+import { Flexbox } from './base/Layout';
 import Pagination from './base/Pagination';
+import Table from './base/Table';
 import Text from './base/Text';
 
-interface IndefinitePaginatedListProps<T> {
+interface IndefinitePaginatedTableProps<T> {
   items?: T[];
   setItems: (items: T[]) => void;
   fetchMoreRoute: string;
-  renderItem: (item: T) => React.ReactNode;
+  renderItem: (item: T) => { [key: string]: React.ReactNode };
   lastKey: any;
   setLastKey: (lastKey: any) => void;
   pageSize: number;
   noneMessage?: string;
   itemsKey?: string;
   header: string;
-  xs?: number;
-  sm?: number;
-  md?: number;
-  lg?: number;
-  xl?: number;
-  xxl?: number;
+  headers: string[];
   inCard?: boolean;
 }
 
-const IndefinitePaginatedList = <T,>({
+const IndefinitePaginatedTable = <T,>({
   items,
   setItems,
   fetchMoreRoute,
@@ -43,24 +39,19 @@ const IndefinitePaginatedList = <T,>({
   pageSize,
   noneMessage = 'No items found.',
   itemsKey = 'items',
-  xs,
-  sm,
-  md,
-  lg,
-  xl,
-  xxl,
+  headers,
   inCard = false,
-}: IndefinitePaginatedListProps<T>) => {
+}: IndefinitePaginatedTableProps<T>) => {
   const { callApi } = useContext(CSRFContext);
   const [loading, setLoading] = useState(false);
-  const [page, setPage] = React.useState(0);
+  const [page, setPage] = useState(0);
 
   const safeItems = useMemo(() => items ?? [], [items]);
   const pageCount = getIndefinitePageCount(safeItems, pageSize);
   const hasMore = hasIndefiniteMore(lastKey);
 
   const fetchMoreData = useCallback(async () => {
-    await fetchIndefiniteMoreData({
+    await fetchIndefiniteMoreData<T>({
       callApi,
       fetchMoreRoute,
       items: safeItems,
@@ -73,7 +64,7 @@ const IndefinitePaginatedList = <T,>({
       itemsKey,
       setLoading,
     });
-  }, [callApi, fetchMoreRoute, lastKey, safeItems, setItems, pageSize, setLastKey, page, setLoading, itemsKey]);
+  }, [callApi, fetchMoreRoute, safeItems, setItems, lastKey, setLastKey, page, setPage, pageSize, itemsKey]);
 
   const pager = (
     <Pagination
@@ -92,6 +83,20 @@ const IndefinitePaginatedList = <T,>({
     />
   );
 
+  const body =
+    safeItems.length > 0 ? (
+      <Flexbox direction="col" gap="2">
+        <Table headers={headers} rows={safeItems.slice(page * pageSize, (page + 1) * pageSize).map(renderItem)} />
+        <Flexbox direction="row" justify="end" alignItems="center" className="w-full">
+          {pager}
+        </Flexbox>
+      </Flexbox>
+    ) : (
+      <Text semibold lg>
+        {noneMessage}
+      </Text>
+    );
+
   if (!inCard) {
     return (
       <Flexbox direction="col" gap="2">
@@ -102,24 +107,7 @@ const IndefinitePaginatedList = <T,>({
           </Text>
           {safeItems.length > 0 && pager}
         </Flexbox>
-        {safeItems.length > 0 ? (
-          <Flexbox direction="col" gap="2">
-            <Row xs={12}>
-              {safeItems.slice(page * pageSize, (page + 1) * pageSize).map((item, index) => (
-                <Col key={index + page * pageSize} xs={xs} sm={sm} md={md} lg={lg} xl={xl} xxl={xxl}>
-                  {renderItem(item)}
-                </Col>
-              ))}
-            </Row>
-            <Flexbox direction="row" justify="end" alignItems="center" className="w-full">
-              {pager}
-            </Flexbox>
-          </Flexbox>
-        ) : (
-          <Text semibold lg>
-            {noneMessage}
-          </Text>
-        )}
+        {body}
       </Flexbox>
     );
   }
@@ -135,28 +123,9 @@ const IndefinitePaginatedList = <T,>({
           {safeItems.length > 0 && pager}
         </Flexbox>
       </CardHeader>
-      <CardBody>
-        {safeItems.length > 0 ? (
-          <Flexbox direction="col" gap="2">
-            <Row xs={12}>
-              {safeItems.slice(page * pageSize, (page + 1) * pageSize).map((item, index) => (
-                <Col key={index + page * pageSize} xs={xs} sm={sm} md={md} lg={lg} xl={xl} xxl={xxl}>
-                  {renderItem(item)}
-                </Col>
-              ))}
-            </Row>
-            <Flexbox direction="row" justify="end" alignItems="center" className="w-full">
-              {pager}
-            </Flexbox>
-          </Flexbox>
-        ) : (
-          <Text semibold lg>
-            {noneMessage}
-          </Text>
-        )}
-      </CardBody>
+      <CardBody>{body}</CardBody>
     </Card>
   );
 };
 
-export default IndefinitePaginatedList;
+export default IndefinitePaginatedTable;

--- a/packages/client/src/pages/ImportRecordPage.tsx
+++ b/packages/client/src/pages/ImportRecordPage.tsx
@@ -1,4 +1,4 @@
-import React, { createRef, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { createRef, useContext, useEffect, useMemo, useState } from 'react';
 
 import { ArrowLeftIcon } from '@primer/octicons-react';
 import { cardOracleId, detailsToCard } from '@utils/cardutil';
@@ -15,13 +15,12 @@ import Checkbox from 'components/base/Checkbox';
 import FormatttedDate from 'components/base/FormatttedDate';
 import { Flexbox } from 'components/base/Layout';
 import Link from 'components/base/Link';
-import Pagination from 'components/base/Pagination';
 import Select from 'components/base/Select';
 import Spinner from 'components/base/Spinner';
-import Table from 'components/base/Table';
 import Text from 'components/base/Text';
 import CSRFForm from 'components/CSRFForm';
 import DynamicFlash from 'components/DynamicFlash';
+import IndefinitePaginatedTable from 'components/IndefinitePaginatedTable';
 import LoadingButton from 'components/LoadingButton';
 import RenderToRoot from 'components/RenderToRoot';
 import { CSRFContext } from 'contexts/CSRFContext';
@@ -129,130 +128,75 @@ const SelectRecordStep: React.FC<SelectRecordStepProps> = ({ cubeId, selectedRec
   const [records, setRecords] = useState<Record[]>([]);
   const [lastKey, setLastKey] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
-  const [page, setPage] = React.useState(0);
   const { callApi } = useContext(CSRFContext);
-
-  const pageCount = Math.ceil(records.length / PAGE_SIZE);
-  const hasMore = !!lastKey;
 
   useEffect(() => {
     const fetchInitial = async () => {
       try {
         const response = await callApi(`/cube/records/list/${cubeId}`, {});
-        const data = await response.json();
-        if (data.records) {
-          setRecords((prevItems) => [...prevItems, ...data.records]);
-          setLastKey(data.lastKey);
+
+        if (response.ok) {
+          const data = await response.json();
+          if (data.records) {
+            setRecords(data.records);
+            setLastKey(data.lastKey);
+          }
         }
       } finally {
         setLoading(false);
       }
     };
-    fetchInitial();
-  }, [callApi, cubeId, setRecords, setLastKey, setLoading]);
 
-  const fetchMore = useCallback(async () => {
-    if (loading || !lastKey) return;
-    setLoading(true);
-    try {
-      const response = await callApi(`/cube/records/list/${cubeId}`, {
-        lastKey: lastKey,
-      });
-
-      if (response.ok) {
-        const json = await response.json();
-        if (json.success === 'true') {
-          const responseItems = json.records;
-          const newItems = [...records, ...responseItems];
-          setRecords(newItems);
-
-          const numItemsShowOnLastPage = records.length % PAGE_SIZE;
-          //If current page is full and we just fetched more items, then move to next page
-          if (numItemsShowOnLastPage === 0 && responseItems.length > 0) {
-            setPage(page + 1);
-          }
-          setLastKey(json.lastKey);
-        }
-      }
-    } finally {
-      setLoading(false);
-    }
-  }, [loading, lastKey, callApi, cubeId, records, setRecords, page, setPage, setLastKey, setLoading]);
-
-  const pager = (
-    <Pagination
-      count={pageCount}
-      active={page}
-      hasMore={hasMore}
-      onClick={async (newPage) => {
-        if (newPage >= pageCount) {
-          await fetchMore();
-        } else {
-          setPage(newPage);
-        }
-      }}
-      loading={loading}
-    />
-  );
+    void fetchInitial();
+  }, [callApi, cubeId]);
 
   if (loading) {
     return <Spinner lg />;
   }
 
   return (
-    <>
-      {records.length > 0 ? (
-        <Flexbox direction="col" gap="2">
-          <Flexbox direction="row" justify="end" alignItems="center" className="w-full p-4">
-            {pager}
-          </Flexbox>
-          <Table
-            headers={['', 'Name', 'Date', 'Players']}
-            rows={records.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE).map((record) => ({
-              '': (
-                <Checkbox
-                  checked={record.id === selectedRecord.id}
-                  setChecked={() => setSelectedRecord(record)}
-                  label={''}
-                />
-              ),
-              Name: <Link href={`/cube/record/${record.id}`}>{record.name}</Link>,
-              Date: <FormatttedDate date={record.date} />,
-              Players: (
-                <Flexbox direction="row" gap="1">
-                  {record.players.map((player, index) => {
-                    if (player.userId) {
-                      return (
-                        <>
-                          <Link key={player.userId} href={`/user/view/${player.userId}`}>
-                            <Text sm>{player.name}</Text>
-                          </Link>
-                          {index < record.players.length - 1 && <Text sm>, </Text>}
-                        </>
-                      );
-                    }
+    <IndefinitePaginatedTable
+      items={records}
+      setItems={setRecords}
+      fetchMoreRoute={`/cube/records/list/${cubeId}`}
+      renderItem={(record) => ({
+        '': (
+          <Checkbox checked={record.id === selectedRecord.id} setChecked={() => setSelectedRecord(record)} label={''} />
+        ),
+        Name: <Link href={`/cube/record/${record.id}`}>{record.name}</Link>,
+        Date: <FormatttedDate date={record.date} />,
+        Players: (
+          <Flexbox direction="row" gap="1">
+            {record.players.map((player, index) => {
+              if (player.userId) {
+                return (
+                  <React.Fragment key={player.userId}>
+                    <Link href={`/user/view/${player.userId}`}>
+                      <Text sm>{player.name}</Text>
+                    </Link>
+                    {index < record.players.length - 1 && <Text sm>, </Text>}
+                  </React.Fragment>
+                );
+              }
 
-                    return (
-                      <Text key={player.name} sm>
-                        {player.name}
-                        {index < record.players.length - 1 && <Text sm>, </Text>}
-                      </Text>
-                    );
-                  })}
-                </Flexbox>
-              ),
-            }))}
-          />
-          <Flexbox direction="row" justify="end" alignItems="center" className="w-full p-4">
-            {pager}
+              return (
+                <Text key={player.name} sm>
+                  {player.name}
+                  {index < record.players.length - 1 && <Text sm>, </Text>}
+                </Text>
+              );
+            })}
           </Flexbox>
-        </Flexbox>
-      ) : (
-        <CardBody>
-          <Text md>No draft reports to show, create a new report to get started!</Text>
-        </CardBody>
-      )}
-    </>
+        ),
+      })}
+      lastKey={lastKey}
+      setLastKey={setLastKey}
+      pageSize={PAGE_SIZE}
+      noneMessage="No draft reports to show, create a new report to get started!"
+      itemsKey="records"
+      header="Records"
+      headers={['', 'Name', 'Date', 'Players']}
+    />
   );
 };
 

--- a/packages/client/src/pages/ImportRecordPage.tsx
+++ b/packages/client/src/pages/ImportRecordPage.tsx
@@ -130,15 +130,12 @@ const SelectRecordStep: React.FC<SelectRecordStepProps> = ({ cubeId, selectedRec
   const [lastKey, setLastKey] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [page, setPage] = React.useState(0);
-  const { csrfFetch } = useContext(CSRFContext);
+  const { callApi } = useContext(CSRFContext);
 
   useEffect(() => {
     const fetchInitial = async () => {
       try {
-        const response = await csrfFetch(`/cube/records/list/${cubeId}`, {
-          method: 'POST',
-          body: JSON.stringify({}),
-        });
+        const response = await callApi(`/cube/records/list/${cubeId}`, {});
         const data = await response.json();
         if (data.records) {
           setRecords((prevItems) => [...prevItems, ...data.records]);
@@ -149,15 +146,14 @@ const SelectRecordStep: React.FC<SelectRecordStepProps> = ({ cubeId, selectedRec
       }
     };
     fetchInitial();
-  }, [csrfFetch, cubeId]);
+  }, [callApi, cubeId]);
 
   const fetchMore = useCallback(async () => {
     if (loading || !lastKey) return;
     setLoading(true);
     try {
-      const response = await csrfFetch(`/cube/records/list/${cubeId}`, {
-        method: 'POST',
-        body: JSON.stringify({ lastKey }),
+      const response = await callApi(`/cube/records/list/${cubeId}`, {
+        lastKey,
       });
       const data = await response.json();
       if (data.records) {
@@ -167,7 +163,7 @@ const SelectRecordStep: React.FC<SelectRecordStepProps> = ({ cubeId, selectedRec
     } finally {
       setLoading(false);
     }
-  }, [loading, lastKey, csrfFetch, cubeId]);
+  }, [loading, lastKey, callApi, cubeId]);
 
   const pageCount = Math.ceil(records.length / PAGE_SIZE);
   const hasMore = !!lastKey;
@@ -180,9 +176,8 @@ const SelectRecordStep: React.FC<SelectRecordStepProps> = ({ cubeId, selectedRec
       onClick={async (newPage) => {
         if (newPage >= pageCount) {
           await fetchMore();
-        } else {
-          setPage(newPage);
         }
+        setPage(newPage);
       }}
       loading={loading}
     />

--- a/packages/client/src/pages/ImportRecordPage.tsx
+++ b/packages/client/src/pages/ImportRecordPage.tsx
@@ -132,6 +132,9 @@ const SelectRecordStep: React.FC<SelectRecordStepProps> = ({ cubeId, selectedRec
   const [page, setPage] = React.useState(0);
   const { callApi } = useContext(CSRFContext);
 
+  const pageCount = Math.ceil(records.length / PAGE_SIZE);
+  const hasMore = !!lastKey;
+
   useEffect(() => {
     const fetchInitial = async () => {
       try {
@@ -146,27 +149,35 @@ const SelectRecordStep: React.FC<SelectRecordStepProps> = ({ cubeId, selectedRec
       }
     };
     fetchInitial();
-  }, [callApi, cubeId]);
+  }, [callApi, cubeId, setRecords, setLastKey, setLoading]);
 
   const fetchMore = useCallback(async () => {
     if (loading || !lastKey) return;
     setLoading(true);
     try {
       const response = await callApi(`/cube/records/list/${cubeId}`, {
-        lastKey,
+        lastKey: lastKey,
       });
-      const data = await response.json();
-      if (data.records) {
-        setRecords((prevItems) => [...prevItems, ...data.records]);
-        setLastKey(data.lastKey);
+
+      if (response.ok) {
+        const json = await response.json();
+        if (json.success === 'true') {
+          const responseItems = json.records;
+          const newItems = [...records, ...responseItems];
+          setRecords(newItems);
+
+          const numItemsShowOnLastPage = records.length % PAGE_SIZE;
+          //If current page is full and we just fetched more items, then move to next page
+          if (numItemsShowOnLastPage === 0 && responseItems.length > 0) {
+            setPage(page + 1);
+          }
+          setLastKey(json.lastKey);
+        }
       }
     } finally {
       setLoading(false);
     }
-  }, [loading, lastKey, callApi, cubeId]);
-
-  const pageCount = Math.ceil(records.length / PAGE_SIZE);
-  const hasMore = !!lastKey;
+  }, [loading, lastKey, callApi, cubeId, records, setRecords, page, setPage, setLastKey, setLoading]);
 
   const pager = (
     <Pagination
@@ -176,8 +187,9 @@ const SelectRecordStep: React.FC<SelectRecordStepProps> = ({ cubeId, selectedRec
       onClick={async (newPage) => {
         if (newPage >= pageCount) {
           await fetchMore();
+        } else {
+          setPage(newPage);
         }
-        setPage(newPage);
       }}
       loading={loading}
     />

--- a/packages/client/src/records/DraftReports.tsx
+++ b/packages/client/src/records/DraftReports.tsx
@@ -1,19 +1,16 @@
-import React, { useCallback, useContext, useState } from 'react';
+import React, { useContext, useState } from 'react';
 
 import { XIcon } from '@primer/octicons-react';
 import Record from '@utils/datatypes/Record';
 
 import Button from 'components/base/Button';
-import { CardBody } from 'components/base/Card';
 import FormatttedDate from 'components/base/FormatttedDate';
 import { Flexbox } from 'components/base/Layout';
 import Link from 'components/base/Link';
-import Pagination from 'components/base/Pagination';
-import Table from 'components/base/Table';
 import Text from 'components/base/Text';
+import IndefinitePaginatedTable from 'components/IndefinitePaginatedTable';
 import RecordDeleteModal from 'components/modals/RecordDeleteModal';
 import withModal from 'components/WithModal';
-import { CSRFContext } from 'contexts/CSRFContext';
 import CubeContext from 'contexts/CubeContext';
 import UserContext from 'contexts/UserContext';
 
@@ -28,117 +25,59 @@ const PAGE_SIZE = 20;
 const DraftReports: React.FC<DraftReportsProps> = ({ records, lastKey }) => {
   const [items, setItems] = useState<Record[]>(records);
   const [lastKeyState, setLastKeyState] = useState<any>(lastKey);
-  const [loading, setLoading] = useState<boolean>(false);
-  const { callApi } = useContext(CSRFContext);
-  const [page, setPage] = React.useState(0);
   const { cube } = useContext(CubeContext);
   const user = useContext(UserContext);
 
-  const pageCount = Math.ceil(items.length / PAGE_SIZE);
-  const hasMore = !!lastKeyState;
-
   const isOwner = user && cube && user.id === cube.owner.id;
 
-  const fetchMore = useCallback(async () => {
-    if (loading || !lastKeyState) return;
-    setLoading(true);
-    try {
-      const response = await callApi(`/cube/records/list/${cube.id}`, {
-        lastKey: lastKeyState,
-      });
-
-      if (response.ok) {
-        const json = await response.json();
-        if (json.success === 'true') {
-          const responseItems = json.records;
-          const newItems = [...items, ...responseItems];
-          setItems(newItems);
-
-          const numItemsShowOnLastPage = items.length % PAGE_SIZE;
-          //If current page is full and we just fetched more items, then move to next page
-          if (numItemsShowOnLastPage === 0 && responseItems.length > 0) {
-            setPage(page + 1);
+  const renderItem = (record: Record) => ({
+    Name: <Link href={`/cube/record/${record.id}`}>{record.name}</Link>,
+    Date: <FormatttedDate date={record.date} />,
+    Players: (
+      <Flexbox direction="row" gap="1">
+        {record.players.map((player, index) => {
+          if (player.userId) {
+            return (
+              <React.Fragment key={player.userId}>
+                <Link href={`/user/view/${player.userId}`}>
+                  <Text sm>{player.name}asdasd</Text>
+                </Link>
+                {index < record.players.length - 1 && <Text sm>, </Text>}
+              </React.Fragment>
+            );
           }
-          setLastKeyState(json.lastKey);
-        }
-      }
-    } finally {
-      setLoading(false);
-    }
-  }, [loading, lastKeyState, callApi, cube.id, items, setItems, page, setPage, setLastKeyState]);
 
-  const pager = (
-    <Pagination
-      count={pageCount}
-      active={page}
-      hasMore={hasMore}
-      onClick={async (newPage) => {
-        if (newPage >= pageCount) {
-          await fetchMore();
-        } else {
-          setPage(newPage);
-        }
-      }}
-      loading={loading}
-    />
-  );
+          return (
+            <Text key={player.name} sm>
+              {player.name}
+              {index < record.players.length - 1 && <Text sm>, </Text>}
+            </Text>
+          );
+        })}
+      </Flexbox>
+    ),
+    '': isOwner && (
+      <RecordDeleteModalButton modalprops={{ recordId: record.id }} color="secondary">
+        <XIcon size={16} className="mx-1" />
+      </RecordDeleteModalButton>
+    ),
+  });
 
   return (
-    <>
-      {items.length > 0 ? (
-        <Flexbox direction="col" gap="2">
-          <Flexbox direction="row" justify="between" alignItems="center" className="w-full p-4">
-            <Text lg semibold>
-              Draft Reports ({items.length}
-              {hasMore ? '+' : ''})
-            </Text>
-            {pager}
-          </Flexbox>
-          <Table
-            headers={['Name', 'Date', 'Players', '']}
-            rows={items.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE).map((record) => ({
-              Name: <Link href={`/cube/record/${record.id}`}>{record.name}</Link>,
-              Date: <FormatttedDate date={record.date} />,
-              Players: (
-                <Flexbox direction="row" gap="1">
-                  {record.players.map((player, index) => {
-                    if (player.userId) {
-                      return (
-                        <>
-                          <Link key={player.userId} href={`/user/view/${player.userId}`}>
-                            <Text sm>{player.name}</Text>
-                          </Link>
-                          {index < record.players.length - 1 && <Text sm>, </Text>}
-                        </>
-                      );
-                    }
-
-                    return (
-                      <Text key={player.name} sm>
-                        {player.name}
-                        {index < record.players.length - 1 && <Text sm>, </Text>}
-                      </Text>
-                    );
-                  })}
-                </Flexbox>
-              ),
-              '': isOwner && (
-                <RecordDeleteModalButton modalprops={{ recordId: record.id }} color="secondary">
-                  <XIcon size={16} className="mx-1" />
-                </RecordDeleteModalButton>
-              ),
-            }))}
-          />
-          <Flexbox direction="row" justify="end" alignItems="center" className="w-full p-4">
-            {pager}
-          </Flexbox>
-        </Flexbox>
-      ) : (
-        <CardBody>
-          <Text md>No draft reports to show, create a new report to get started!</Text>
-        </CardBody>
-      )}
-    </>
+    <IndefinitePaginatedTable
+      items={items}
+      setItems={setItems}
+      itemsKey="records"
+      lastKey={lastKeyState}
+      setLastKey={setLastKeyState}
+      pageSize={PAGE_SIZE}
+      header="Draft Reports"
+      fetchMoreRoute={`/cube/records/list/${cube.id}`}
+      renderItem={renderItem}
+      noneMessage="No draft reports to show, create a new report to get started!"
+      headers={['Name', 'Date', 'Players', '']}
+      inCard
+    />
   );
 };
 

--- a/packages/client/src/records/DraftReports.tsx
+++ b/packages/client/src/records/DraftReports.tsx
@@ -29,7 +29,7 @@ const DraftReports: React.FC<DraftReportsProps> = ({ records, lastKey }) => {
   const [items, setItems] = useState<Record[]>(records);
   const [lastKeyState, setLastKeyState] = useState<any>(lastKey);
   const [loading, setLoading] = useState<boolean>(false);
-  const { csrfFetch } = useContext(CSRFContext);
+  const { callApi } = useContext(CSRFContext);
   const [page, setPage] = React.useState(0);
   const { cube } = useContext(CubeContext);
   const user = useContext(UserContext);
@@ -43,12 +43,8 @@ const DraftReports: React.FC<DraftReportsProps> = ({ records, lastKey }) => {
     if (loading || !lastKeyState) return;
     setLoading(true);
     try {
-      const response = await csrfFetch(`/cube/records/list/${cube.id}`, {
-        method: 'POST',
-        body: JSON.stringify({ lastKey: lastKeyState }),
-        headers: {
-          'Content-Type': 'application/json',
-        },
+      const response = await callApi(`/cube/records/list/${cube.id}`, {
+        lastKey: lastKeyState,
       });
       const data = await response.json();
       if (data.records) {
@@ -59,7 +55,7 @@ const DraftReports: React.FC<DraftReportsProps> = ({ records, lastKey }) => {
     } finally {
       setLoading(false);
     }
-  }, [loading, lastKeyState, csrfFetch, cube.id]);
+  }, [loading, lastKeyState, callApi, cube.id]);
 
   const pager = (
     <Pagination

--- a/packages/client/src/records/DraftReports.tsx
+++ b/packages/client/src/records/DraftReports.tsx
@@ -46,11 +46,15 @@ const DraftReports: React.FC<DraftReportsProps> = ({ records, lastKey }) => {
       const response = await csrfFetch(`/cube/records/list/${cube.id}`, {
         method: 'POST',
         body: JSON.stringify({ lastKey: lastKeyState }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
       });
       const data = await response.json();
       if (data.records) {
         setItems((prevItems) => [...prevItems, ...data.records]);
         setLastKeyState(data.lastKey);
+        setPage(page + 1);
       }
     } finally {
       setLoading(false);

--- a/packages/client/src/records/DraftReports.tsx
+++ b/packages/client/src/records/DraftReports.tsx
@@ -46,16 +46,26 @@ const DraftReports: React.FC<DraftReportsProps> = ({ records, lastKey }) => {
       const response = await callApi(`/cube/records/list/${cube.id}`, {
         lastKey: lastKeyState,
       });
-      const data = await response.json();
-      if (data.records) {
-        setItems((prevItems) => [...prevItems, ...data.records]);
-        setLastKeyState(data.lastKey);
-        setPage(page + 1);
+
+      if (response.ok) {
+        const json = await response.json();
+        if (json.success === 'true') {
+          const responseItems = json.records;
+          const newItems = [...items, ...responseItems];
+          setItems(newItems);
+
+          const numItemsShowOnLastPage = items.length % PAGE_SIZE;
+          //If current page is full and we just fetched more items, then move to next page
+          if (numItemsShowOnLastPage === 0 && responseItems.length > 0) {
+            setPage(page + 1);
+          }
+          setLastKeyState(json.lastKey);
+        }
       }
     } finally {
       setLoading(false);
     }
-  }, [loading, lastKeyState, callApi, cube.id]);
+  }, [loading, lastKeyState, callApi, cube.id, items, setItems, page, setPage, setLastKeyState]);
 
   const pager = (
     <Pagination

--- a/packages/client/src/records/TrophyArchive.tsx
+++ b/packages/client/src/records/TrophyArchive.tsx
@@ -24,7 +24,7 @@ const TrophyArchive: React.FC<TrophyArchiveProps> = ({ records, lastKey }) => {
   const [items, setItems] = useState<Record[]>(records);
   const [lastKeyState, setLastKeyState] = useState<any>(lastKey);
   const [loading, setLoading] = useState<boolean>(false);
-  const { csrfFetch } = useContext(CSRFContext);
+  const { callApi } = useContext(CSRFContext);
   const [page, setPage] = React.useState(0);
 
   const pageCount = Math.ceil(items.length / PAGE_SIZE);
@@ -34,9 +34,8 @@ const TrophyArchive: React.FC<TrophyArchiveProps> = ({ records, lastKey }) => {
     if (loading || !lastKeyState) return;
     setLoading(true);
     try {
-      const response = await csrfFetch('/api/draftreports', {
-        method: 'POST',
-        body: JSON.stringify({ lastKey: lastKeyState }),
+      const response = await callApi('/api/draftreports', {
+        lastKey: lastKeyState,
       });
       const data = await response.json();
       if (data.reports) {
@@ -46,7 +45,7 @@ const TrophyArchive: React.FC<TrophyArchiveProps> = ({ records, lastKey }) => {
     } finally {
       setLoading(false);
     }
-  }, [loading, lastKeyState, csrfFetch]);
+  }, [loading, lastKeyState, callApi]);
 
   const trophyCount = useMemo(() => {
     return items.reduce((count, item) => count + item.trophy.length, 0);

--- a/packages/client/src/utils/indefinitePagination.ts
+++ b/packages/client/src/utils/indefinitePagination.ts
@@ -1,0 +1,79 @@
+export interface IndefinitePaginationFetchArgs<T> {
+  callApi: (route: RequestInfo, body: any) => Promise<Response>;
+  fetchMoreRoute: string;
+  items: T[];
+  setItems: (items: T[]) => void;
+  lastKey: any;
+  setLastKey: (lastKey: any) => void;
+  page: number;
+  setPage: (page: number) => void;
+  pageSize: number;
+  itemsKey?: string;
+  setLoading: (loading: boolean) => void;
+}
+
+export const getIndefinitePageCount = <T>(items: T[], pageSize: number) => Math.ceil(items.length / pageSize);
+
+export const hasIndefiniteMore = (lastKey: any) => !!lastKey;
+
+export const fetchIndefiniteMoreData = async <T>({
+  callApi,
+  fetchMoreRoute,
+  items,
+  setItems,
+  lastKey,
+  setLastKey,
+  page,
+  setPage,
+  pageSize,
+  itemsKey = 'items',
+  setLoading,
+}: IndefinitePaginationFetchArgs<T>) => {
+  setLoading(true);
+
+  try {
+    const response = await callApi(fetchMoreRoute, {
+      lastKey,
+    });
+
+    if (response.ok) {
+      const json = await response.json();
+
+      // eslint-disable-next-line no-restricted-syntax
+      if (json.success === 'true' || itemsKey in json) {
+        const responseItems = json[itemsKey];
+        const newItems = [...items, ...responseItems];
+        setItems(newItems);
+
+        const numItemsShowOnLastPage = items.length % pageSize;
+        //If current page is full and we just fetched more items, then move to next page
+        if (numItemsShowOnLastPage === 0 && responseItems.length > 0) {
+          setPage(page + 1);
+        }
+        setLastKey(json.lastKey);
+      }
+    }
+    setLoading(false);
+  } finally {
+    setLoading(false);
+  }
+};
+
+export const handleIndefinitePageSelection = async ({
+  newPage,
+  pageCount,
+  setPage,
+  fetchMoreData,
+}: {
+  newPage: number;
+  pageCount: number;
+  setPage: (page: number) => void;
+  fetchMoreData: () => Promise<void>;
+}) => {
+  if (newPage >= pageCount) {
+    await fetchMoreData();
+    return;
+  }
+
+  setPage(newPage);
+};

--- a/packages/server/src/router/routes/cube/records/list.ts
+++ b/packages/server/src/router/routes/cube/records/list.ts
@@ -16,6 +16,7 @@ export const getRecordsHandler = async (req: Request, res: Response) => {
   try {
     const results = await recordDao.getByCube(cubeId, 20, lastKey || undefined);
     return res.status(200).json({
+      success: 'true',
       records: results.items,
       lastKey: results.lastKey,
     });


### PR DESCRIPTION
# Problems

1. Records page in Cube and in Import record did not set Content-Type JSON so the backend did not see lastKey. Some other endpoints had the same issue
2. Also their frontend logic for paging had problems (ones already fixed) with being able to past past the end

# Solution
I built on the changes commit by commit so might be easier to review that way. By the end I consolidated the paging logic within IndefinitePaginatedList into a utility class and made IndefinitePaginatedTable as the tabular version.

A bunch of other usages of Pagination likely can be converted to IndefinitePaginatedTable, solving slight logic differences in how the paging/fetching occurs.

# Testing

While testing I set the page size to 2 in frontend and backend since I don't have that many records

## Before

Paging never refreshes the list b/c the backend never got the lastKey. It also takes 2 clicks to get to the next page
<img width="1702" height="539" alt="old-records-list" src="https://github.com/user-attachments/assets/1cc58899-236e-4b41-b92d-b6ae4a06ec29" />

## After

Paging works as smooth as possible.
<img width="1836" height="460" alt="new-import-record-paging-v2" src="https://github.com/user-attachments/assets/8ead3084-839c-4785-9848-5f80a21e8c5f" />

Due to the way dynamodb works, if the number of records is evenly divisible by the page size, there has to be one more click on next page before we know there are no more results.
<img width="1655" height="332" alt="new-draft-records-v2" src="https://github.com/user-attachments/assets/aed2b944-fc65-4bda-9884-b61a3118ce6a" />

# Future

PRs to update other Pagination usages, such as CreateRecordFromDraftModal, to use IndefinitePaginatedTable or List