### PR TITLE
Fix Print and Play PDF export for self-hosted card images

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,4 +5,3 @@ The changes here are concise, one liners to be put in a future user facing blogp
 - Tag searches (cube tags, oracle tags, and art tags) now support exact matching with the `=` operator, so `otag=removal` finds only the exact tag while `otag:removal` still matches any tag containing it.
 - Oracle and art tag searches now respect Scryfall's tag hierarchy, so searching a broad tag also finds cards that only carry a more specific one — e.g. `otag:leaves-body-behind` now finds Wurmcoil Engine (tagged `splits-on-death`).
 - The cube tray is now available on card pages, so you can drag related, synergistic, and other-printing cards straight into your cube boards.
-

--- a/packages/cdk/lib/cubecobra-stack.ts
+++ b/packages/cdk/lib/cubecobra-stack.ts
@@ -394,6 +394,11 @@ function createEnvironmentVariables(
   if (params.r2SecretAccessKey) envVars.R2_SECRET_ACCESS_KEY = params.r2SecretAccessKey;
   if (params.r2Bucket) envVars.R2_BUCKET = params.r2Bucket;
 
+  // The server needs the card image host to allowlist it in the image proxy
+  // (packages/server/src/router/routes/tool/imageproxy.ts), which the Print &
+  // Play PDF export uses to fetch self-hosted card images without CORS issues.
+  if (params.cardImageBaseUrl) envVars.CARD_IMAGE_BASE_URL = params.cardImageBaseUrl;
+
   return envVars;
 }
 

--- a/packages/server/jest.config.mjs
+++ b/packages/server/jest.config.mjs
@@ -38,8 +38,13 @@ export default {
     '^types/(.*)$': '<rootDir>/src/types/$1',
   },
 
-  // Transform ignore patterns
-  transformIgnorePatterns: ['node_modules/(?!(.*\\.mjs$))'],
+  // Transform ignore patterns. sanitize-html@2.17.6 pulls a nested htmlparser2@12 whose entry
+  // (dist/index.js) is native ESM; babel-jest must transform it (and its ESM deps) or requiring
+  // it throws "Cannot use import statement outside a module". The nested package names are listed
+  // explicitly so the negative lookahead fails at both node_modules/ segments of the nested path.
+  transformIgnorePatterns: [
+    'node_modules/(?!(.*\\.mjs$|(sanitize-html|htmlparser2|domhandler|domutils|dom-serializer|domelementtype|entities)/))',
+  ],
 
   // Test file patterns
   testMatch: ['**/*.test.ts'],

--- a/packages/server/src/router/routes/tool/imageproxy.ts
+++ b/packages/server/src/router/routes/tool/imageproxy.ts
@@ -1,5 +1,25 @@
 import { Request, Response } from '../../../types/express';
 
+// Origins the proxy is allowed to fetch from, to prevent it being used as an
+// open proxy. Scryfall is always allowed (legacy `imgUrl` values and the
+// fallback when CARD_IMAGE_BASE_URL is unset still point there). When card
+// images are self-hosted, their URLs are `${CARD_IMAGE_BASE_URL}/...` (R2 via
+// Cloudflare) — see packages/jobs/src/update_cards.ts — so that origin, and the
+// general CDN origin, must be allowed too.
+const getAllowedOrigins = (): string[] => {
+  const origins = ['https://cards.scryfall.io'];
+  for (const envUrl of [process.env.CARD_IMAGE_BASE_URL, process.env.CDN_BASE_URL]) {
+    if (envUrl) {
+      try {
+        origins.push(new URL(envUrl).origin);
+      } catch {
+        // Ignore malformed env values.
+      }
+    }
+  }
+  return origins;
+};
+
 export const imageProxyHandler = async (req: Request, res: Response) => {
   try {
     const { url } = req.query;
@@ -8,13 +28,23 @@ export const imageProxyHandler = async (req: Request, res: Response) => {
       return res.status(400).send('Missing or invalid URL parameter');
     }
 
-    // Only allow Scryfall image URLs to prevent abuse
-    if (!url.startsWith('https://cards.scryfall.io/')) {
-      return res.status(403).send('Only Scryfall image URLs are allowed');
+    // Only allow known image hosts to prevent the proxy being abused.
+    let requestedOrigin: string;
+    try {
+      requestedOrigin = new URL(url).origin;
+    } catch {
+      return res.status(400).send('Missing or invalid URL parameter');
+    }
+    if (!getAllowedOrigins().includes(requestedOrigin)) {
+      return res.status(403).send('Image URL host is not allowed');
     }
 
-    // Fetch the image from Scryfall
-    const response = await fetch(url);
+    // Fetch the image from the allowed host. Scryfall (and other well-behaved
+    // hosts) reject requests that send a default HTTP-library User-Agent with a
+    // 400, so we must identify ourselves — see imageUtils.ts.
+    const response = await fetch(url, {
+      headers: { 'User-Agent': 'CubeCobra/1.0 (+https://cubecobra.com)' },
+    });
 
     if (!response.ok) {
       return res.status(response.status).send('Failed to fetch image');


### PR DESCRIPTION
The image proxy used by the Print & Play PDF export only allowed cards.scryfall.io URLs, so it 403'd the self-hosted webp card images (served from CARD_IMAGE_BASE_URL) and every card failed to load.

- imageproxy: allow the configured card-image / CDN origins in addition to Scryfall, and send an identifying User-Agent (Scryfall and other hosts reject the default undici UA with a 400).
- cdk: pass CARD_IMAGE_BASE_URL to the server env (was jobs-only) so the proxy can allowlist the card-image host in deployed environments.