### PR TITLE
Upgrade to Typescript 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51722,7 +51722,7 @@
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.0",
-        "typescript": "^5.7.0",
+        "typescript": "^6.0.3",
         "vite": "^6.0.0"
       }
     },
@@ -51771,7 +51771,7 @@
         "@types/react-plotly.js": "^2.6.0",
         "@vitejs/plugin-react": "^4.3.0",
         "tsx": "^4.19.0",
-        "typescript": "^5.7.0",
+        "typescript": "^6.0.3",
         "vite": "^6.0.0"
       }
     },
@@ -52386,7 +52386,7 @@
         "@types/aws-lambda": "^8.10.131",
         "@types/node": "^20.11.16",
         "esbuild": "^0.28.1",
-        "typescript": "^5.3.3"
+        "typescript": "^6.0.3"
       }
     },
     "packages/cardUpdateMonitorLambda/node_modules/@esbuild/aix-ppc64": {
@@ -52909,7 +52909,7 @@
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
-        "typescript": "~5.6.3"
+        "typescript": "^6.0.3"
       }
     },
     "packages/cdk/node_modules/@aws-cdk/cloud-assembly-schema": {
@@ -53483,7 +53483,7 @@
         "terser-webpack-plugin": "^5.3.10",
         "ts-jest": "^29.4.5",
         "ts-loader": "^9.5.1",
-        "typescript": "^5.4.5",
+        "typescript": "^6.0.3",
         "webpack": "^5.105.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.2.6"
@@ -55229,7 +55229,7 @@
         "@types/node": "^20.11.0",
         "node-fetch": "^2.7.0",
         "tsx": "^4.7.0",
-        "typescript": "^5.3.3"
+        "typescript": "^6.0.3"
       }
     },
     "packages/integrationTests/node_modules/typescript": {
@@ -55272,7 +55272,7 @@
         "ts-jest": "^29.1.2",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
-        "typescript": "^5.4.5"
+        "typescript": "^6.0.3"
       }
     },
     "packages/jobs/node_modules/event-stream": {
@@ -55357,7 +55357,7 @@
         "resolve-tspaths": "^0.8.22",
         "ts-jest": "^29.4.5",
         "tsconfig-paths": "^4.2.0",
-        "typescript": "^5.6.3"
+        "typescript": "^6.0.3"
       }
     },
     "packages/recommenderService/node_modules/@types/uuid": {
@@ -55539,7 +55539,7 @@
         "@types/node": "^24.10.0",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
       }
     },
     "packages/scripts/node_modules/@types/node": {
@@ -55823,7 +55823,7 @@
         "ts-jest": "^29.1.4",
         "tsconfig-paths": "^4.2.0",
         "tspath": "^2.6.8",
-        "typescript": "^5.4.5"
+        "typescript": "^6.0.3"
       }
     },
     "packages/server/node_modules/@aws-sdk/client-sesv2": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "globals": "^16.5.0",
         "postcss": "^8.4.38",
         "tailwindcss": "^3.4.3",
-        "typescript": "^5.4.5"
+        "typescript": "^6.0.3"
       },
       "devDependencies": {
         "@eslint/compat": "^1.4.1",
@@ -30691,8 +30691,9 @@
       "version": "2.13.2",
       "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.13.2.tgz",
       "integrity": "sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg==",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "picocolors": "^1.1.1",
         "shell-quote": "^1.8.3"
@@ -31369,6 +31370,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lerna/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/lerna/node_modules/upath": {
@@ -48469,9 +48484,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -50400,8 +50415,9 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.3.tgz",
       "integrity": "sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -50458,8 +50474,9 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "devOptional": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -50472,8 +50489,9 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -50485,8 +50503,9 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -50498,8 +50517,9 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -50523,8 +50543,9 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
       "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -50536,8 +50557,9 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -50549,13 +50571,13 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -50564,8 +50586,9 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "devOptional": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -50577,8 +50600,9 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
       "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -50587,8 +50611,9 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -50600,8 +50625,9 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -50610,8 +50636,9 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
       "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "default-browser": "^5.2.1",
         "define-lazy-prop": "^3.0.0",
@@ -50629,8 +50656,9 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -50642,8 +50670,9 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -50655,8 +50684,9 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -51706,6 +51736,20 @@
         "undici-types": "~6.21.0"
       }
     },
