### PR TITLE
Add words/wc/wordcount filter for approximate word count

### DIFF
--- a/packages/client/src/components/modals/AdvancedFilterModal.tsx
+++ b/packages/client/src/components/modals/AdvancedFilterModal.tsx
@@ -294,6 +294,15 @@ const AdvancedFilterModal: React.FC<AdvancedFilterModalProps> = ({ isOpen, setOp
             setValue={(value: string) => updateValue(value, 'loyalty')}
             setOperator={(operator: string) => updateValue(operator, 'loyaltyOp')}
           />
+          <NumericField
+            name="wordCount"
+            humanName="Approximate Word Count"
+            placeholder={'Any integer number, e.g. "20"'}
+            value={values.wordCount}
+            operator={values.wordCountOp}
+            setValue={(value: string) => updateValue(value, 'wordCount')}
+            setOperator={(operator: string) => updateValue(operator, 'wordCountOp')}
+          />
           <SelectField
             humanName="Rarity"
             value={values.rarity}

--- a/packages/server/content/wiki/reference/filter-syntax.md
+++ b/packages/server/content/wiki/reference/filter-syntax.md
@@ -123,6 +123,20 @@ numeric comparisons to filter by the number of keywords a card has.
 | `keywords>3`      | cards with more than 3 keywords.                           |
 | `keywords=0`      | cards with no keywords.                                    |
 
+## Approximate Word Count
+
+You can use `words:`, `wc:`, or `wordcount:` to filter cards by the approximate number of words in
+their oracle text (whitespace-split, so reminder text and face separators count).
+Matches the "Approximate Word Count" sort and analytics stat.
+
+Operators supported: `:`, `=`, `<`, `>`, `<=`, `>=`, `!=`, `<>`.
+
+| Query           | Matches                                          |
+| --------------- | ------------------------------------------------ |
+| `words>10`      | cards with more than 10 words of oracle text.    |
+| `wc<=45`        | cards with 45 or fewer words of oracle text.     |
+| `wordcount=22`  | cards with exactly 22 words of oracle text.      |
+
 ## Scryfall Tags
 
 CubeCobra imports the community-sourced tags from [Scryfall Tagger](https://tagger.scryfall.com/).

--- a/packages/server/test/cards/filtering.test.ts
+++ b/packages/server/test/cards/filtering.test.ts
@@ -538,3 +538,38 @@ describe('Color identity filtering (case insensitive)', () => {
     assertColorIdentityFilter(makeFilter(`ci<>M`));
   });
 });
+
+describe('Word count filter syntax', () => {
+  const cardWithText = (name: string, oracle_text: string): Card =>
+    createCard({ details: createCardDetails({ name, name_lower: name.toLowerCase(), oracle_text }) });
+
+  const shortCard = cardWithText('Short', 'Draw a card');
+  const mediumCard = cardWithText('Medium', 'Draw two cards and gain three life');
+  const longCard = cardWithText(
+    'Long',
+    'Whenever this creature attacks, target opponent reveals their hand and you may cast a spell for free',
+  );
+
+  it.each(['words', 'wc', 'wordcount', 'WORDCOUNT'])('parses %s alias', (alias) => {
+    const { err, filter } = makeFilter(`${alias}>5`);
+    expect(err).toBeFalsy();
+    expect(filter?.fieldsUsed).toEqual(['wordCount']);
+  });
+
+  it('filters by word count', () => {
+    const { filter } = makeFilter('words>5');
+    expect(filter!(shortCard)).toBe(false);
+    expect(filter!(mediumCard)).toBe(true);
+    expect(filter!(longCard)).toBe(true);
+
+    const { filter: filter2 } = makeFilter('wc<=7');
+    expect(filter2!(shortCard)).toBe(true);
+    expect(filter2!(mediumCard)).toBe(true);
+    expect(filter2!(longCard)).toBe(false);
+
+    const { filter: filter3 } = makeFilter('wordcount=7');
+    expect(filter3!(shortCard)).toBe(false);
+    expect(filter3!(mediumCard)).toBe(true);
+    expect(filter3!(longCard)).toBe(false);
+  });
+});

--- a/packages/utils/nearley/cardFilters.ne
+++ b/packages/utils/nearley/cardFilters.ne
@@ -69,6 +69,7 @@ import {
   cardOracleTags,
   cardArtTags,
   cardBoard,
+  cardWordCount,
 } from '../../cardutil';
 %} # %}
 
@@ -134,6 +135,7 @@ condition -> (
   | otagCondition
   | atagCondition
   | boardCondition
+  | wordCountCondition
 ) {% ([[condition]]) => condition %}
 
 cmcCondition -> ("mv"i | "cmc"i) integerOpValue {% ([, valuePred]) => genericCondition('cmc', cardCmc, valuePred) %}
