### PR TITLE
Add Type (Primary) sort variant

### DIFF
--- a/packages/server/test/cards/sort.test.ts
+++ b/packages/server/test/cards/sort.test.ts
@@ -865,6 +865,87 @@ describe('Grouping by type', () => {
   });
 });
 
+describe('Grouping by Type (Primary)', () => {
+  const SORT = 'Type (Primary)';
+
+  it('Single-typed card produces one label', () => {
+    const card = createCard({
+      type_line: 'Instant',
+      details: createCardDetails({ type: 'Instant' }),
+    });
+    expect(cardGetLabels(card, SORT, true)).toEqual(['Instant']);
+  });
+
+  it('Multi-typed card picks the highest-priority MTG type (Creature over Artifact)', () => {
+    const card = createCard({
+      type_line: 'Legendary Artifact Creature',
+      details: createCardDetails({ type: 'Legendary Artifact Creature' }),
+    });
+    expect(cardGetLabels(card, SORT, true)).toEqual(['Creature']);
+  });
+
+  it('Land Creature is Creature, not Land', () => {
+    const card = createCard({
+      type_line: 'Land Creature',
+      details: createCardDetails({ type: 'Land Creature' }),
+    });
+    expect(cardGetLabels(card, SORT, true)).toEqual(['Creature']);
+  });
+
+  it('Artifact Planeswalker picks Planeswalker (earlier CARD_TYPES rank than Artifact)', () => {
+    const card = createCard({
+      type_line: 'Artifact Planeswalker',
+      details: createCardDetails({ type: 'Artifact Planeswalker' }),
+    });
+    expect(cardGetLabels(card, SORT, true)).toEqual(['Planeswalker']);
+  });
+
+  it('Contraption override still yields Contraption alone', () => {
+    const card = createCard({
+      type_line: 'Artifact Contraption',
+      details: createCardDetails({ type: 'Artifact Contraption' }),
+    });
+    expect(cardGetLabels(card, SORT, true)).toEqual(['Contraption']);
+  });
+
+  it('Plane override still yields Plane alone', () => {
+    const card = createCard({
+      type_line: 'Plane - Dominaria',
+      details: createCardDetails({ type: 'Plane - Dominaria' }),
+    });
+    expect(cardGetLabels(card, SORT, true)).toEqual(['Plane']);
+  });
+
+  it('Mixed MTG and custom types prefers the MTG type', () => {
+    const card = createCard({
+      type_line: 'Creature Miracle',
+      details: createCardDetails({ type: 'Creature Miracle' }),
+    });
+    expect(cardGetLabels(card, SORT, true)).toEqual(['Creature']);
+  });
+
+  it('Custom-only types fall back to first alphabetical', () => {
+    const card = createCard({
+      type_line: 'Sith Lord - Human Cyborg',
+      details: createCardDetails({ type: 'Sith Lord - Human Cyborg' }),
+    });
+    expect(cardGetLabels(card, SORT, true)).toEqual(['Lord']);
+  });
+
+  it('Sums across groups equal the total (no card in two buckets)', () => {
+    const cards = [
+      createCard({
+        type_line: 'Legendary Artifact Creature',
+        details: createCardDetails({ type: 'Legendary Artifact Creature' }),
+      }),
+      createCard({ type_line: 'Artifact', details: createCardDetails({ type: 'Artifact' }) }),
+      createCard({ type_line: 'Instant', details: createCardDetails({ type: 'Instant' }) }),
+    ];
+    const total = cards.reduce((sum, c) => sum + cardGetLabels(c, SORT, false).length, 0);
+    expect(total).toBe(cards.length);
+  });
+});
+
 describe('Grouping by Set (Release Date)', () => {
   const SORT = 'Set (Release Date)';
 

--- a/packages/utils/src/sorting/Sort.ts
+++ b/packages/utils/src/sorting/Sort.ts
@@ -220,6 +220,7 @@ export const SORTS: string[] = [
   'Keywords',
   'Toughness',
   'Type',
+  'Type (Primary)',
   'Types-Multicolor',
   'Devotion to White',
   'Devotion to Blue',
@@ -590,6 +591,11 @@ export function getLabelsRaw(
   } else if (sort === 'Type') {
     const { mtgTypes, otherTypes } = sortMtgTypesThenCustom(cube, false);
     ret = [...mtgTypes, ...otherTypes];
+  } else if (sort === 'Type (Primary)') {
+    // Same buckets and priority order as 'Type' — the difference is per-card
+    // (see cardGetLabels): each card lands in only its first matching bucket.
+    const { mtgTypes, otherTypes } = sortMtgTypesThenCustom(cube, false);
+    ret = [...mtgTypes, ...otherTypes];
   } else if (sort === 'Supertype') {
     //Will not handle custom supertypes because not possible to distinguish from types
     ret = SUPER_TYPES;
@@ -941,6 +947,23 @@ export function cardGetLabels(
       ret = ['Plane'];
     } else {
       ret = filterOutSupertypes(typesAndSuperTypes);
+    }
+  } else if (sort === 'Type (Primary)') {
+    // Assign each card to a single bucket — the earliest one it qualifies for
+    // in the sort's own label ordering (CARD_TYPES priority, then custom types).
+    const { typesAndSuperTypes } = splitCardTypes(effectiveCard);
+    if (typesAndSuperTypes.includes('Contraption')) {
+      ret = ['Contraption'];
+    } else if (typesAndSuperTypes.includes('Plane')) {
+      ret = ['Plane'];
+    } else {
+      const candidates = filterOutSupertypes(typesAndSuperTypes);
+      const mtg = candidates
+        .filter((t) => CARD_TYPES.includes(t))
+        .sort((a, b) => CARD_TYPES.indexOf(a) - CARD_TYPES.indexOf(b));
+      const custom = candidates.filter((t) => !CARD_TYPES.includes(t)).sort();
+      const primary = mtg[0] ?? custom[0];
+      ret = primary ? [primary] : [];
     }
   } else if (sort === 'Tags') {
     ret = effectiveCard.tags || [];


### PR DESCRIPTION
Tired of the repeated question of why "Type" causes duplicates, so this is just a stab at a possible way to make a more logical Type sort by defining an opinionated order of types and ensuring that each card only falls into the first one it matches.

```
Artifact Creature -> Creature
Enchantment Artifact -> Artifact
```

I'm using the existing type display order here, but that's possibly questionable because Land gets put near the end of that which might be more confusing to people that expect their `Ancient Den` or `Dryad Arbor` to show up under Lands..

If there's a desire to rank Lands higher, but still _display_ them last, then it might be best to create a secondary ordinal list - one for display and one for sort.