+    "packages/annotator/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "packages/archetypeAnnotater": {
       "name": "@cubecobra/archetype-annotater",
       "version": "0.1.0",
@@ -51739,6 +51783,20 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "packages/archetypeAnnotater/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/botDeckbuildLambda": {
@@ -52815,6 +52873,20 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
+    "packages/cardUpdateMonitorLambda/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "packages/cdk": {
       "name": "@cubecobra/cdk",
       "version": "0.1.0",
@@ -53414,7 +53486,7 @@
         "typescript": "^5.4.5",
         "webpack": "^5.105.0",
         "webpack-cli": "^5.1.4",
-        "webpack-dev-server": "^5.0.4"
+        "webpack-dev-server": "^5.2.6"
       }
     },
     "packages/client/node_modules/@eslint/eslintrc": {
@@ -53506,21 +53578,6 @@
       },
       "peerDependencies": {
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-      }
-    },
-    "packages/client/node_modules/@typescript-eslint/eslint-plugin/node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/client/node_modules/@typescript-eslint/experimental-utils": {
@@ -53633,21 +53690,6 @@
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
-    "packages/client/node_modules/@typescript-eslint/type-utils/node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "packages/client/node_modules/@typescript-eslint/types": {
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
@@ -53704,21 +53746,6 @@
       },
       "peerDependencies": {
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-      }
-    },
-    "packages/client/node_modules/@typescript-eslint/typescript-estree/node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/client/node_modules/@typescript-eslint/utils": {
@@ -53783,6 +53810,20 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "packages/client/node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "packages/client/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -53797,6 +53838,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "packages/client/node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "packages/client/node_modules/brace-expansion": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
@@ -53806,6 +53860,70 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "packages/client/node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/client/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "packages/client/node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "packages/client/node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/client/node_modules/doctrine": {
@@ -54053,6 +54171,19 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "packages/client/node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "packages/client/node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -54083,6 +54214,21 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "packages/client/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "packages/client/node_modules/glob": {
@@ -54133,6 +54279,39 @@
         "node": ">= 4"
       }
     },
+    "packages/client/node_modules/ipaddr.js": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/client/node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/client/node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "packages/client/node_modules/js-yaml": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
@@ -54163,6 +54342,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "packages/client/node_modules/launch-editor": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
+      "integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.1",
+        "shell-quote": "^1.8.4"
+      }
+    },
     "packages/client/node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -54192,6 +54382,25 @@
         "node": "*"
       }
     },
+    "packages/client/node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "packages/client/node_modules/p-locate": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
@@ -54206,6 +54415,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/client/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "packages/client/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "packages/client/node_modules/rimraf": {
@@ -54251,6 +54486,19 @@
         "node": ">=8"
       }
     },
+    "packages/client/node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "packages/client/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -54269,6 +54517,78 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/client/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/client/node_modules/webpack-dev-server": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.6.tgz",
+      "integrity": "sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/bonjour": "^3.5.13",
+        "@types/connect-history-api-fallback": "^1.5.4",
+        "@types/express": "^4.17.25",
+        "@types/express-serve-static-core": "^4.17.21",
+        "@types/serve-index": "^1.9.4",
+        "@types/serve-static": "^1.15.5",
+        "@types/sockjs": "^0.3.36",
+        "@types/ws": "^8.5.10",
+        "ansi-html-community": "^0.0.8",
+        "bonjour-service": "^1.2.1",
+        "chokidar": "^3.6.0",
+        "colorette": "^2.0.10",
+        "compression": "^1.8.1",
+        "connect-history-api-fallback": "^2.0.0",
+        "express": "^4.22.1",
+        "graceful-fs": "^4.2.6",
+        "http-proxy-middleware": "^2.0.9",
+        "ipaddr.js": "^2.1.0",
+        "launch-editor": "^2.14.1",
+        "open": "^10.0.3",
+        "p-retry": "^6.2.0",
+        "schema-utils": "^4.2.0",
+        "selfsigned": "^5.5.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "^0.3.24",
+        "spdy": "^4.0.2",
+        "webpack-dev-middleware": "^7.4.2",
+        "ws": "^8.18.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "webpack": {
+          "optional": true
+        },
+        "webpack-cli": {
+          "optional": true
+        }
       }
     },
     "packages/dailyJobsLambda": {
@@ -54912,6 +55232,20 @@
         "typescript": "^5.3.3"
       }
     },
