### PR TITLE
Allow collaborators to add and manage draft records

### DIFF
--- a/packages/client/src/components/records/RecordsNavbar.tsx
+++ b/packages/client/src/components/records/RecordsNavbar.tsx
@@ -10,7 +10,6 @@ import CSRFForm from 'components/CSRFForm';
 import CreateRecordFromDraftModal from 'components/modals/CreateRecordFromDraftModal';
 import withModal from 'components/WithModal';
 import CubeContext from 'contexts/CubeContext';
-import UserContext from 'contexts/UserContext';
 
 import { defaultRecordName } from '../../records/recordName';
 
@@ -46,12 +45,9 @@ const CreateNewRecordButton: React.FC<{ cubeId: string }> = ({ cubeId }) => {
 };
 
 const RecordsNavbar: React.FC = () => {
-  const user = useContext(UserContext);
-  const { cube } = useContext(CubeContext);
+  const { cube, canEdit } = useContext(CubeContext);
 
-  const isOwner = user && cube && user.id === cube.owner.id;
-
-  if (!isOwner) {
+  if (!canEdit || !cube) {
     return null;
   }
 

--- a/packages/client/src/records/DraftReports.tsx
+++ b/packages/client/src/records/DraftReports.tsx
@@ -12,7 +12,6 @@ import IndefinitePaginatedTable from 'components/IndefinitePaginatedTable';
 import RecordDeleteModal from 'components/modals/RecordDeleteModal';
 import withModal from 'components/WithModal';
 import CubeContext from 'contexts/CubeContext';
-import UserContext from 'contexts/UserContext';
 
 const RecordDeleteModalButton = withModal(Button, RecordDeleteModal);
 interface DraftReportsProps {
@@ -25,10 +24,9 @@ const PAGE_SIZE = 20;
 const DraftReports: React.FC<DraftReportsProps> = ({ records, lastKey }) => {
   const [items, setItems] = useState<Record[]>(records);
   const [lastKeyState, setLastKeyState] = useState<any>(lastKey);
-  const { cube } = useContext(CubeContext);
-  const user = useContext(UserContext);
+  const { cube, canEdit } = useContext(CubeContext);
 
-  const isOwner = user && cube && user.id === cube.owner.id;
+  const isOwner = canEdit;
 
   const renderItem = (record: Record) => ({
     Name: <Link href={`/cube/record/${record.id}`}>{record.name}</Link>,

--- a/packages/client/src/records/RecordDecks.tsx
+++ b/packages/client/src/records/RecordDecks.tsx
@@ -21,7 +21,6 @@ import SampleHandModal from 'components/modals/SampleHandModal';
 import withModal from 'components/WithModal';
 import CubeContext from 'contexts/CubeContext';
 import DisplayContext, { DisplayContextProvider } from 'contexts/DisplayContext';
-import UserContext from 'contexts/UserContext';
 
 interface RecordDecksProps {
   record: Record;
@@ -48,14 +47,13 @@ const firstPlayerIndexWithDeck = (record: Record, draft: Draft | undefined): num
 };
 
 const RecordDecksContent: React.FC<RecordDecksProps> = ({ record, draft, players }) => {
-  const { cube } = useContext(CubeContext);
-  const user = useContext(UserContext);
+  const { canEdit } = useContext(CubeContext);
   const { showCustomImages, toggleShowCustomImages } = useContext(DisplayContext);
   // Default to the first player who actually has a deck; fall back to player 0.
   const firstWithDeck = firstPlayerIndexWithDeck(record, draft);
   const [selectedUserIndex, setSelectedUserIndex] = React.useState<number>(firstWithDeck >= 0 ? firstWithDeck : 0);
 
-  const isOwner = !!(user && cube && user.id === cube.owner.id);
+  const isOwner = canEdit;
   const selectedPlayer = record.players[selectedUserIndex];
   const selectedHasDeck = seatHasDeck(draft, selectedUserIndex);
 

--- a/packages/client/src/records/RecordMatches.tsx
+++ b/packages/client/src/records/RecordMatches.tsx
@@ -13,7 +13,6 @@ import EditRoundModal from 'components/modals/EditRoundModal';
 import RemoveRoundModal from 'components/modals/RemoveRoundModal';
 import withModal from 'components/WithModal';
 import CubeContext from 'contexts/CubeContext';
-import UserContext from 'contexts/UserContext';
 
 const AddRoundLink = withModal(Link, AddRoundModal);
 const EditRoundLink = withModal(Link, EditRoundModal);
@@ -25,10 +24,9 @@ interface RecordMatchesProps {
 }
 
 const RecordMatches: React.FC<RecordMatchesProps> = ({ record }) => {
-  const { cube } = useContext(CubeContext);
-  const user = useContext(UserContext);
+  const { canEdit } = useContext(CubeContext);
 
-  const isOwner = user && cube && user.id === cube.owner.id;
+  const isOwner = canEdit;
 
   return (
     <CardBody>

--- a/packages/client/src/records/RecordOverview.tsx
+++ b/packages/client/src/records/RecordOverview.tsx
@@ -12,7 +12,6 @@ import EditRecordOverviewModal from 'components/modals/EditRecordOverviewModal';
 import ShareRecordModal from 'components/modals/ShareRecordModal';
 import withModal from 'components/WithModal';
 import CubeContext from 'contexts/CubeContext';
-import UserContext from 'contexts/UserContext';
 
 const EditRecordOverviewLink = withModal(Link, EditRecordOverviewModal);
 const ShareRecordLink = withModal(Link, ShareRecordModal);
@@ -24,10 +23,9 @@ interface RecordOverviewProps {
 // The record's header block, shown at the top of the page (no longer a tab):
 // name, date, description, and owner controls.
 const RecordOverview: React.FC<RecordOverviewProps> = ({ record }) => {
-  const { cube } = useContext(CubeContext);
-  const user = useContext(UserContext);
+  const { canEdit } = useContext(CubeContext);
 
-  const isOwner = user && cube && user.id === cube.owner.id;
+  const isOwner = canEdit;
 
   return (
     <CardBody>

--- a/packages/client/src/records/RecordStandings.tsx
+++ b/packages/client/src/records/RecordStandings.tsx
@@ -9,7 +9,6 @@ import Text from 'components/base/Text';
 import AssignTrophiesModal from 'components/modals/AssignTrophiesModal';
 import withModal from 'components/WithModal';
 import CubeContext from 'contexts/CubeContext';
-import UserContext from 'contexts/UserContext';
 
 const AssignTrophiesLink = withModal(Link, AssignTrophiesModal);
 
@@ -18,10 +17,9 @@ interface RecordStandingsProps {
 }
 
 const RecordStandings: React.FC<RecordStandingsProps> = ({ record }) => {
-  const { cube } = useContext(CubeContext);
-  const user = useContext(UserContext);
+  const { canEdit } = useContext(CubeContext);
 
-  const isOwner = user && cube && user.id === cube.owner.id;
+  const isOwner = canEdit;
 
   const standings = useMemo(() => {
     // playerRecord respects a manual override when present, else derives from matches.


### PR DESCRIPTION
Record routes already permit collaborators server-side (isCubeEditable grants owner, admins, and collaborators), but the client UI gated the record-management controls on an owner-only check, so collaborators never saw the buttons.

Switch the client to canEdit from CubeContext, which mirrors the server's isCubeEditable, exposing the create/edit/upload/delete controls to collaborators.