### PR TITLE
feat: Add new export with set + version number

### DIFF
--- a/packages/client/src/components/cube/CubeHero.tsx
+++ b/packages/client/src/components/cube/CubeHero.tsx
@@ -309,6 +309,12 @@ const CubeHero: React.FC<CubeHeroProps> = ({ cube, minified = false, activeLink 
         Card Names (.txt)
       </a>
       <a
+        href={`/cube/download/versioned/${cube.id}?${urlSegment}`}
+        className="!text-text hover:!text-link-active font-medium"
+      >
+        Card Versions (.txt)
+      </a>
+      <a
         href={`/cube/download/csv/${cube.id}?${urlSegment}`}
         className="!text-text hover:!text-link-active font-medium"
       >

--- a/packages/server/src/router/routes/cube/download.ts
+++ b/packages/server/src/router/routes/cube/download.ts
@@ -265,6 +265,67 @@ export const xmageHandler = async (req: Request, res: Response) => {
   }
 };
 
+export const versionedHandler = async (req: Request, res: Response) => {
+  try {
+    if (!req.params.id) {
+      req.flash('danger', 'Invalid cube ID');
+      return redirect(req, res, '/404');
+    }
+
+    const cube = await cubeDao.getById(req.params.id);
+
+    if (!cube || !isCubeViewable(cube, req.user)) {
+      req.flash('danger', `Cube ID ${req.params.id} not found/`);
+      return redirect(req, res, '/404');
+    }
+
+    const cards = await cubeDao.getCards(cube.id);
+
+    const boardsToExport = getBoardsToExport(req, cards);
+
+    res.setHeader('Content-disposition', `attachment; filename=${cube.name.replace(/\W/g, '')}.txt`);
+    res.setHeader('Content-type', 'text/plain');
+    res.charset = 'UTF-8';
+
+    for (const boardname of boardsToExport) {
+      const list = cards[boardname];
+      if (!Array.isArray(list)) continue;
+      for (const card of list as Card[]) {
+        const details = cardFromId(card.cardID);
+        card.details = details;
+      }
+      const sorted = sortCardsByQuery(req, list as Card[]);
+
+      // Put all selected boards in main
+      // Moxfield/Archidekt/Draftmancer all use different rules
+      for (const card of sorted) {
+        // Possible card formats:
+        // 1 Cardname
+        // 1 Cardname (SET)
+        // 1 Cardname (SET) 123
+        const set = cardSet(card).toUpperCase();
+        const collectorNumber = cardCollectorNumber(card);
+
+        let line = `1 ${cardName(card)}`;
+        if (set) {
+          line += ` (${set})`;
+          if (collectorNumber) {
+            line += ` ${collectorNumber}`;
+          }
+        }
+
+        res.write(`${line}\r\n`);
+      }
+
+      res.write(`\r\n`);
+    }
+
+    return res.end();
+  } catch (err) {
+    return handleRouteError(req, res, err, '/404');
+  }
+};
+
 export const plaintextHandler = async (req: Request, res: Response) => {
   try {
     if (!req.params.id) {
@@ -335,6 +396,11 @@ export const routes = [
     path: '/xmage/:id',
     method: 'get',
     handler: [xmageHandler],
+  },
+  {
+    path: '/versioned/:id',
+    method: 'get',
+    handler: [versionedHandler],
   },
   {
     path: '/plaintext/:id',


### PR DESCRIPTION
Addressing ["Increased Draftmancer Compatibility"](https://discord.com/channels/592787488523943937/1531325637682532574) Discord thread.

New route and link which produces a list of the cards composing the cube as well as their set and collector number. This format is commonly used in Moxfield/Archidekt/Draftmancer. 

```
1 Rograkh, Son of Rohgahh (CMR) 197
1 Thrasios, Triton Hero (C16) 46
1 Ancient Tomb (UMA) 236
1 Badgermole Cub (TLA) 167
1 Biomancer's Familiar (RNA) 158
1 Birds of Paradise (M10) 168
...
```

See https://draftmancer.com/cubeformat.html for reference (in Discord thread.)