+    "packages/integrationTests/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "packages/jobs": {
       "name": "@cubecobra/jobs",
       "version": "1.0.0",
@@ -54970,6 +55304,20 @@
       "dependencies": {
         "duplexer": "~0.1.1",
         "through": "~2.3.4"
+      }
+    },
+    "packages/jobs/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/recommenderService": {
@@ -55138,6 +55486,20 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "packages/recommenderService/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/recommenderService/node_modules/zip-stream": {
@@ -55314,6 +55676,20 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "packages/scripts/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/scripts/node_modules/undici-types": {
@@ -55962,6 +56338,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/server/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/server/node_modules/undici-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,7 @@
         "autoprefixer": "^10.4.19",
         "globals": "^16.5.0",
         "postcss": "^8.4.38",
-        "tailwindcss": "^3.4.3",
-        "typescript": "^6.0.3"
+        "tailwindcss": "^3.4.3"
       },
       "devDependencies": {
         "@eslint/compat": "^1.4.1",
@@ -35,6 +34,7 @@
         "rimraf": "^5.0.7",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.46.3"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -51736,20 +51736,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "packages/annotator/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "packages/archetypeAnnotater": {
       "name": "@cubecobra/archetype-annotater",
       "version": "0.1.0",
@@ -51783,20 +51769,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "packages/archetypeAnnotater/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/botDeckbuildLambda": {
@@ -52873,20 +52845,6 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
-    "packages/cardUpdateMonitorLambda/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "packages/cdk": {
       "name": "@cubecobra/cdk",
       "version": "0.1.0",
@@ -53368,20 +53326,6 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      }
-    },
-    "packages/cdk/node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/cdk/node_modules/undici-types": {
@@ -55232,20 +55176,6 @@
         "typescript": "^6.0.3"
       }
     },
-    "packages/integrationTests/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "packages/jobs": {
       "name": "@cubecobra/jobs",
       "version": "1.0.0",
@@ -55304,20 +55234,6 @@
       "dependencies": {
         "duplexer": "~0.1.1",
         "through": "~2.3.4"
-      }
-    },
-    "packages/jobs/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/recommenderService": {
@@ -55486,20 +55402,6 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "packages/recommenderService/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/recommenderService/node_modules/zip-stream": {
@@ -55676,20 +55578,6 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "packages/scripts/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/scripts/node_modules/undici-types": {
@@ -56338,20 +56226,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/server/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/server/node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "globals": "^16.5.0",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.3",
-    "typescript": "^5.4.5"
+    "typescript": "^6.0.3"
   },
   "devDependencies": {
     "@eslint/compat": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -60,8 +60,7 @@
     "autoprefixer": "^10.4.19",
     "globals": "^16.5.0",
     "postcss": "^8.4.38",
-    "tailwindcss": "^3.4.3",
-    "typescript": "^6.0.3"
+    "tailwindcss": "^3.4.3"
   },
   "devDependencies": {
     "@eslint/compat": "^1.4.1",
@@ -80,6 +79,7 @@
     "rimraf": "^5.0.7",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.46.3"
   },
   "packageManager": "npm@10.9.0",

--- a/packages/annotator/package.json
+++ b/packages/annotator/package.json
@@ -26,7 +26,7 @@
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vite": "^6.0.0"
   }
 }

--- a/packages/annotator/tsconfig.json
+++ b/packages/annotator/tsconfig.json
@@ -10,7 +10,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/packages/archetypeAnnotater/package.json
+++ b/packages/archetypeAnnotater/package.json
@@ -20,24 +20,24 @@
     "pipeline-tags": "npm run compute-tag-vectors && npm run reduce-and-cluster-tags && npm run prepare-app"
   },
   "dependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "react-plotly.js": "^2.6.0",
