### PR TITLE
Fix draftsim out-of-vocab picks; share ML scoring with recommender

### DIFF
--- a/packages/client/src/components/draftSimulator/DraftTableView.tsx
+++ b/packages/client/src/components/draftSimulator/DraftTableView.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import type { CardMeta, SimulationRunData, SlimPool } from '@utils/datatypes/SimulationReport';
 
+import { modelScoresToProbabilities } from '../../utils/botRatings';
 import { buildOracleRemapping, loadDraftBot, localBatchDraftRanked } from '../../utils/draftBot';
 import { MTG_COLORS } from './SimulatorCharts';
 
@@ -41,14 +42,6 @@ function archetypeColorCodes(archetype: string | undefined): string[] {
     .split('')
     .filter((c) => Object.prototype.hasOwnProperty.call(MTG_COLORS, c) && c !== 'C' && c !== 'M');
   return colors.length > 0 ? colors : ['C'];
-}
-
-function softmaxPcts(ratings: number[]): number[] {
-  if (ratings.length === 0) return [];
-  const max = Math.max(...ratings);
-  const exps = ratings.map((v) => Math.exp(v - max));
-  const sum = exps.reduce((a, b) => a + b, 0);
-  return exps.map((v) => (v / sum) * 100);
 }
 
 function buildPackContents(
@@ -494,7 +487,9 @@ const PackOverlay: React.FC<{
         const remapping = buildOracleRemapping(cardMeta);
         const [ranked] = await localBatchDraftRanked([{ pack: availableOracles, pool: seatPool }], remapping);
         if (!cancelled && ranked) {
-          const pcts = softmaxPcts(ranked.map((c) => c.rating));
+          // Shared softmax with SimulatorPickBreakdown / server (handles -Infinity
+          // out-of-vocab and all-OOV packs); ×100 for the percentage display.
+          const pcts = modelScoresToProbabilities(ranked.map((c) => c.rating)).map((p) => p * 100);
           const scoreMap = new Map<string, MlScore>();
           ranked.forEach((card, idx) => scoreMap.set(card.oracle, { rank: idx + 1, pct: pcts[idx] ?? 0 }));
           setMlScores(scoreMap);

--- a/packages/client/src/utils/botRatings.ts
+++ b/packages/client/src/utils/botRatings.ts
@@ -1,23 +1,14 @@
+import { softmax } from '@utils/drafting/mlScoring';
+
 /** Softmax — for raw logit inputs (e.g., the client-side TF.js bot, which returns
  *  the model's last-layer outputs directly). Don't use this on values that are
  *  already normalized probabilities, since softmax-of-softmax collapses to nearly
  *  uniform. For server-returned ratings (which already include a final-layer
- *  softmax on the ML service side), use `normalizeProbabilities` instead. */
-export const modelScoresToProbabilities = (scores: number[]): number[] => {
-  if (scores.length === 0) return [];
-
-  const finiteScores = scores.map((score) => (Number.isFinite(score) ? score : Number.NEGATIVE_INFINITY));
-  const maxScore = Math.max(...finiteScores);
-
-  if (!Number.isFinite(maxScore)) {
-    return scores.map(() => 0);
-  }
-
-  const exps = finiteScores.map((score) => (Number.isFinite(score) ? Math.exp(score - maxScore) : 0));
-  const total = exps.reduce((acc, value) => acc + value, 0);
-
-  return total > 0 ? exps.map((value) => value / total) : scores.map(() => 0);
-};
+ *  softmax on the ML service side), use `normalizeProbabilities` instead.
+ *
+ *  Delegates to the shared @utils softmax so the sim display, pack ranking, and
+ *  the recommender service all use one implementation. */
+export const modelScoresToProbabilities = softmax;
 
 /** Renormalize already-probability-shaped values to sum to 1. Use this for ratings
  *  returned by the server ML service (`/api/draftbots/predict`, `getBotPrediction`,

--- a/packages/client/src/utils/draftBot.ts
+++ b/packages/client/src/utils/draftBot.ts
@@ -28,6 +28,21 @@ import { MODEL_VERSION } from '@utils/modelVersion';
 import { BasicLandInfo } from '@utils/datatypes/SimulationReport';
 import { type LandTrimDeck, runManabaseTrim } from '@utils/drafting/landTrim';
 import { pickAddedBasics } from '@utils/drafting/manabaseHeuristics';
+import {
+  buildOracleRemapping,
+  buildSeatMlMaps,
+  type LogitLookup,
+  mlOracle,
+  pickTop,
+  rankPack,
+  type RatedCard,
+} from '@utils/drafting/mlScoring';
+
+// The ML post-processing (remapping, out-of-vocab rule, ranking, softmax) now
+// lives in @utils/drafting/mlScoring so the browser sim and the recommender
+// service share one implementation. Re-exported here for existing importers.
+export { buildOracleRemapping, buildSeatMlMaps };
+export type { RatedCard };
 
 // Models are served only from the CDN. We deliberately do NOT fall back to the
 // app origin: the bundle is ~70 MB and proxying it through our server would
@@ -194,17 +209,7 @@ export function countOutOfVocabOracles(cardMeta: Record<string, { mlOracleId?: s
 // Shared forward pass helper
 // ---------------------------------------------------------------------------
 
-export type RatedCard = { oracle: string; rating: number };
-type MlSeatMaps = { toMl: Record<string, string>; fromMl: Record<string, string[]> };
 type DeckCardMeta = DeckbuildEntry['cardMeta'][string];
-
-/**
- * Resolve the ML oracle ID for a given oracle ID, applying the remapping for
- * cards not in the training vocabulary (e.g. Black Lotus → most similar known card).
- */
-function mlOracle(oracle: string, remapping?: Record<string, string>): string {
-  return remapping?.[oracle] ?? oracle;
-}
 
 /**
  * Thrown when a WebGL context loss or GPU OOM is detected during TF.js inference.
@@ -311,33 +316,6 @@ async function forwardPass(
   return out;
 }
 
-/**
- * Build an oracle remapping from CardMeta: maps original oracle ID → ML oracle ID
- * for cards whose mlOracleId differs (i.e. not in training vocab).
- */
-export function buildOracleRemapping(cardMeta: Record<string, { mlOracleId?: string }>): Record<string, string> {
-  const remapping: Record<string, string> = {};
-  for (const [oracle, meta] of Object.entries(cardMeta)) {
-    if (meta.mlOracleId) remapping[oracle] = meta.mlOracleId;
-  }
-  return remapping;
-}
-
-export function buildSeatMlMaps(poolOracles: string[], remapping?: Record<string, string>): MlSeatMaps {
-  const toMl: Record<string, string> = {};
-  const fromMl: Record<string, string[]> = {};
-
-  for (const oracle of poolOracles) {
-    if (toMl[oracle] !== undefined) continue;
-    const mapped = mlOracle(oracle, remapping);
-    toMl[oracle] = mapped;
-    if (!fromMl[mapped]) fromMl[mapped] = [];
-    if (!fromMl[mapped]!.includes(oracle)) fromMl[mapped]!.push(oracle);
-  }
-
-  return { toMl, fromMl };
-}
-
 // ---------------------------------------------------------------------------
 // Embedding extraction (used for clustering / UMAP visualization)
 // ---------------------------------------------------------------------------
@@ -418,6 +396,17 @@ export function reshapeEmbeddings(flat: Float32Array, n: number): number[][] {
 // Draft picking (used during simulation)
 // ---------------------------------------------------------------------------
 
+// Build the logit lookup that the shared rankPack/pickTop consume from a decoder
+// output row. Returns undefined for out-of-vocab cards (no ML index), which the
+// shared helpers treat as never-take; an in-vocab card missing a value defaults
+// to 0, matching the original inline behavior.
+const rowLogitLookup =
+  (logits: Float32Array, rowBase: number, remapping?: Record<string, string>): LogitLookup =>
+  (oracle) => {
+    const idx = oracleToIndex[mlOracle(oracle, remapping)];
+    return idx === undefined ? undefined : (logits[rowBase + idx] ?? 0);
+  };
+
 /**
  * Picks one card per seat for a single pick round.
  * Exact port of the server's draftBatch() + simulateall top-1 extraction.
@@ -440,24 +429,10 @@ export async function localPickBatch(
 
   const logits = await forwardPass(pools, draftDecoder, remapping, chunkSize);
 
-  // Extract top pick per seat via pack-masked argmax.
-  // Softmax preserves the same ordering while doing substantially more work.
-  return packs.map((pack, i) => {
-    if (pack.length === 0) return '';
-    const rowBase = i * numOracles;
-
-    let bestOracle = '';
-    let bestRaw = -Infinity;
-    for (const oracle of pack) {
-      const idx = oracleToIndex[mlOracle(oracle, remapping)];
-      const raw = idx !== undefined ? (logits[rowBase + idx] ?? 0) : 0;
-      if (raw > bestRaw) {
-        bestRaw = raw;
-        bestOracle = oracle;
-      }
-    }
-    return bestOracle;
-  });
+  // Top pick per seat via the shared pack-masked argmax (out-of-vocab never-take,
+  // all-out-of-vocab falls back to the first card). Softmax preserves the same
+  // ordering, so the argmax matches the server draft() pick.
+  return packs.map((pack, i) => pickTop(pack, rowLogitLookup(logits, i * numOracles, remapping)));
 }
 
 // ---------------------------------------------------------------------------
@@ -477,15 +452,7 @@ export async function localBatchBuild(
     return pools.map(() => []);
   }
   const logits = await forwardPass(pools, deckBuildDecoder, remapping, chunkSize);
-  return pools.map((pool, i) => {
-    const rowBase = i * numOracles;
-    return pool
-      .map((oracle) => {
-        const idx = oracleToIndex[mlOracle(oracle, remapping)];
-        return { oracle, rating: idx !== undefined ? (logits[rowBase + idx] ?? 0) : 0 };
-      })
-      .sort((a, b) => b.rating - a.rating);
-  });
+  return pools.map((pool, i) => rankPack(pool, rowLogitLookup(logits, i * numOracles, remapping)));
 }
 
 /**
@@ -507,15 +474,7 @@ export async function localBatchDraftRanked(
     remapping,
     chunkSize,
   );
-  return inputs.map(({ pack }, i) => {
-    const rowBase = i * numOracles;
-    return pack
-      .map((oracle) => {
-        const idx = oracleToIndex[mlOracle(oracle, remapping)];
-        return { oracle, rating: idx !== undefined ? (logits[rowBase + idx] ?? 0) : 0 };
-      })
-      .sort((a, b) => b.rating - a.rating);
-  });
+  return inputs.map(({ pack }, i) => rankPack(pack, rowLogitLookup(logits, i * numOracles, remapping)));
 }
 
 /**

--- a/packages/client/test/utils/mlScoring.test.ts
+++ b/packages/client/test/utils/mlScoring.test.ts
@@ -1,0 +1,111 @@
+import {
+  buildOracleRemapping,
+  buildSeatMlMaps,
+  mlOracle,
+  OUT_OF_VOCAB_RATING,
+  pickTop,
+  rankPack,
+  softmax,
+} from '@utils/drafting/mlScoring';
+
+// These tests pin the shared post-processing that BOTH the browser sim
+// (client draftBot.ts) and the recommender service (recommenderService ml.ts)
+// depend on. They are the guardrail against the two runtimes diverging again —
+// e.g. the regression where out-of-vocab cards scored 0 instead of never-take
+// and were first-picked in the sim while showing ~0% in a normal draft.
+
+describe('mlOracle / remapping', () => {
+  it('applies the remap for out-of-vocab cards and passes others through', () => {
+    const remapping = { 'black-lotus': 'sol-ring' };
+    expect(mlOracle('black-lotus', remapping)).toBe('sol-ring');
+    expect(mlOracle('llanowar-elves', remapping)).toBe('llanowar-elves');
+    expect(mlOracle('llanowar-elves')).toBe('llanowar-elves');
+  });
+
+  it('builds a remapping only for cards with a differing mlOracleId', () => {
+    const remapping = buildOracleRemapping({
+      'black-lotus': { mlOracleId: 'sol-ring' },
+      'llanowar-elves': {},
+    });
+    expect(remapping).toEqual({ 'black-lotus': 'sol-ring' });
+  });
+
+  it('tracks multiple originals that share one ML oracle', () => {
+    const maps = buildSeatMlMaps(['lotus-a', 'lotus-b', 'sol-ring'], {
+      'lotus-a': 'shared-power',
+      'lotus-b': 'shared-power',
+    });
+    expect(maps.toMl['lotus-a']).toBe('shared-power');
+    expect(maps.fromMl['shared-power']).toEqual(['lotus-a', 'lotus-b']);
+    expect(maps.fromMl['sol-ring']).toEqual(['sol-ring']);
+  });
+});
+
+describe('softmax (single source of truth for sim + server + display)', () => {
+  it('produces a probability distribution that sums to 1', () => {
+    const out = softmax([2, 1, 0]);
+    const sum = out.reduce((a, b) => a + b, 0);
+    expect(sum).toBeCloseTo(1, 10);
+    // monotonic: larger logit → larger probability
+    expect(out[0]).toBeGreaterThan(out[1]!);
+    expect(out[1]).toBeGreaterThan(out[2]!);
+  });
+
+  it('is stable for large logits (no overflow)', () => {
+    const out = softmax([1000, 999, 998]);
+    expect(out.every((p) => Number.isFinite(p))).toBe(true);
+    expect(out.reduce((a, b) => a + b, 0)).toBeCloseTo(1, 10);
+  });
+
+  it('gives out-of-vocab (-Infinity) entries probability 0', () => {
+    const out = softmax([1, OUT_OF_VOCAB_RATING, 0]);
+    expect(out[1]).toBe(0);
+    expect(out[0]! + out[2]!).toBeCloseTo(1, 10);
+  });
+
+  it('returns all zeros when every entry is out-of-vocab', () => {
+    expect(softmax([OUT_OF_VOCAB_RATING, OUT_OF_VOCAB_RATING])).toEqual([0, 0]);
+  });
+
+  it('returns [] for an empty pack', () => {
+    expect(softmax([])).toEqual([]);
+  });
+});
+
+describe('rankPack', () => {
+  const logits: Record<string, number> = { a: -0.5, b: 2.0, c: -3.0 };
+  const logitFor = (o: string): number | undefined => logits[o];
+
+  it('sorts pack cards by descending raw logit', () => {
+    const ranked = rankPack(['a', 'b', 'c'], logitFor);
+    expect(ranked.map((r) => r.oracle)).toEqual(['b', 'a', 'c']);
+  });
+
+  it('ranks an out-of-vocab card last, below negative-logit real cards', () => {
+    const ranked = rankPack(['a', 'b', 'c', 'newset'], logitFor);
+    expect(ranked.map((r) => r.oracle)).toEqual(['b', 'a', 'c', 'newset']);
+    const newset = ranked.find((r) => r.oracle === 'newset');
+    expect(newset!.rating).toBe(OUT_OF_VOCAB_RATING);
+  });
+});
+
+describe('pickTop', () => {
+  it('picks the highest raw logit', () => {
+    const logits: Record<string, number> = { a: -0.5, b: 2.0, c: -3.0 };
+    expect(pickTop(['a', 'b', 'c'], (o) => logits[o])).toBe('b');
+  });
+
+  it('never picks an out-of-vocab card over a real card with a negative logit', () => {
+    // Regression guard: a no-data card must NOT beat a real card whose logit is negative.
+    const logits: Record<string, number> = { real: -1.2 };
+    expect(pickTop(['newset', 'real'], (o) => logits[o])).toBe('real');
+  });
+
+  it('falls back to the first card when every card is out-of-vocab', () => {
+    expect(pickTop(['x', 'y'], () => undefined)).toBe('x');
+  });
+
+  it('returns empty string for an empty pack', () => {
+    expect(pickTop([], () => undefined)).toBe('');
+  });
+});

--- a/packages/recommenderService/src/mlutils/ml.ts
+++ b/packages/recommenderService/src/mlutils/ml.ts
@@ -4,6 +4,8 @@ import path from 'path';
 
 import 'dotenv/config';
 
+import { softmax } from '@utils/drafting/mlScoring';
+
 import { getAllOracleIds } from './cardCatalog';
 import cloudwatch from './cloudwatch';
 
@@ -118,13 +120,6 @@ export const ensureModelsReady = (timeout = 30000): Promise<void> => {
       }
     }, 500);
   });
-};
-
-const softmax = (array: number[]) => {
-  const max = Math.max(...array);
-  const exps = array.map((x) => Math.exp(x - max));
-  const sum = exps.reduce((a, b) => a + b, 0);
-  return exps.map((value) => value / sum);
 };
 
 const encodeIndeces = (indeces: number[]) => {

--- a/packages/utils/src/drafting/mlScoring.ts
+++ b/packages/utils/src/drafting/mlScoring.ts
@@ -1,0 +1,141 @@
+/**
+ * Shared, environment-independent post-processing for the draft ML model.
+ *
+ * The neural-net forward pass (encode pool → decoder → raw logits) is inherently
+ * environment-bound: the browser sim runs it via TF.js/WebGL (client draftBot.ts)
+ * and the recommender service runs it via TF-node (recommenderService ml.ts). But
+ * everything AFTER the forward pass — oracle remapping, the out-of-vocab rule,
+ * pack ranking/pick, and the softmax — is pure array/map math with no TF
+ * dependency. Historically each runtime reimplemented it, and the two drifted
+ * (e.g. out-of-vocab cards scored 0 on the client but were dropped on the server,
+ * so no-data cards were first-picked in the sim while ~0% in a normal draft).
+ *
+ * This module is the single source of truth for that post-processing. Both
+ * runtimes import it and inject only their own forward pass. Keep it free of any
+ * TF / DOM / Node dependency so it stays importable from client and server alike.
+ */
+
+export type RatedCard = { oracle: string; rating: number };
+
+/** Maps an original oracle id to its ML-vocab equivalent for out-of-vocab cards. */
+export type OracleRemapping = Record<string, string>;
+
+/** toMl: original → ML oracle. fromMl: ML oracle → all originals that map to it. */
+export type SeatMlMaps = { toMl: Record<string, string>; fromMl: Record<string, string[]> };
+
+/**
+ * Rating for a card the model has no opinion on: out of the training vocabulary
+ * AND with no ML substitute. Ranked at -Infinity so it is never preferred over an
+ * in-vocab card whose decoder logit may legitimately be negative. This mirrors the
+ * server draft path, which drops out-of-vocab pack cards entirely. (Assigning 0
+ * instead made no-data cards — e.g. brand-new sets — win the argmax.)
+ */
+export const OUT_OF_VOCAB_RATING = -Infinity;
+
+/**
+ * Resolve the ML oracle id for an oracle id, applying the remapping for cards not
+ * in the training vocabulary (e.g. Black Lotus → most similar known card).
+ */
+export function mlOracle(oracle: string, remapping?: OracleRemapping): string {
+  return remapping?.[oracle] ?? oracle;
+}
+
+/**
+ * Build an oracle remapping from CardMeta: original oracle id → ML oracle id for
+ * cards whose mlOracleId differs (i.e. not in the training vocab).
+ */
+export function buildOracleRemapping(cardMeta: Record<string, { mlOracleId?: string }>): OracleRemapping {
+  const remapping: OracleRemapping = {};
+  for (const [oracle, meta] of Object.entries(cardMeta)) {
+    if (meta.mlOracleId) remapping[oracle] = meta.mlOracleId;
+  }
+  return remapping;
+}
+
+/**
+ * Build the per-seat oracle↔ML maps. Multiple original oracles can share one ML
+ * oracle (several unknown cards substituting to the same known card), so fromMl
+ * tracks all originals to allow mapping a ranked ML result back.
+ */
+export function buildSeatMlMaps(poolOracles: string[], remapping?: OracleRemapping): SeatMlMaps {
+  const toMl: Record<string, string> = {};
+  const fromMl: Record<string, string[]> = {};
+
+  for (const oracle of poolOracles) {
+    if (toMl[oracle] !== undefined) continue;
+    const mapped = mlOracle(oracle, remapping);
+    toMl[oracle] = mapped;
+    if (!fromMl[mapped]) fromMl[mapped] = [];
+    if (!fromMl[mapped]!.includes(oracle)) fromMl[mapped]!.push(oracle);
+  }
+
+  return { toMl, fromMl };
+}
+
+/**
+ * Numerically stable softmax over raw model scores, returning probabilities that
+ * sum to 1. Out-of-vocab entries (OUT_OF_VOCAB_RATING / any non-finite value) get
+ * probability 0. If every entry is non-finite (all out-of-vocab) or the exponentials
+ * sum to 0, returns all zeros. This is the one softmax used by the sim display, the
+ * server /predict response, and pack ranking — do not fork it.
+ */
+export const softmax = (scores: number[]): number[] => {
+  if (scores.length === 0) return [];
+
+  const finiteScores = scores.map((score) => (Number.isFinite(score) ? score : Number.NEGATIVE_INFINITY));
+  let maxScore = Number.NEGATIVE_INFINITY;
+  for (const score of finiteScores) if (score > maxScore) maxScore = score;
+
+  if (!Number.isFinite(maxScore)) {
+    return scores.map(() => 0);
+  }
+
+  const exps = finiteScores.map((score) => (Number.isFinite(score) ? Math.exp(score - maxScore) : 0));
+  const total = exps.reduce((acc, value) => acc + value, 0);
+
+  return total > 0 ? exps.map((value) => value / total) : scores.map(() => 0);
+};
+
+/**
+ * Look up the raw model logit for a pack card. Returns undefined when the card is
+ * out of vocab (no logit available), which rankPack/pickTop treat as never-take.
+ */
+export type LogitLookup = (oracle: string) => number | undefined;
+
+/**
+ * Rate each pack card by its raw model logit, assigning OUT_OF_VOCAB_RATING to
+ * out-of-vocab cards, sorted descending. Returns raw scores — callers apply
+ * softmax() for display. Ordering matches the server draft() (softmax is monotonic,
+ * so argmax/sort agree with or without it).
+ */
+export function rankPack(pack: string[], logitFor: LogitLookup): RatedCard[] {
+  return pack
+    .map((oracle) => {
+      const raw = logitFor(oracle);
+      return { oracle, rating: raw === undefined ? OUT_OF_VOCAB_RATING : raw };
+    })
+    .sort((a, b) => b.rating - a.rating);
+}
+
+/**
+ * Top pick for a pack: argmax of raw logits. Out-of-vocab cards (OUT_OF_VOCAB_RATING)
+ * can never win over an in-vocab card. If the pack is empty returns ''; if every card
+ * is out-of-vocab the model can't rank them, so fall back to the first card so a pick
+ * is always made.
+ */
+export function pickTop(pack: string[], logitFor: LogitLookup): string {
+  if (pack.length === 0) return '';
+
+  let bestOracle = '';
+  let bestRaw = OUT_OF_VOCAB_RATING;
+  for (const oracle of pack) {
+    const raw = logitFor(oracle);
+    const rating = raw === undefined ? OUT_OF_VOCAB_RATING : raw;
+    if (rating > bestRaw) {
+      bestRaw = rating;
+      bestOracle = oracle;
+    }
+  }
+
+  return bestOracle === '' ? pack[0]! : bestOracle;
+}


### PR DESCRIPTION
The browser draft simulator scored out-of-vocab cards (new sets with no data) at 0, which beat real cards' negative logits and made them ~100% first picks, while a normal server-backed draft showed ~0% for the same cards. Rank out-of-vocab cards at -Infinity (never-take) to match the server, which drops them entirely.

Extract the environment-independent post-processing (remapping, out-of-vocab rule, pack ranking/pick, softmax) into @utils/drafting/mlScoring so the browser sim and the recommender service share one implementation instead of drifting. Consolidate the three duplicated softmax copies (server ml.ts, botRatings, DraftTableView) and add mlScoring unit tests pinning the behavior.