### PR TITLE
Fix duplicate set groups in Set (Release Date) sort

### DIFF
--- a/packages/server/test/cards/sort.test.ts
+++ b/packages/server/test/cards/sort.test.ts
@@ -951,6 +951,20 @@ describe('Grouping by Set (Release Date)', () => {
     assertGroupOrdering(groups, ['RGPHD', 'MSK', 'RNA', 'BLB', 'MRD']);
     assertCardOrdering(groups, ['Card infinity', 'Card 4', 'Card 3', 'Card 2', 'Card 5']);
   });
+
+  // A card's setIndex can drift out of sync when its cached details predate a
+  // catalog rebuild, producing two cards with the same set but different indices.
+  it('Same set with different setIndex values still yields one group', async () => {
+    const cards = [
+      createCardFromDetails({ name: 'Card A', set: 'MOM', setIndex: 500 }),
+      createCardFromDetails({ name: 'Card B', set: 'MOM', setIndex: 502 }),
+      createCardFromDetails({ name: 'Card C', set: 'LEA', setIndex: 0 }),
+    ];
+
+    const groups = sortGroupsOrdered(cards, SORT, true);
+    assertGroupOrdering(groups, ['LEA', 'MOM']);
+    assertCardOrdering(groups, ['Card C', 'Card A', 'Card B']);
+  });
 });
 
 //The ordering here is by set code alphanumeric

--- a/packages/utils/src/sorting/Sort.ts
+++ b/packages/utils/src/sorting/Sort.ts
@@ -664,24 +664,20 @@ export function getLabelsRaw(
     }
     ret = sets.sort();
   } else if (sort === 'Set (Release Date)') {
-    //Use a map to prevent duplicates when we want both set and setIndex later.
-    //Sets treat each object as unique even if the contents are the same
-    const sets = new Map<string, { set: string; setIndex: number }>();
+    // Dedupe by set code — cards whose cached details predate a catalog rebuild can
+    // carry stale setIndex values, so keying by set alone (and picking the earliest
+    // seen setIndex) avoids surfacing the same set as two groups.
+    const setIndexBySet = new Map<string, number>();
     for (const card of cube || []) {
       const set = cardSet(card).toUpperCase();
       const setIndex = cardSetIndex(card);
-      //Encode set and set index into string for uniqueness
-      const key = `${set}-${setIndex}`;
-      if (!sets.has(key)) {
-        sets.set(key, {
-          set,
-          setIndex,
-        });
+      const existing = setIndexBySet.get(set);
+      if (existing === undefined || setIndex < existing) {
+        setIndexBySet.set(set, setIndex);
       }
     }
 
-    //Sort based on setIndex and then return the set codes in that order
-    ret = [...sets.values()].sort((a, b) => a.setIndex - b.setIndex).map((a) => a.set);
+    ret = [...setIndexBySet.entries()].sort((a, b) => a[1] - b[1]).map(([set]) => set);
   } else if (sort === 'Artist') {
     const artists: string[] = [];
     for (const card of cube || []) {


### PR DESCRIPTION
`getLabelsRaw` was keying by `set+setIndex`, so any card whose cached details predated a catalog rebuild (and thus carried a stale `setIndex`) surfaced its set as a second, near-empty group. Dedupe by set code and pick the earliest observed `setIndex` for ordering. Regression test added.