-    "plotly.js": "^2.35.0",
     "@aws-sdk/client-s3": "^3.700.0",
     "@aws-sdk/credential-providers": "^3.700.0",
     "@tensorflow/tfjs-node": "^4.22.0",
     "dotenv": "^16.0.0",
-    "ml-kmeans": "^6.0.0"
+    "ml-kmeans": "^6.0.0",
+    "plotly.js": "^2.35.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-plotly.js": "^2.6.0"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.3.0",
-    "vite": "^6.0.0",
-    "tsx": "^4.19.0",
-    "typescript": "^5.7.0",
+    "@types/node": "^22.0.0",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "@types/react-plotly.js": "^2.6.0",
-    "@types/node": "^22.0.0"
+    "@vitejs/plugin-react": "^4.3.0",
+    "tsx": "^4.19.0",
+    "typescript": "^6.0.3",
+    "vite": "^6.0.0"
   }
 }

--- a/packages/archetypeAnnotater/tsconfig.json
+++ b/packages/archetypeAnnotater/tsconfig.json
@@ -15,7 +15,8 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "rootDir": "./src"
   },
   "include": ["src"]
 }

--- a/packages/archetypeAnnotater/tsconfig.json
+++ b/packages/archetypeAnnotater/tsconfig.json
@@ -10,13 +10,14 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["node"]
   },
   "include": ["src"]
 }

--- a/packages/cardUpdateMonitorLambda/package.json
+++ b/packages/cardUpdateMonitorLambda/package.json
@@ -20,6 +20,6 @@
     "@types/aws-lambda": "^8.10.131",
     "@types/node": "^20.11.16",
     "esbuild": "^0.28.1",
-    "typescript": "^5.3.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/cardUpdateMonitorLambda/tsconfig.json
+++ b/packages/cardUpdateMonitorLambda/tsconfig.json
@@ -12,7 +12,6 @@
     "resolveJsonModule": true,
     "moduleResolution": "node",
     "types": ["node"],
