### PR TITLE
Allow CDN-hosted card images through the image proxy (fixes #2981)

### DIFF
--- a/packages/server/src/router/routes/tool/imageproxy.ts
+++ b/packages/server/src/router/routes/tool/imageproxy.ts
@@ -8,9 +8,12 @@ export const imageProxyHandler = async (req: Request, res: Response) => {
       return res.status(400).send('Missing or invalid URL parameter');
     }
 
-    // Only allow Scryfall image URLs to prevent abuse
-    if (!url.startsWith('https://cards.scryfall.io/')) {
-      return res.status(403).send('Only Scryfall image URLs are allowed');
+    // Only allow Scryfall or our own card-image CDN URLs to prevent abuse
+    const allowedPrefixes = ['https://cards.scryfall.io/', process.env.CARD_IMAGE_BASE_URL].filter(
+      (prefix): prefix is string => Boolean(prefix),
+    );
+    if (!allowedPrefixes.some((prefix) => url.startsWith(prefix))) {
+      return res.status(403).send('Only Scryfall or CubeCobra CDN image URLs are allowed');
     }
 
     // Fetch the image from Scryfall


### PR DESCRIPTION
Fixing #2981.

The Print and Play feature was always producing an empty PDF with `Failed to convert image: Error: Failed to fetch image` errors for each card image.

The error was occurring in getImageDataUrl in /components/modals/PrintAndPlayExportModal.tsx.

The route `/tool/imageproxy` is used in that function, but that route filters out any URLs that don't start with `https://cards.scryfall.io/`.

However, it seems like the cardImageNormal of each card (card.details?.image_normal) was changed in [this commit](https://github.com/dekkerglen/CubeCobra/commit/bcbac8199ff7265af0c3bcf25b255dc339817495) to be self hosted instead of straight from Scryfall.

This PR adjusts this by allowing URLs from Scryfall and from the CARD_IMAGE_BASE_URL.