### PR TITLE
Fix deleted P1P1 packs persisting as orphaned rows

### DIFF
--- a/packages/server/src/dynamo/dao/P1P1PackDynamoDao.ts
+++ b/packages/server/src/dynamo/dao/P1P1PackDynamoDao.ts
@@ -16,7 +16,7 @@
  * when dualWriteEnabled flag is set.
  */
 
-import { DynamoDBDocumentClient, QueryCommandInput, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { DeleteCommand, DynamoDBDocumentClient, QueryCommandInput, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import { NativeAttributeValue } from '@aws-sdk/lib-dynamodb';
 import Card from '@utils/datatypes/Card';
 import {
@@ -188,6 +188,21 @@ export class P1P1PackDynamoDao extends BaseDynamoDao<P1P1PackExtended, Unhydrate
   }
 
   /**
+   * Gets a pack's DynamoDB metadata (createdBy, cubeId, etc.) without hydrating from S3.
+   *
+   * Unlike getById(), this does not depend on the S3 payload, so it still returns a result for
+   * packs whose S3 data is missing (e.g. orphaned rows left by an older delete path). Callers that
+   * only need ownership/permission info — or that want to clean up an orphaned row — should use this.
+   */
+  public async getMetadataById(id: string): Promise<UnhydratedP1P1Pack | undefined> {
+    const raw = await this.getRaw({
+      PK: this.typedKey(id),
+      SK: this.itemType(),
+    });
+    return raw?.item;
+  }
+
+  /**
    * Queries packs by cube with pagination.
    */
   public async queryByCube(
@@ -322,6 +337,21 @@ export class P1P1PackDynamoDao extends BaseDynamoDao<P1P1PackExtended, Unhydrate
    * Deletes a pack by ID.
    */
   public async deleteById(id: string): Promise<void> {
+    // Delete the DynamoDB row first, by key. We can't route through getById()/delete(here)
+    // because getById() hydrates from S3 and returns undefined once the S3 payload is gone —
+    // deleting S3 first would leave the DynamoDB row orphaned (still listed, createdByUsername
+    // falling back to "Unknown", and undeletable since the next lookup 404s). Deleting by key
+    // avoids the S3 dependency entirely and is order-independent.
+    await this.dynamoClient.send(
+      new DeleteCommand({
+        TableName: this.tableName,
+        Key: {
+          PK: this.typedKey(id),
+          SK: this.itemType(),
+        },
+      }),
+    );
+
     // Delete from S3
     try {
       const key = this.getS3Key(id);
@@ -329,12 +359,6 @@ export class P1P1PackDynamoDao extends BaseDynamoDao<P1P1PackExtended, Unhydrate
       await deleteObject(bucket, key);
     } catch (error) {
       console.error(`Failed to delete S3 object for pack ${id}:`, error);
-    }
-
-    // Delete from DynamoDB
-    const pack = await this.getById(id);
-    if (pack) {
-      await this.delete(pack);
     }
   }
 

--- a/packages/server/src/router/routes/tool/api/deletep1p1.ts
+++ b/packages/server/src/router/routes/tool/api/deletep1p1.ts
@@ -23,8 +23,10 @@ export const deleteP1P1Handler = async (req: Request, res: Response) => {
       return res.status(401).json({ error: 'Authentication required' });
     }
 
-    // Get the pack to check permissions
-    const pack = await p1p1PackDao.getById(packId);
+    // Get the pack metadata to check permissions. Use getMetadataById (DynamoDB only) rather than
+    // getById (which also hydrates from S3) so that orphaned rows — whose S3 payload is already
+    // gone — can still be found and cleaned up here instead of 404ing forever.
+    const pack = await p1p1PackDao.getMetadataById(packId);
     if (!pack) {
       return res.status(404).json({ error: 'P1P1 pack not found' });
     }


### PR DESCRIPTION
deleteById deleted the S3 payload before fetching the pack via getById to remove the DynamoDB row. Since getById hydrates from S3, it returned undefined once S3 was gone, so the DynamoDB row was never deleted. The orphaned row kept appearing in the P1P1 list (attributed to "Unknown", the createdByUsername fallback for missing S3 data) and could not be re-deleted because the handler's getById also 404'd.

Delete the DynamoDB row directly by key (no S3 dependency) before removing S3, and add getMetadataById so the delete handler can look up and clean up already-orphaned rows via DynamoDB metadata instead of hydrating from S3.