-    "baseUrl": ".",
     "paths": {
       "@server/*": ["../server/src/*"],
       "@utils/*": ["../utils/src/*"]

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -23,7 +23,7 @@
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
-    "typescript": "~5.6.3"
+    "typescript": "^6.0.3"
   },
   "dependencies": {
     "aws-cdk-lib": "2.246.0",

--- a/packages/cdk/tsconfig.json
+++ b/packages/cdk/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "CommonJS",
-    "moduleResolution": "Node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "esModuleInterop": true,
     "lib": ["es2020", "dom"],
     "declaration": true,

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -113,7 +113,7 @@
     "terser-webpack-plugin": "^5.3.10",
     "ts-jest": "^29.4.5",
     "ts-loader": "^9.5.1",
-    "typescript": "^5.4.5",
+    "typescript": "^6.0.3",
     "webpack": "^5.105.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.6"

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -11,7 +11,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": false,
@@ -19,19 +19,19 @@
     "jsx": "react-jsx",
     "jsxImportSource": "react",
     "outDir": "./dist",
-    "baseUrl": "./",
     "paths": {
       "@utils/*": ["../utils/src/*"],
-      "components/*": ["src/components/*"],
-      "utils/*": ["src/utils/*"],
-      "modals/*": ["src/components/modals/*"],
-      "contexts/*": ["src/contexts/*"],
-      "analytics/*": ["src/analytics/*"],
-      "hooks/*": ["src/hooks/*"],
-      "layouts/*": ["src/layouts/*"],
-      "drafting/*": ["src/drafting/*"],
-      "markdown/*": ["src/markdown/*"]
-    }
+      "components/*": ["./src/components/*"],
+      "utils/*": ["./src/utils/*"],
+      "modals/*": ["./src/components/modals/*"],
+      "contexts/*": ["./src/contexts/*"],
+      "analytics/*": ["./src/analytics/*"],
+      "hooks/*": ["./src/hooks/*"],
+      "layouts/*": ["./src/layouts/*"],
+      "drafting/*": ["./src/drafting/*"],
+      "markdown/*": ["./src/markdown/*"]
+    },
+    "rootDir": ".."
   },
   "include": [
     "src",

--- a/packages/dailyJobsLambda/tsconfig.json
+++ b/packages/dailyJobsLambda/tsconfig.json
@@ -4,7 +4,6 @@
     "outDir": "dist",
     "esModuleInterop": true,
     "target": "ES2020",
-    "baseUrl": "./",
     "paths": {
       "@utils/*": ["../utils/src/*"],
       "@server/*": ["../server/src/*"]
@@ -21,7 +20,8 @@
     "skipLibCheck": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "rootDir": ".."
   },
   "exclude": ["node_modules", "dist"],
   "include": ["src/**/*.ts", "../utils/src", "../server/src"]

--- a/packages/integrationTests/package.json
+++ b/packages/integrationTests/package.json
@@ -33,6 +33,6 @@
     "@types/node": "^20.11.0",
     "node-fetch": "^2.7.0",
     "tsx": "^4.7.0",
-    "typescript": "^5.3.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/integrationTests/tsconfig.json
+++ b/packages/integrationTests/tsconfig.json
@@ -12,12 +12,11 @@
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
     "types": ["node", "@types/node"],
-    "baseUrl": ".",
     "paths": {
-      "@features/*": ["features/*"],
-      "@steps/*": ["features/steps/*"],
-      "@support/*": ["features/support/*"],
-      "@scripts/*": ["scripts/*"]
+      "@features/*": ["./features/*"],
+      "@steps/*": ["./features/steps/*"],
+      "@support/*": ["./features/support/*"],
+      "@scripts/*": ["./scripts/*"]
     }
   },
   "ts-node": {

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -37,11 +37,11 @@
     "@aws-sdk/client-s3": "^3.927.0",
     "@aws-sdk/credential-providers": "^3.926.0",
     "@aws-sdk/lib-storage": "^3.927.0",
-    "JSONStream": "^1.3.5",
-    "jsonparse": "^1.3.1",
     "dotenv": "^16.0.0",
     "event-stream": "^4.0.1",
     "hnswlib-node": "^3.0.0",
+    "jsonparse": "^1.3.1",
+    "JSONStream": "^1.3.5",
     "lodash": "^4.17.21",
     "module-alias": "^2.2.3",
     "node-fetch": "^2.7.0",
@@ -56,7 +56,7 @@
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^5.4.5"
+    "typescript": "^6.0.3"
   },
   "_moduleAliases": {
     "@server": "../server/src",

--- a/packages/jobs/tsconfig.json
+++ b/packages/jobs/tsconfig.json
@@ -6,7 +6,6 @@
     "esModuleInterop": true,
     "target": "ES2020",
     "jsx": "react",
-    "baseUrl": "./",
     "paths": {
       "@utils/*": ["../utils/src/*"],
       "@server/*": ["../server/src/*"],
@@ -26,7 +25,8 @@
     "skipLibCheck": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "rootDir": ".."
   },
   "exclude": ["node_modules", "src/client", "dist"],
   "include": ["src/**/*.js", "src/**/*.ts", "src/**/*.tsx"]

--- a/packages/jobs/tsconfig.json
+++ b/packages/jobs/tsconfig.json
@@ -13,8 +13,8 @@
       "routes/*": ["../server/src/routes/*"],
       "dynamo/*": ["../server/src/dynamo/*"]
     },
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "moduleDetection": "force",