@@ -224,6 +226,8 @@ keywordCondition -> ("kw"i | "keyword"i | "keywords"i) stringSetElementOpValue {
 otagCondition -> ("otag"i | "oracletag"i | "oracletags"i) tagSetElementOpValue {% ([, valuePred]) => genericCondition('otag', cardOracleTags, valuePred) %}
 
 atagCondition -> ("atag"i | "arttag"i | "arttags"i | "illustrationtag"i) tagSetElementOpValue {% ([, valuePred]) => genericCondition('atag', cardArtTags, valuePred) %}
+
+wordCountCondition -> ("words"i | "wc"i | "wordcount"i) integerOpValue {% ([, valuePred]) => genericCondition('wordCount', cardWordCount, valuePred) %}
 
 # board=mainboard, board=maybeboard, board=basics, or any custom-board key.
 # In non-cube contexts cardBoard() defaults to 'mainboard' so board=mainboard

--- a/packages/utils/src/datatypes/Card.ts
+++ b/packages/utils/src/datatypes/Card.ts
@@ -154,6 +154,7 @@ export const allFields = [
   'atag',
   'edhrecRank',
   'edhrecSalt',
+  'wordCount',
 ] as const;
 
 export type AllField = (typeof allFields)[number];
@@ -172,6 +173,7 @@ export const numFields = [
   'legality',
   'edhrecRank',
   'edhrecSalt',
+  'wordCount',
 ] as const;
 
 export type NumField = (typeof numFields)[number];

--- a/packages/utils/src/filtering/FuncOperations.ts
+++ b/packages/utils/src/filtering/FuncOperations.ts
@@ -107,6 +107,7 @@ export const FIELD_LABELS: Record<string, string> = {
   firstPrintYear: 'first printed',
   keywords: 'keywords',
   board: 'board',
+  wordCount: 'approximate word count',
 };
 
 export const fieldLabel = (propertyName: string): string => FIELD_LABELS[propertyName] ?? propertyName;

--- a/packages/utils/src/generated/filtering/cardFilters.js
+++ b/packages/utils/src/generated/filtering/cardFilters.js
@@ -85,6 +85,7 @@ import {
   cardOracleTags,
   cardArtTags,
   cardBoard,
+  cardWordCount,
 } from '../../cardutil';
 
 
@@ -2464,6 +2465,7 @@ var grammar = {
     {"name": "condition$subexpression$1", "symbols": ["otagCondition"]},
     {"name": "condition$subexpression$1", "symbols": ["atagCondition"]},
     {"name": "condition$subexpression$1", "symbols": ["boardCondition"]},
+    {"name": "condition$subexpression$1", "symbols": ["wordCountCondition"]},
     {"name": "condition", "symbols": ["condition$subexpression$1"], "postprocess": ([[condition]]) => condition},
     {"name": "cmcCondition$subexpression$1$subexpression$1", "symbols": [/[mM]/, /[vV]/], "postprocess": function(d) {return d.join(""); }},
     {"name": "cmcCondition$subexpression$1", "symbols": ["cmcCondition$subexpression$1$subexpression$1"]},
@@ -2758,6 +2760,13 @@ var grammar = {
     {"name": "atagCondition$subexpression$1$subexpression$4", "symbols": [/[iI]/, /[lL]/, /[lL]/, /[uU]/, /[sS]/, /[tT]/, /[rR]/, /[aA]/, /[tT]/, /[iI]/, /[oO]/, /[nN]/, /[tT]/, /[aA]/, /[gG]/], "postprocess": function(d) {return d.join(""); }},
     {"name": "atagCondition$subexpression$1", "symbols": ["atagCondition$subexpression$1$subexpression$4"]},
     {"name": "atagCondition", "symbols": ["atagCondition$subexpression$1", "tagSetElementOpValue"], "postprocess": ([, valuePred]) => genericCondition('atag', cardArtTags, valuePred)},
+    {"name": "wordCountCondition$subexpression$1$subexpression$1", "symbols": [/[wW]/, /[oO]/, /[rR]/, /[dD]/, /[sS]/], "postprocess": function(d) {return d.join(""); }},
+    {"name": "wordCountCondition$subexpression$1", "symbols": ["wordCountCondition$subexpression$1$subexpression$1"]},
+    {"name": "wordCountCondition$subexpression$1$subexpression$2", "symbols": [/[wW]/, /[cC]/], "postprocess": function(d) {return d.join(""); }},
+    {"name": "wordCountCondition$subexpression$1", "symbols": ["wordCountCondition$subexpression$1$subexpression$2"]},
+    {"name": "wordCountCondition$subexpression$1$subexpression$3", "symbols": [/[wW]/, /[oO]/, /[rR]/, /[dD]/, /[cC]/, /[oO]/, /[uU]/, /[nN]/, /[tT]/], "postprocess": function(d) {return d.join(""); }},
+    {"name": "wordCountCondition$subexpression$1", "symbols": ["wordCountCondition$subexpression$1$subexpression$3"]},
+    {"name": "wordCountCondition", "symbols": ["wordCountCondition$subexpression$1", "integerOpValue"], "postprocess": ([, valuePred]) => genericCondition('wordCount', cardWordCount, valuePred)},
     {"name": "boardCondition$subexpression$1", "symbols": [/[bB]/, /[oO]/, /[aA]/, /[rR]/, /[dD]/], "postprocess": function(d) {return d.join(""); }},
     {"name": "boardCondition", "symbols": ["boardCondition$subexpression$1", "stringOpValue"], "postprocess": ([, valuePred]) => genericCondition('board', cardBoard, valuePred)},
     {"name": "includeExtrasCondition$subexpression$1$subexpression$1", "symbols": [/[iI]/, /[nN]/, /[cC]/, /[lL]/, /[uU]/, /[dD]/, /[eE]/], "postprocess": function(d) {return d.join(""); }},


### PR DESCRIPTION
New `words:`, `wc:`, `wordcount:` grammar over the existing `cardWordCount` accessor (which also backs the Approximate Word Count sort and analytics stat). Labelled "Approximate Word Count" in the advanced filter modal, `FIELD_LABELS`, and the filter-syntax wiki reference.

EDIT: Removed the generated nearley file because it looks to be out of sync with master.
EDIT2: Bleh.. that causes the tests to fail.
EDIT3: Fixed.