### PR TITLE
Show combo count in Combos analytics header

### DIFF
--- a/packages/client/src/analytics/Combos.tsx
+++ b/packages/client/src/analytics/Combos.tsx
@@ -196,7 +196,7 @@ const Combos: React.FC = () => {
   return (
     <Flexbox direction="col" gap="2" className="m-2">
       <Text semibold lg>
-        Combos
+        Combos ({comboData.length})
       </Text>
       <Text>
         A list of combos in the cube. These combos are curated by{' '}


### PR DESCRIPTION
One-line change matching the Tokens and Keywords analytics pages, which include the count next to the section title.