--- a/packages/recommenderService/package.json
+++ b/packages/recommenderService/package.json
@@ -44,9 +44,9 @@
     "@types/jest": "^29.5.14",
     "@types/response-time": "^2.3.8",
     "@types/uuid": "^10.0.0",
-    "archiver": "^7.0.1",
     "@typescript-eslint/eslint-plugin": "^8.8.1",
     "@typescript-eslint/parser": "^8.8.1",
+    "archiver": "^7.0.1",
     "copyfiles": "^2.4.1",
     "eslint": "^9.13.0",
     "jest": "^29.7.0",
@@ -54,6 +54,6 @@
     "resolve-tspaths": "^0.8.22",
     "ts-jest": "^29.4.5",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^5.6.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/recommenderService/tsconfig.json
+++ b/packages/recommenderService/tsconfig.json
@@ -12,8 +12,8 @@
       "router/*": ["./src/router/*"],
       "types/*": ["./src/types/*"]
     },
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "moduleDetection": "force",

--- a/packages/recommenderService/tsconfig.json
+++ b/packages/recommenderService/tsconfig.json
@@ -6,12 +6,11 @@
     "rootDir": "..",
     "esModuleInterop": true,
     "target": "ES2020",
-    "baseUrl": "./src",
     "paths": {
-      "@utils/*": ["../../utils/src/*"],
-      "mlutils/*": ["mlutils/*"],
-      "router/*": ["router/*"],
-      "types/*": ["types/*"]
+      "@utils/*": ["../utils/src/*"],
+      "mlutils/*": ["./src/mlutils/*"],
+      "router/*": ["./src/router/*"],
+      "types/*": ["./src/types/*"]
     },
     "module": "commonjs",
     "moduleResolution": "node",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -33,7 +33,7 @@
     "@types/node": "^24.10.0",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "dependencies": {
     "@aws-crypto/sha256-js": "^5.2.0",

--- a/packages/scripts/tsconfig.json
+++ b/packages/scripts/tsconfig.json
@@ -6,7 +6,6 @@
     "esModuleInterop": true,
     "target": "ES2020",
     "jsx": "react",
-    "baseUrl": "./",
     "paths": {
       "@utils/*": ["../utils/src/*"],
       "@server/*": ["../server/src/*"],
@@ -25,7 +24,8 @@
     "skipLibCheck": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "rootDir": ".."
   },
   "exclude": ["node_modules", "src/client"],
   "include": ["src/**/*.js", "src/**/*.ts", "src/**/*.tsx", "src"]

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -131,6 +131,6 @@
     "ts-jest": "^29.1.4",
     "tsconfig-paths": "^4.2.0",
     "tspath": "^2.6.8",
-    "typescript": "^5.4.5"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/server/src/dynamo/dao/CubeAnalyticDynamoDao.ts
+++ b/packages/server/src/dynamo/dao/CubeAnalyticDynamoDao.ts
@@ -19,7 +19,7 @@
 
 import CubeAnalytic from '@utils/datatypes/CubeAnalytic';
 
-import { getObject, putObject } from '../s3client';
+import { deleteObject, getObject, putObject } from '../s3client';
 
 export interface CubeAnalyticBatch {
   [cubeId: string]: CubeAnalytic;
@@ -74,7 +74,6 @@ export class CubeAnalyticDynamoDao {
    * @param cubeId - The ID of the cube to delete analytics for
    */
   public async deleteByCube(cubeId: string): Promise<void> {
-    const { deleteObject } = await import('../s3client');
     await deleteObject(process.env.DATA_BUCKET as string, `cube_analytic/${cubeId}.json`);
   }
 

--- a/packages/server/src/dynamo/dao/CubeDynamoDao.ts
+++ b/packages/server/src/dynamo/dao/CubeDynamoDao.ts
@@ -70,6 +70,8 @@ import { cdnUrl } from '@utils/cdnUrl';
 import { CardStatus } from '@utils/datatypes/Card';
 import Cube, { CubeImage, ViewDefinition } from '@utils/datatypes/Cube';
 import { CubeCards } from '@utils/datatypes/Cube';
+import { getNewCubeViews } from '@utils/datatypes/Cube';
+import { VIEW_DEFAULT_SORTS } from '@utils/datatypes/Cube';
 import CubeAnalytic from '@utils/datatypes/CubeAnalytic';
 import User from '@utils/datatypes/User';
 import { normalizeDraftFormatSteps } from '@utils/draftutil';
@@ -307,10 +309,8 @@ export class CubeDynamoDao extends BaseDynamoDao<Cube, UnhydratedCube> {
       let views = item.views;
 
       if (!views || views.length === 0) {
-        const { getNewCubeViews } = await import('@utils/datatypes/Cube');
         views = getNewCubeViews(item.defaultSorts);
       } else {
-        const { VIEW_DEFAULT_SORTS } = await import('@utils/datatypes/Cube');
         views = views.map((view) => {
           if (!view.defaultSorts || view.defaultSorts.length !== 4) {
             const defaultSorts = [...(view.defaultSorts || [])];
@@ -352,10 +352,8 @@ export class CubeDynamoDao extends BaseDynamoDao<Cube, UnhydratedCube> {
       let views = item.views;
 
       if (!views || views.length === 0) {
-        const { getNewCubeViews } = await import('@utils/datatypes/Cube');
         views = getNewCubeViews(item.defaultSorts);
       } else {
-        const { VIEW_DEFAULT_SORTS } = await import('@utils/datatypes/Cube');
         views = views.map((view) => {
           if (!view.defaultSorts || view.defaultSorts.length !== 4) {
             const defaultSorts = [...(view.defaultSorts || [])];
@@ -391,11 +389,9 @@ export class CubeDynamoDao extends BaseDynamoDao<Cube, UnhydratedCube> {
 
     if (!views || views.length === 0) {
       // No views configured - create defaults
-      const { getNewCubeViews } = await import('@utils/datatypes/Cube');
       views = getNewCubeViews(item.defaultSorts);
     } else {
       // Views exist - ensure each has exactly 4 defaultSorts
-      const { VIEW_DEFAULT_SORTS } = await import('@utils/datatypes/Cube');
       views = views.map((view) => {
         if (!view.defaultSorts || view.defaultSorts.length !== 4) {
           // Missing or incomplete defaultSorts - fill with defaults

--- a/packages/server/src/router/routes/cube/blog.ts
+++ b/packages/server/src/router/routes/cube/blog.ts
@@ -1,4 +1,5 @@
 import CubeType from '@utils/datatypes/Cube';
+import { CUBE_VISIBILITY } from '@utils/datatypes/Cube';
 import { FeedTypes } from '@utils/datatypes/Feed';
 import UserType from '@utils/datatypes/User';
 import { sanitizeChangelog } from 'dynamo/dao/ChangelogDynamoDao';
@@ -149,7 +150,6 @@ export const createBlogHandler = async (req: Request, res: Response) => {
     // Only publish to follower feeds if the cube is public (not unlisted or private)
     // Private cubes should not have their blog posts visible to anyone except the owner
     // Unlisted cubes should not publish to follower feeds
-    const { CUBE_VISIBILITY } = await import('@utils/datatypes/Cube');
     const shouldPublishToFeed = cube.visibility === CUBE_VISIBILITY.PUBLIC;
 
     if (shouldPublishToFeed) {
@@ -203,7 +203,6 @@ export const getBlogPostHandler = async (req: Request, res: Response) => {
       }
 
       // Private cubes: only owner or collaborators can view blog posts
-      const { CUBE_VISIBILITY } = await import('@utils/datatypes/Cube');
       if (cube && cube.visibility === CUBE_VISIBILITY.PRIVATE) {
         if (!isCubeEditable(cube, req.user)) {
           req.flash('danger', 'Blog post not found');

--- a/packages/server/src/router/routes/user/blog.ts
+++ b/packages/server/src/router/routes/user/blog.ts
@@ -1,3 +1,4 @@
+import { CUBE_VISIBILITY } from '@utils/datatypes/Cube';
 import { PatronStatuses } from '@utils/datatypes/Patron';
 import { sanitizeChangelog } from 'dynamo/dao/ChangelogDynamoDao';
 import { blogDao, packageDao, patronDao, userDao } from 'dynamo/daos';
@@ -22,7 +23,6 @@ export const handler = async (req: Request, res: Response) => {
     const posts = await blogDao.queryByOwner(req.params.userid, undefined, 10);
 
     // Filter out blog posts from private/unlisted cubes unless the viewer is the owner
-    const { CUBE_VISIBILITY } = await import('@utils/datatypes/Cube');
     const filteredPosts = posts.items.filter((post) => {
       // DEVLOG posts are always visible
       if (post.cube === 'DEVBLOG') {

--- a/packages/server/src/router/routes/user/getmoreblogs.ts
+++ b/packages/server/src/router/routes/user/getmoreblogs.ts
@@ -1,3 +1,4 @@
+import { CUBE_VISIBILITY } from '@utils/datatypes/Cube';
 import { blogDao } from 'dynamo/daos';
 import { csrfProtection, ensureAuth } from 'router/middleware';
 
@@ -8,7 +9,6 @@ export const handler = async (req: Request, res: Response) => {
   const posts = await blogDao.queryByOwner(owner, lastKey, 10);
 
   // Filter out blog posts from private/unlisted cubes unless the viewer is the owner
-  const { CUBE_VISIBILITY } = await import('@utils/datatypes/Cube');
   const filteredPosts = posts.items.filter((post) => {
     // DEVLOG posts are always visible
     if (post.cube === 'DEVBLOG') {

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -15,8 +15,8 @@
       "dynamo/*": ["./src/dynamo/*"],
       "types/*": ["./src/types/*"]
     },
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "moduleDetection": "force",
@@ -40,5 +40,8 @@
     "jest.setup.ts",
     "jest.config.ts",
     "test"
-  ]
+  ],
+  "ts-node": {
+    "files": true
+  }
 }

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -6,15 +6,14 @@
     "esModuleInterop": true,
     "target": "ES2020",
     "jsx": "react",
-    "baseUrl": "./",
     "paths": {
       "@client/*": ["../client/src/*"],
       "@jobs/*": ["../jobs/src/*"],
       "@utils/*": ["../utils/src/*"],
-      "serverutils/*": ["src/serverutils/*"],
-      "router/*": ["src/router/*"],
-      "dynamo/*": ["src/dynamo/*"],
-      "types/*": ["src/types/*"]
+      "serverutils/*": ["./src/serverutils/*"],
+      "router/*": ["./src/router/*"],
+      "dynamo/*": ["./src/dynamo/*"],
+      "types/*": ["./src/types/*"]
     },
     "module": "commonjs",
     "moduleResolution": "node",
@@ -28,7 +27,8 @@
     "skipLibCheck": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "rootDir": ".."
   },
   "exclude": ["node_modules", "src/client"],
   "include": [


### PR DESCRIPTION
# Changes

1. Switch typescript to dev dependency in the top-level package
2. Upgrade to typescript 6
3. Run 5 to 6 migration on the tsconfigs
4. Update client tsconfig moduleResolution from node to bundler, to appease the TS gods
    1. Which for server package meant I had to convert await require to imports
    2. Also ts-node hated express-messages types so needed to add a ts-node config option

What I don't understand is why some packages are still using typescript 5.X, as evidence by running `tsc --version` in the package folders and based on the package-lock.json additions for those packages. Still trying to figure out what those are holding it back.
Edit: I've got all the packages but client upgrade to 6 now